### PR TITLE
fix: Feed back manual control into pressure controller

### DIFF
--- a/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
+++ b/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
@@ -26,6 +26,7 @@ void DimmedPump::setPower(float setpoint) {
     _ctrlPressure = setpoint > 0 ? 20.0f : 0.0f;
     _mode = ControlMode::POWER;
     _power = std::clamp(setpoint, 0.0f, 100.0f);
+    _controllerPower = _power; // Feed manual control back into pressure controller
     _psm.set(static_cast<int>(_power));
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that manual power settings for the pump are correctly reflected in the controller’s power display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->