### PR TITLE
Fix Chart resize on screen rotation

### DIFF
--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -78,7 +78,7 @@ export function Home() {
             <h2 className="text-2xl font-bold">Overview</h2>
           </div>
 
-          <div className="p-6">
+          <div className="p-6 h-full">
             <OverviewChart />
           </div>
         </div>


### PR DESCRIPTION
One liner fix. The issue is that on smaller screens (mobile) even when I rotate the screen the Chart does not adjust to the full width of the parent div and remains small. Turns out its because the correct dimensions of the parent div are not detected. This PR fixes the issue. 

**Before:**
Vertical
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c211e6a9-ff68-49b1-9180-0818721d5ddf" />

Horizontal (After screen rotate)
<img width="750"  alt="image" src="https://github.com/user-attachments/assets/4067d5c9-1e10-4e0d-bce6-b13fc022ed70" />


**After this PR:**
Horizontal (after screen rotate)
<img width="750" alt="image" src="https://github.com/user-attachments/assets/06e071a4-2ff4-4689-937a-1f3ecbef9bc8" />

This issue does not exist on larger screens (tablet, laptop) and this change is a no-op on such screens.
