### PR TITLE
feat: Turn down Autotune shutoff temp

### DIFF
--- a/lib/GaggiMateController/src/peripherals/Heater.cpp
+++ b/lib/GaggiMateController/src/peripherals/Heater.cpp
@@ -96,7 +96,7 @@ void Heater::loopAutotune() {
             softPwm(TUNER_OUTPUT_SPAN);
             vTaskDelay(1 / portTICK_PERIOD_MS);
         }
-        if (temperature > 125.0f) {
+        if (temperature > MAX_AUTOTUNE_TEMP) {
             output = 0.0f;
             autotuning = false;
             softPwm(TUNER_OUTPUT_SPAN);

--- a/lib/GaggiMateController/src/peripherals/Heater.h
+++ b/lib/GaggiMateController/src/peripherals/Heater.h
@@ -9,7 +9,7 @@
 
 enum class PIDLibrary { Legacy, Nimrod };
 
-constexpr float TUNER_INPUT_SPAN = 160.0f;
+constexpr float MAX_AUTOTUNE_TEMP = 125.0f;
 constexpr float TUNER_OUTPUT_SPAN = 1000.0f;
 
 using heater_error_callback_t = std::function<void()>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lowered the temperature threshold for autotuning the heater, which may improve the accuracy and responsiveness of the autotuning process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->