### PR TITLE
New MQTT topics

### DIFF
--- a/src/display/plugins/MQTTPlugin.cpp
+++ b/src/display/plugins/MQTTPlugin.cpp
@@ -83,6 +83,7 @@ void MQTTPlugin::setup(Controller *controller, PluginManager *pluginManager) {
             case 1: modeStr = "Brew"; break;
             case 2: modeStr = "Steam"; break;
             case 3: modeStr = "Water"; break;
+            case 4: modeStr = "Grind"; break;
             default: modeStr = "Unknown"; break; // Fallback in case of unexpected value
         }
         char json[100];

--- a/src/display/plugins/MQTTPlugin.h
+++ b/src/display/plugins/MQTTPlugin.h
@@ -17,6 +17,7 @@ class MQTTPlugin : public Plugin {
 
   private:
     void publish(const std::string &topic, const std::string &message);
+    void publishBrewState(const char *state);
     MQTTClient client;
     WiFiClient net;
 


### PR DESCRIPTION
**Fix**: 
- Target temperature was always 0, due to a bug not getting the right value.

**Added**:
- New topics:
  - /controller/mode - Displaying current mode {standby|brew|steam|water|grind|unknown}
  - /controller/brew/state - Show if a brew is currently ongoing or ended. Can be used for triggering automations based on brew start/stop. Includes timestamp, for ease of use for time based delayed automations.