### PR TITLE
Add Clock format to settings and UI

### DIFF
--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -43,6 +43,7 @@ Settings::Settings() {
     homeAssistantPassword = preferences.getString("ha_pw", "");
     standbyTimeout = preferences.getInt("sbt", DEFAULT_STANDBY_TIMEOUT_MS);
     timezone = preferences.getString("tz", DEFAULT_TIMEZONE);
+    clock24hFormat = preferences.getBool("clk_24h", true);
     selectedProfile = preferences.getString("sp", "");
     profilesMigrated = preferences.getBool("pm", false);
     favoritedProfiles = explode(preferences.getString("fp", ""), ',');
@@ -252,6 +253,11 @@ void Settings::setTimezone(String timezone) {
     save();
 }
 
+void Settings::setClockFormat(bool clock_24h_format) {
+    this->clock24hFormat = clock_24h_format;
+    save();
+}
+
 void Settings::setSelectedProfile(String selected_profile) {
     this->selectedProfile = std::move(selected_profile);
     save();
@@ -322,6 +328,7 @@ void Settings::doSave() {
     preferences.putString("ha_u", homeAssistantUser);
     preferences.putString("ha_pw", homeAssistantPassword);
     preferences.putString("tz", timezone);
+    preferences.putBool("clk_24h", clock24hFormat);
     preferences.putString("sp", selectedProfile);
     preferences.putInt("sbt", standbyTimeout);
     preferences.putBool("pm", profilesMigrated);

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -58,6 +58,7 @@ class Settings {
     int getHomeAssistantPort() const { return homeAssistantPort; }
     bool isMomentaryButtons() const { return momentaryButtons; }
     String getTimezone() const { return timezone; }
+    bool isClock24hFormat() const { return clock24hFormat; }
     String getSelectedProfile() const { return selectedProfile; }
     bool isProfilesMigrated() const { return profilesMigrated; }
     std::vector<String> getFavoritedProfiles() const { return favoritedProfiles; }
@@ -99,6 +100,7 @@ class Settings {
     void setHomeAssistantPort(int homeAssistantPort);
     void setMomentaryButtons(bool momentary_buttons);
     void setTimezone(String timezone);
+    void setClockFormat(bool format_24h);
     void setSelectedProfile(String selected_profile);
     void setProfilesMigrated(bool profiles_migrated);
     void setFavoritedProfiles(std::vector<String> favorited_profiles);
@@ -143,6 +145,7 @@ class Settings {
     int homeAssistantPort = 1883;
     bool momentaryButtons = false;
     String timezone = DEFAULT_TIMEZONE;
+    bool clock24hFormat = true;
     String otaChannel = DEFAULT_OTA_CHANNEL;
     std::vector<String> favoritedProfiles;
 

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -280,6 +280,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setGrindDelay(request->arg("grindDelay").toDouble());
             if (request->hasArg("timezone"))
                 settings->setTimezone(request->arg("timezone"));
+            settings->setClockFormat(request->hasArg("clock24hFormat"));
             if (request->hasArg("standbyTimeout"))
                 settings->setStandbyTimeout(request->arg("standbyTimeout").toInt() * 1000);
             settings->save(true);
@@ -316,6 +317,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["grindDelay"] = settings.getGrindDelay();
     doc["delayAdjust"] = settings.isDelayAdjust();
     doc["timezone"] = settings.getTimezone();
+    doc["clock24hFormat"] = settings.isClock24hFormat();
     doc["standbyTimeout"] = settings.getStandbyTimeout() / 1000;
     serializeJson(doc, *response);
     request->send(response);

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -530,8 +530,11 @@ void DefaultUI::updateStandbyScreen() const {
     if (!apActive && WiFi.status() == WL_CONNECTED) {
         tm timeinfo;
         if (getLocalTime(&timeinfo, 50)) {
-            char time[6];
-            strftime(time, 6, "%H:%M", &timeinfo);
+            // allocate enough space for both 12h/24h time formats
+            char time[9];
+            Settings &settings = controller->getSettings();
+            const char* format = settings.isClock24hFormat() ? "%H:%M" : "%I:%M %p";
+            strftime(time, sizeof(time), format, &timeinfo);
             lv_label_set_text(ui_StandbyScreen_time, time);
             lv_obj_clear_flag(ui_StandbyScreen_time, LV_OBJ_FLAG_HIDDEN);
         }

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -51,6 +51,9 @@ export function Settings() {
       if (key === 'delayAdjust') {
         value = !formData.delayAdjust;
       }
+      if (key === 'clock24hFormat') {
+        value = !formData.clock24hFormat;
+      }
       setFormData({
         ...formData,
         [key]: value,
@@ -317,6 +320,25 @@ export function Settings() {
                 ))
               }
             </select>
+          </div>
+        <div>
+            <b>Clock</b>
+        </div>
+        <div className="flex flex-row gap-4">
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                id="clock24hFormat"
+                name="clock24hFormat"
+                value="clock24hFormat"
+                type="checkbox"
+                className="sr-only peer"
+                checked={!!formData.clock24hFormat}
+                onChange={onChange('clock24hFormat')}
+              />
+              <div
+                className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[4px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
+            </label>
+            <p>Use 24h Format</p>
           </div>
           <div>
             <label htmlFor="pid" className="block font-medium text-gray-700 dark:text-gray-400">


### PR DESCRIPTION
This PR adds a new settings toggle to choose between 24h and 12h clock format mentioned in https://github.com/jniebuhr/gaggimate/issues/130

Mainly getting myself familiar with the code base so I started with some smaller task. I tested the change both using a mock for the API using vite-plugin-mock (which I can add in a separate PR if you're interested to have such tests without relying on the controller to respond to API calls). I also flashed it on my device and tested it that way. 

**Web UI**
<img src="https://github.com/user-attachments/assets/4a199ea4-19db-4773-8195-63f7ddab9761" width="450">

**Display**
<p float>
<img src="https://github.com/user-attachments/assets/4214c666-f128-4aff-8897-6e320a4b2c32" height="350">
<img src="https://github.com/user-attachments/assets/79c8ea47-d965-4daf-9cf8-cd7afd628318" height="350">
</p>