### PR TITLE
Fixed PSM divider back to 2

### DIFF
--- a/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
+++ b/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
@@ -3,7 +3,7 @@
 #include <GaggiMateController.h>
 
 DimmedPump::DimmedPump(uint8_t ssr_pin, uint8_t sense_pin, PressureSensor *pressure_sensor)
-    : _ssr_pin(ssr_pin), _sense_pin(sense_pin), _psm(_sense_pin, _ssr_pin, 100, FALLING, 1, 4), _pressureSensor(pressure_sensor),
+    : _ssr_pin(ssr_pin), _sense_pin(sense_pin), _psm(_sense_pin, _ssr_pin, 100, FALLING, 2, 4), _pressureSensor(pressure_sensor),
       _pressureController(0.03f, &_ctrlPressure, &_ctrlFlow, &_currentPressure, &_controllerPower, &_valveStatus) {
     _psm.set(0);
 }


### PR DESCRIPTION
PSM divider was set determined to be working correctly when set to 2 a while ago

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal configuration of the dimmed pump component to improve its behavior. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->