### PR TITLE
Feat/hw scales

### DIFF
--- a/lib/GaggiMateController/src/ControllerConfig.h
+++ b/lib/GaggiMateController/src/ControllerConfig.h
@@ -8,6 +8,7 @@ struct Capabilities {
     bool ssrPump;
     bool ledControls;
     bool tof;
+    bool hwScale;
 };
 
 struct ControllerConfig {

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -37,16 +37,33 @@ void GaggiMateController::setup() {
     this->brewBtn = new DigitalInput(_config.brewButtonPin, [this](const bool state) { _ble.sendBrewBtnState(state); });
     this->steamBtn = new DigitalInput(_config.steamButtonPin, [this](const bool state) { _ble.sendSteamBtnState(state); });
 
-    // 5-Pin peripheral port
-    Wire.begin(_config.scaleSdaPin, _config.scaleSclPin, 400000);
-    this->ledController = new LedController(&Wire);
-    this->distanceSensor = new DistanceSensor(&Wire, [this](int distance) { _ble.sendTofMeasurement(distance); });
-    if (this->ledController->isAvailable()) {
-        _config.capabilites.ledControls = true;
-        _config.capabilites.tof = true;
-        _ble.registerLedControlCallback(
-            [this](uint8_t channel, uint8_t brightness) { ledController->setChannel(channel, brightness); });
+    this->hardwareScale = new HardwareScale(_config.scaleSdaPin, _config.scaleSda1Pin, _config.scaleSclPin,
+                                              [this](float weight) { _ble.sendScaleMeasurement(weight); },
+                                              [this](float scaleFactor1, float scaleFactor2) { _ble.sendScaleCalibration(scaleFactor1, scaleFactor2); });
+    this->hardwareScale->setup();
+    if (this->hardwareScale->isAvailable()) {
+        _config.capabilites.hwScale = true;
+        _ble.registerScaleTareCallback([this]() {
+            this->hardwareScale->tare();
+        });
+
+        _ble.registerScaleCalibrationCallback([this](float scaleFactor1, float scaleFactor2) {
+            this->hardwareScale->setScaleFactors(scaleFactor1, scaleFactor2);
+        });
+        _ble.registerScaleCalibrateCallback([this](uint8_t scale, float calibration_weight) {
+            this->hardwareScale->calibrateScale(scale, calibration_weight);
+        });
     }
+    // // 5-Pin peripheral port
+    // Wire.begin(_config.scaleSdaPin, _config.scaleSclPin, 400000);
+    // this->ledController = new LedController(&Wire);
+    // this->distanceSensor = new DistanceSensor(&Wire, [this](int distance) { _ble.sendTofMeasurement(distance); });
+    // if (this->ledController->isAvailable()) {
+    //     _config.capabilites.ledControls = true;
+    //     _config.capabilites.tof = true;
+    //     _ble.registerLedControlCallback(
+    //         [this](uint8_t channel, uint8_t brightness) { ledController->setChannel(channel, brightness); });
+    // }
 
     String systemInfo = make_system_info(_config);
     _ble.initServer(systemInfo);

--- a/lib/GaggiMateController/src/GaggiMateController.h
+++ b/lib/GaggiMateController/src/GaggiMateController.h
@@ -10,6 +10,7 @@
 #include <peripherals/PressureSensor.h>
 #include <peripherals/Pump.h>
 #include <peripherals/SimpleRelay.h>
+#include <peripherals/HardwareScale.h>
 #include <vector>
 
 constexpr double PING_TIMEOUT_SECONDS = 20.0;
@@ -47,7 +48,7 @@ class GaggiMateController {
     PressureSensor *pressureSensor = nullptr;
     LedController *ledController = nullptr;
     DistanceSensor *distanceSensor = nullptr;
-
+    HardwareScale *hardwareScale = nullptr;
     std::vector<ControllerConfig> configs;
 
     unsigned long lastPingTime = 0;

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -103,7 +103,7 @@ float HardwareScale::convertRawToWeight(const RawReading &raw) const {
     // throw away the bottom 7 bits, as we only have ~17 effective bits
     float weight1 = (static_cast<float>(raw.value1 & 0xFFFFFF80) - _offset1) / _scale_factor1;
     float weight2 = (static_cast<float>(raw.value2 & 0xFFFFFF80) - _offset2) / _scale_factor2;
-    return std::clamp(std::round((weight1 + weight2) * 10.0f) / 10.0f, 0.0f, MAX_SCALE_GRAMS);
+    return std::clamp(std::round((weight1 + weight2) * 100.0f) / 100.0f, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
 }
 
 float HardwareScale::getWeight() const {
@@ -120,7 +120,7 @@ void HardwareScale::loop() {
     float reading = convertRawToWeight(_raw_weight);
     _weight = 0.5f * reading + 0.5f * _weight;
     _weight = std::clamp(_weight, 0.0f, MAX_SCALE_GRAMS);
-    ESP_LOGI(LOG_TAG, "Scale Reading: %0.2f, Smoothed Weight: %0.1f", reading, _weight);
+    ESP_LOGI(LOG_TAG, "Scale Reading: %0.2f, Smoothed Weight: %0.2f", reading, _weight);
     _reading_callback(_weight);
 }
 

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -1,0 +1,183 @@
+// filepath: /Users/eric/Developer/gaggimate/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+
+#include "HardwareScale.h"
+#include <Arduino.h>
+
+#define HX711_GAIN 128
+#define MAX_SCALE_GRAMS 1500.0f
+#define MAX_WAIT_READ_MS 250
+#define MAX_STARTUP_WAIT_MS 1200
+
+HardwareScale::HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, const scale_reading_callback_t &reading_callback, const scale_configuration_callback_t &config_callback)
+    : _data_pin1(data_pin1), _data_pin2(data_pin2), _clock_pin(clock_pin), _scale_factor1(1.0f), _scale_factor2(1.0f),
+      _offset1(0.0f), _offset2(0.0f), _is_taring_or_calibrating(false), _reading_callback(reading_callback), _configuration_callback(config_callback), taskHandle(nullptr) {
+    _raw_weight = {0, 0};
+}
+
+void HardwareScale::setup() {
+    pinMode(_data_pin1, INPUT);
+    pinMode(_data_pin2, INPUT);
+    pinMode(_clock_pin, OUTPUT);
+    digitalWrite(_clock_pin, LOW);
+    ESP_LOGV(LOG_TAG, "Initializing hardware scale on DATA: %d, CLOCK: %d", _data_pin, _clock_pin);
+    
+    long start = millis();
+    while (!isReady() && (millis() - start) < MAX_STARTUP_WAIT_MS) {
+            delay(10);
+    }
+    if (!isReady()) {
+        ESP_LOGE(LOG_TAG, "HX711 modules (%d, %d) not ready after max wait time, aborting setup", digitalRead(_data_pin1), digitalRead(_data_pin2));
+        is_initialized = false;
+        return;
+    } else {
+        ESP_LOGI(LOG_TAG, "HX711 modules are ready after %d ms", millis() - start);
+    }
+
+    // do a warm-up of 5 readings
+    for (int i = 0; i < 5; i++) {
+        long start = millis();
+        while (!isReady() && (millis() - start) < MAX_WAIT_READ_MS) {
+            delay(10);
+        }
+        if (!isReady()) {
+            ESP_LOGE(LOG_TAG, "HX711 modules (%d, %d) not ready after max wait time, aborting setup", digitalRead(_data_pin1), digitalRead(_data_pin2));
+            is_initialized = false;
+            return;
+        }
+        readRaw();
+    }
+    tare();
+    is_initialized = true;
+    ESP_LOGI(LOG_TAG, "Hardware scale initialized successfully");
+
+    // ensure we setup an initial value for the scale factors in the BLE server
+    _configuration_callback(_scale_factor1, _scale_factor2);
+
+    xTaskCreate(loopTask, "HardwareScale::loop", configMINIMAL_STACK_SIZE * 4, this, 1, &taskHandle);
+}
+
+bool HardwareScale::isReady() { return digitalRead(_data_pin1) == LOW && digitalRead(_data_pin2) == LOW; }
+
+HardwareScale::RawReading HardwareScale::readRaw() {
+    unsigned long value1 = 0;
+    unsigned long value2 = 0;
+
+    // Ensure that the read process is not interrupted. The timing of the SCK signal is critical for the HX711.
+    // If an interrupt occurs during the read, and the pulse time exceeds 60 microseconds, the HX711 may enter power-down mode.
+    // This can lead to corrupted readings.
+    noInterrupts();
+
+    // Read 24 bits
+    for (int8_t i = 23; i >= 0; i--) {
+        digitalWrite(_clock_pin, HIGH);
+        delayMicroseconds(1);
+        value1 |= (digitalRead(_data_pin1) << i);
+        value2 |= (digitalRead(_data_pin2) << i);
+        digitalWrite(_clock_pin, LOW);
+        delayMicroseconds(1);
+    }
+
+    // Set gain for next reading
+    for (uint8_t i = 0; i < (HX711_GAIN == 128 ? 1 : (HX711_GAIN == 64 ? 3 : 2)); ++i) {
+        digitalWrite(_clock_pin, HIGH);
+        delayMicroseconds(1);
+        digitalWrite(_clock_pin, LOW);
+        delayMicroseconds(1);
+    }
+
+    interrupts();
+
+    // Convert to signed 24-bit
+    if (value1 & 0x800000) {
+        value1 |= 0xFF000000;
+    }
+
+    if (value2 & 0x800000) {
+        value2 |= 0xFF000000;
+    }
+
+    return {static_cast<long>(value1), static_cast<long>(value2)};
+}
+
+float HardwareScale::convertRawToWeight(const RawReading &raw) const {
+    // throw away the bottom 7 bits, as we only have ~17 effective bits
+    float weight1 = (static_cast<float>(raw.value1 & 0xFFFFFF80) - _offset1) / _scale_factor1;
+    float weight2 = (static_cast<float>(raw.value2 & 0xFFFFFF80) - _offset2) / _scale_factor2;
+    return std::clamp(std::round((weight1 + weight2) * 10.0f) / 10.0f, 0.0f, MAX_SCALE_GRAMS);
+}
+
+float HardwareScale::getWeight() const {
+    return _weight;
+}
+
+void HardwareScale::loop() {
+    while (!isReady() || _is_taring_or_calibrating) {
+        vTaskDelay(1);
+    }
+
+    _raw_weight = readRaw();
+    ESP_LOGI(LOG_TAG, "Raw Scale Reading: %ld, %ld", _raw_weight.value1, _raw_weight.value2);
+    float reading = convertRawToWeight(_raw_weight);
+    _weight = 0.5f * reading + 0.5f * _weight;
+    _weight = std::clamp(_weight, 0.0f, MAX_SCALE_GRAMS);
+    ESP_LOGI(LOG_TAG, "Scale Reading: %0.2f, Smoothed Weight: %0.1f", reading, _weight);
+    _reading_callback(_weight);
+}
+
+void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
+    _scale_factor1 = scale_factor1;
+    _scale_factor2 = scale_factor2;
+    ESP_LOGI(LOG_TAG, "Set scale factors: %.3f, %.3f", _scale_factor1, _scale_factor2);
+}
+
+void HardwareScale::tare() {
+    _is_taring_or_calibrating = true;
+
+    long raw1 = 0;
+    long raw2 = 0;
+    for (int i = 0; i < 10; i++) {
+        while (!isReady()) {
+            delay(10);
+        }
+        _raw_weight = readRaw();
+        raw1 += _raw_weight.value1;
+        raw2 += _raw_weight.value2;
+    }
+    _offset1 = raw1 / 10;
+    _offset2 = raw2 / 10;
+    _weight = 0.0f; // Reset weight to zero after tare
+    ESP_LOGI(LOG_TAG, "Tared scale offsets: %.3f, %.3f", _offset1, _offset2);
+    _is_taring_or_calibrating = false;
+}
+
+void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
+    _is_taring_or_calibrating = true;
+
+    long value = 0;
+    for (int i = 0; i < 10; i++) {
+        while (!isReady()) {
+            delay(10);
+        }
+        value += (scale == 0) ? readRaw().value1 : readRaw().value2; // Read from the first scale
+    }
+    value /= 10;
+
+    if (scale == 0) {
+        _scale_factor1 = (static_cast<float>(value) - _offset1) / calibrationWeight; // 2225.767
+    } else if (scale == 1) {
+        _scale_factor2 = (static_cast<float>(value) - _offset2) / calibrationWeight; // -2159.782
+    }
+
+    ESP_LOGI(LOG_TAG, "Calibrated scale %d with factor: %.3f", scale, (scale == 0 ? _scale_factor1 : _scale_factor2));
+    _is_taring_or_calibrating = false;
+    _configuration_callback(_scale_factor1, _scale_factor2);
+}
+
+[[noreturn]] void HardwareScale::loopTask(void *arg) {
+    TickType_t lastWake = xTaskGetTickCount();
+    auto *scale = static_cast<HardwareScale *>(arg);
+    while (true) {
+        scale->loop();
+        xTaskDelayUntil(&lastWake, pdMS_TO_TICKS(SCALE_READ_INTERVAL_MS));
+    }
+}

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -8,10 +8,13 @@ constexpr int SCALE_READ_INTERVAL_MS = 100;
 
 using scale_reading_callback_t = std::function<void(float)>;
 using scale_configuration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
+using void_callback_t = std::function<void()>;
 
 class HardwareScale {
     public:
-        HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, const scale_reading_callback_t &reading_callback, const scale_configuration_callback_t &config_callback);
+        HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, 
+            const scale_reading_callback_t &reading_callback,
+            const scale_configuration_callback_t &config_callback);
         ~HardwareScale() = default;
 
          struct RawReading {

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -1,0 +1,55 @@
+#ifndef HARDWARESCALE_H
+#define HARDWARESCALE_H
+
+#include <Arduino.h>
+#include <functional>
+
+constexpr int SCALE_READ_INTERVAL_MS = 100;
+
+using scale_reading_callback_t = std::function<void(float)>;
+using scale_configuration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
+
+class HardwareScale {
+    public:
+        HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, const scale_reading_callback_t &reading_callback, const scale_configuration_callback_t &config_callback);
+        ~HardwareScale() = default;
+
+         struct RawReading {
+            long value1;
+            long value2;
+        };
+
+        void setup();
+        void loop();
+        inline float getWeight() const;
+        inline RawReading getRawWeight() const { return _raw_weight; }
+        void setScaleFactors(float scale_factor1, float scale_factor2);
+        void calibrateScale(uint8_t scale, float calibrationWeight);
+        bool isReady();
+        bool isAvailable() const { return is_initialized; }
+        void tare();
+
+    private:
+        bool is_initialized;
+        uint8_t _data_pin1;
+        uint8_t _data_pin2;
+        uint8_t _clock_pin;
+        RawReading _raw_weight;
+        float _weight = 0.0f;
+        float _scale_factor1;
+        float _scale_factor2;
+        float _offset1;
+        float _offset2;
+        bool _is_taring_or_calibrating;
+        scale_reading_callback_t _reading_callback;
+        scale_configuration_callback_t _configuration_callback;
+        xTaskHandle taskHandle;
+
+        const char *LOG_TAG = "HardwareScale";
+        static void loopTask(void *arg);
+        
+        RawReading readRaw();
+        float convertRawToWeight(const RawReading &raw) const;
+};
+
+#endif // HARDWARESCALE_H

--- a/lib/GaggiMateController/src/utilities.h
+++ b/lib/GaggiMateController/src/utilities.h
@@ -13,6 +13,7 @@ inline String make_system_info(ControllerConfig config) {
     capabilities["dm"] = config.capabilites.dimming;
     capabilities["led"] = config.capabilites.ledControls;
     capabilities["tof"] = config.capabilites.tof;
+    capabilities["hs"] = config.capabilites.hwScale;
     doc["cp"] = capabilities;
     return doc.as<String>();
 }

--- a/lib/NimBLEComm/src/NimBLEClientController.h
+++ b/lib/NimBLEComm/src/NimBLEClientController.h
@@ -19,6 +19,9 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void sendPidSettings(const String &pid);
     void setPressureScale(float scale);
     void sendLedControl(uint8_t channel, uint8_t brightness);
+    void sendScaleTare();
+    void sendCalibrateScale(uint8_t cell, float calibrationWeight);
+    void sendScaleCalibration(float scaleFactor1, float scaleFactor2);
     bool isReadyForConnection() const;
     bool isConnected();
     void scan();
@@ -30,6 +33,8 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void registerAutotuneResultCallback(const pid_control_callback_t &callback);
     void registerVolumetricMeasurementCallback(const float_callback_t &callback);
     void registerTofMeasurementCallback(const int_callback_t &callback);
+    void registerScaleMeasurementCallback(const float_callback_t &callback);
+    void registerScaleCalibrationCallback(const scale_calibration_callback_t &callback);
     std::string readInfo() const;
     NimBLEClient *getClient() const { return client; };
 
@@ -56,6 +61,10 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     NimBLERemoteCharacteristic *volumetricTareChar = nullptr;
     NimBLERemoteCharacteristic *ledControlChar = nullptr;
     NimBLERemoteCharacteristic *tofMeasurementChar = nullptr;
+    NimBLERemoteCharacteristic *scaleTareChar = nullptr;
+    NimBLERemoteCharacteristic *scaleCalibrationChar = nullptr;
+    NimBLERemoteCharacteristic *scaleCalibrateChar = nullptr;
+    NimBLERemoteCharacteristic *scaleWeightMeasurementChar = nullptr; 
     NimBLEAdvertisedDevice *serverDevice = nullptr;
     bool readyForConnection = false;
 
@@ -66,7 +75,9 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     sensor_read_callback_t sensorCallback = nullptr;
     float_callback_t volumetricMeasurementCallback = nullptr;
     int_callback_t tofMeasurementCallback = nullptr;
-
+    float_callback_t scaleMeasurementCallback = nullptr;
+    scale_calibration_callback_t scaleCalibrationCallback = nullptr;
+    void_callback_t scaleTareCompleteCallback = nullptr;
     String _lastOutputControl = "";
 
     // BLEAdvertisedDeviceCallbacks override

--- a/lib/NimBLEComm/src/NimBLEComm.h
+++ b/lib/NimBLEComm/src/NimBLEComm.h
@@ -23,6 +23,10 @@
 #define VOLUMETRIC_TARE_UUID "a8bd52e0-77c3-412c-847c-4e802c3982f9"
 #define TOF_MEASUREMENT_UUID "7282c525-21a0-416a-880d-21fe98602533"
 #define LED_CONTROL_UUID "37804a2b-49ab-4500-8582-db4279fc8573"
+#define SCALE_TARE_UUID "c1b8f0d2-3a4e-4f5c-9b6d-7f8c1e2b3a4e"
+#define SCALE_CALIBRATION_UUID "d2b3a4e1-3f0d-4f5c-9b6d-7f8c1e2b3a4e"
+#define SCALE_CALIBRATE_UUID "e1b3a4d2-3f0d-4f5c-9b6d-7f8c1e2b3a4e"
+#define SCALE_WEIGHT_MEASUREMENT_UUID "f1b3a4d2-3f0d-4f5c-9b6d-7f8c1e2b3a4e"
 
 constexpr size_t ERROR_CODE_COMM_SEND = 1;
 constexpr size_t ERROR_CODE_COMM_RCV = 2;
@@ -37,6 +41,8 @@ using remote_err_callback_t = std::function<void(int errorCode)>;
 using autotune_callback_t = std::function<void(int testTime, int samples)>;
 using brew_callback_t = std::function<void(bool brewButtonStatus)>;
 using steam_callback_t = std::function<void(bool steamButtonStatus)>;
+using scale_calibrate_callback_t = std::function<void(uint8_t cell, float calibrationWeight)>;
+using scale_calibration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
 using void_callback_t = std::function<void()>;
 
 // New combined callbacks
@@ -53,6 +59,7 @@ struct SystemCapabilities {
     bool pressure;
     bool ledControl;
     bool tof;
+    bool hwScale;
 };
 
 struct SystemInfo {

--- a/lib/NimBLEComm/src/NimBLEServerController.cpp
+++ b/lib/NimBLEComm/src/NimBLEServerController.cpp
@@ -151,8 +151,8 @@ void NimBLEServerController::sendTofMeasurement(int value) {
 
 void NimBLEServerController::sendScaleMeasurement(float weight) {
     if (deviceConnected && scaleWeightMeasurementChar != nullptr) {
-        char data[9]; // 1500.000 is 8 bytes + null terminator
-        snprintf(data, sizeof(data), "%.3f", weight);
+        char data[9]; // -1500.00 is 8 bytes + null terminator
+        snprintf(data, sizeof(data), "%.2f", weight);
         scaleWeightMeasurementChar->setValue(data);
         scaleWeightMeasurementChar->notify();
     }

--- a/lib/NimBLEComm/src/NimBLEServerController.cpp
+++ b/lib/NimBLEComm/src/NimBLEServerController.cpp
@@ -63,6 +63,14 @@ void NimBLEServerController::initServer(const String infoString) {
     ledControlChar = pService->createCharacteristic(LED_CONTROL_UUID, NIMBLE_PROPERTY::WRITE);
     ledControlChar->setCallbacks(this);
 
+    scaleTareChar = pService->createCharacteristic(SCALE_TARE_UUID, NIMBLE_PROPERTY::WRITE);
+    scaleTareChar->setCallbacks(this);
+    scaleCalibrationChar = pService->createCharacteristic(SCALE_CALIBRATION_UUID, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+    scaleCalibrationChar->setCallbacks(this);
+    scaleCalibrateChar = pService->createCharacteristic(SCALE_CALIBRATE_UUID, NIMBLE_PROPERTY::WRITE);
+    scaleCalibrateChar->setCallbacks(this);
+    scaleWeightMeasurementChar = pService->createCharacteristic(SCALE_WEIGHT_MEASUREMENT_UUID, NIMBLE_PROPERTY::NOTIFY);
+
     pService->start();
 
     ota_dfu_ble.configure_OTA(pServer);
@@ -141,6 +149,24 @@ void NimBLEServerController::sendTofMeasurement(int value) {
     }
 }
 
+void NimBLEServerController::sendScaleMeasurement(float weight) {
+    if (deviceConnected && scaleWeightMeasurementChar != nullptr) {
+        char data[9]; // 1500.000 is 8 bytes + null terminator
+        snprintf(data, sizeof(data), "%.3f", weight);
+        scaleWeightMeasurementChar->setValue(data);
+        scaleWeightMeasurementChar->notify();
+    }
+}
+
+void NimBLEServerController::sendScaleCalibration(float scaleFactor1, float scaleFactor2) {
+    if (deviceConnected && scaleCalibrationChar != nullptr) {
+        char data[32]; // -9999.999,-9999.999 is 19 bytes + null terminator
+        snprintf(data, sizeof(data), "%.3f,%.3f", scaleFactor1, scaleFactor2);
+        scaleCalibrationChar->setValue(data);
+        scaleCalibrationChar->notify();
+    }
+}
+
 void NimBLEServerController::registerOutputControlCallback(const simple_output_callback_t &callback) {
     outputControlCallback = callback;
 }
@@ -161,6 +187,14 @@ void NimBLEServerController::registerLedControlCallback(const led_control_callba
 void NimBLEServerController::setInfo(const String infoString) {
     this->infoString = infoString;
     infoChar->setValue(infoString);
+}
+
+void NimBLEServerController::registerScaleTareCallback(const void_callback_t &callback) { scaleTareCallback = callback; }
+void NimBLEServerController::registerScaleCalibrateCallback(const scale_calibrate_callback_t &callback) {
+    scaleCalibrateCallback = callback;
+}
+void NimBLEServerController::registerScaleCalibrationCallback(const scale_calibration_callback_t &callback) {
+    scaleCalibrationCallback = callback;
 }
 
 void NimBLEServerController::registerPidControlCallback(const pid_control_callback_t &callback) { pidControlCallback = callback; }
@@ -251,6 +285,27 @@ void NimBLEServerController::onWrite(NimBLECharacteristic *pCharacteristic) {
             uint8_t brightness = get_token(msg, 1, ',').toInt();
             ledControlCallback(channel, brightness);
             ESP_LOGV(LOG_TAG, "Received led control, %d: %d", channel, brightness);
+        }
+    } else if (pCharacteristic->getUUID().equals(NimBLEUUID(SCALE_TARE_UUID))) {
+        ESP_LOGV(LOG_TAG, "Received scale tare");
+        if (scaleTareCallback != nullptr) {
+            scaleTareCallback();
+        }
+    } else if (pCharacteristic->getUUID().equals(NimBLEUUID(SCALE_CALIBRATION_UUID))) {
+        auto calibration = String(pCharacteristic->getValue().c_str());
+        float scaleFactor1 = get_token(calibration, 0, ',').toFloat();
+        float scaleFactor2 = get_token(calibration, 1, ',').toFloat();
+        ESP_LOGV(LOG_TAG, "Received scale calibration: %.2f, %.2f", scaleFactor1, scaleFactor2);
+        if (scaleCalibrationCallback != nullptr) {
+            scaleCalibrationCallback(scaleFactor1, scaleFactor2);
+        }
+    } else if (pCharacteristic->getUUID().equals(NimBLEUUID(SCALE_CALIBRATE_UUID))) {
+        auto calibration = String(pCharacteristic->getValue().c_str());
+        uint8_t scale = get_token(calibration, 0, ',').toInt();
+        float calibrationWeight = get_token(calibration, 1, ',').toFloat();
+        ESP_LOGV(LOG_TAG, "Received scale calibrate: %d, %.2f", scale, calibrationWeight);
+        if (scaleCalibrateCallback != nullptr) {
+            scaleCalibrateCallback(scale, calibrationWeight);
         }
     }
 }

--- a/lib/NimBLEComm/src/NimBLEServerController.h
+++ b/lib/NimBLEComm/src/NimBLEServerController.h
@@ -16,6 +16,8 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     void sendAutotuneResult(float Kp, float Ki, float Kd);
     void sendVolumetricMeasurement(float value);
     void sendTofMeasurement(int value);
+    void sendScaleMeasurement(float weight);
+    void sendScaleCalibration(float scaleFactor1, float scaleFactor2);
     void registerOutputControlCallback(const simple_output_callback_t &callback);
     void registerAdvancedOutputControlCallback(const advanced_output_callback_t &callback);
     void registerAltControlCallback(const pin_control_callback_t &callback);
@@ -25,6 +27,9 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     void registerPressureScaleCallback(const float_callback_t &callback);
     void registerTareCallback(const void_callback_t &callback);
     void registerLedControlCallback(const led_control_callback_t &callback);
+    void registerScaleTareCallback(const void_callback_t &callback);
+    void registerScaleCalibrateCallback(const scale_calibrate_callback_t &callback);
+    void registerScaleCalibrationCallback(const scale_calibration_callback_t &callback);
     void setInfo(String infoString);
 
   private:
@@ -46,6 +51,10 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     NimBLECharacteristic *volumetricTareChar = nullptr;
     NimBLECharacteristic *tofMeasurementChar = nullptr;
     NimBLECharacteristic *ledControlChar = nullptr;
+    NimBLECharacteristic *scaleTareChar = nullptr;
+    NimBLECharacteristic *scaleCalibrationChar = nullptr;
+    NimBLECharacteristic *scaleCalibrateChar = nullptr;
+    NimBLECharacteristic *scaleWeightMeasurementChar = nullptr; 
 
     simple_output_callback_t outputControlCallback = nullptr;
     advanced_output_callback_t advancedControlCallback = nullptr;
@@ -55,6 +64,9 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     autotune_callback_t autotuneCallback = nullptr;
     float_callback_t pressureScaleCallback = nullptr;
     void_callback_t tareCallback = nullptr;
+    void_callback_t scaleTareCallback = nullptr;
+    scale_calibrate_callback_t scaleCalibrateCallback = nullptr;
+    scale_calibration_callback_t scaleCalibrationCallback = nullptr;
     led_control_callback_t ledControlCallback = nullptr;
 
     // BLEServerCallbacks overrides

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -15,6 +15,7 @@
 #include <display/plugins/SmartGrindPlugin.h>
 #include <display/plugins/WebUIPlugin.h>
 #include <display/plugins/mDNSPlugin.h>
+#include <display/plugins/HardwareScalePlugin.h>
 
 const String LOG_TAG = F("Controller");
 
@@ -46,7 +47,8 @@ void Controller::setup() {
     }
     pluginManager->registerPlugin(new WebUIPlugin());
     pluginManager->registerPlugin(&ShotHistory);
-    pluginManager->registerPlugin(&BLEScales);
+    // pluginManager->registerPlugin(&BLEScales);
+    pluginManager->registerPlugin(&HardwareScales);
     pluginManager->registerPlugin(new LedControlPlugin());
     pluginManager->setup(this);
 
@@ -128,6 +130,21 @@ void Controller::setupBluetooth() {
         ESP_LOGV(LOG_TAG, "Received new TOF distance: %d", value);
         pluginManager->trigger("controller:tof:change", "value", value);
     });
+
+    clientController.registerScaleMeasurementCallback([this](const float value) {
+        ESP_LOGV(LOG_TAG, "Received new scale measurement: %.2f", value);
+        pluginManager->trigger("controller:scale:measurement", "value", value);
+    });
+    clientController.registerScaleCalibrationCallback([this](const float scaleFactor1, const float scaleFactor2) {
+        ESP_LOGV(LOG_TAG, "Received new scale calibration: %.3f, %.3f", scaleFactor1, scaleFactor2);
+        settings.setScaleFactors(scaleFactor1, scaleFactor2);
+        Event e;
+        e.id = "controller:scale:cal_update";
+        e.setFloat("scaleFactor1", scaleFactor1);
+        e.setFloat("scaleFactor2", scaleFactor2);
+        pluginManager->trigger(e);
+    });
+
     pluginManager->trigger("controller:bluetooth:init");
 }
 
@@ -148,6 +165,7 @@ void Controller::setupInfos() {
                                     .pressure = doc["cp"]["ps"].as<bool>(),
                                     .ledControl = doc["cp"]["led"].as<bool>(),
                                     .tof = doc["cp"]["tof"].as<bool>(),
+                                    .hwScale = doc["cp"]["hs"].as<bool>()
                                 }};
     }
 }

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -66,6 +66,10 @@ Settings::Settings() {
     emptyTankDistance = preferences.getInt("sr_ed", 200);
     fullTankDistance = preferences.getInt("sr_fd", 50);
 
+    // Hardware scale settings
+    scaleFactor1 = preferences.getFloat("hs_sf1", 0.0f);
+    scaleFactor2 = preferences.getFloat("hs_sf2", 0.0f);
+
     preferences.end();
 
     xTaskCreate(loopTask, "Settings::loop", configMINIMAL_STACK_SIZE * 6, this, 1, &taskHandle);
@@ -373,6 +377,12 @@ void Settings::setFullTankDistance(int full_tank_distance) {
     save();
 }
 
+void Settings::setScaleFactors(float scale_factor_1, float scale_factor_2) {
+    scaleFactor1 = scale_factor_1;
+    scaleFactor2 = scale_factor_2;
+    save();
+}
+
 void Settings::doSave() {
     if (!dirty) {
         return;
@@ -441,6 +451,10 @@ void Settings::doSave() {
     preferences.putInt("sr_exb", sunriseExtBrightness);
     preferences.putInt("sr_ed", emptyTankDistance);
     preferences.putInt("sr_fd", fullTankDistance);
+
+    // Hardware scale settings
+    preferences.putFloat("hs_sf1", scaleFactor1);
+    preferences.putFloat("hs_sf2", scaleFactor2);
 
     preferences.end();
 }

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -76,6 +76,8 @@ class Settings {
     int getSunriseExtBrightness() const { return sunriseExtBrightness; }
     int getEmptyTankDistance() const { return emptyTankDistance; }
     int getFullTankDistance() const { return fullTankDistance; }
+    float getScaleFactor1() const { return scaleFactor1; }
+    float getScaleFactor2() const { return scaleFactor2; }
     void setTargetBrewTemp(int target_brew_temp);
     void setTargetSteamTemp(int target_steam_temp);
     void setTargetWaterTemp(int target_water_temp);
@@ -134,6 +136,7 @@ class Settings {
     void setSunriseExtBrightness(int sunrise_ext_brightness);
     void setEmptyTankDistance(int empty_tank_distance);
     void setFullTankDistance(int full_tank_distance);
+    void setScaleFactors(float scale_factor_1, float scale_factor_2);
 
   private:
     Preferences preferences;
@@ -202,6 +205,10 @@ class Settings {
     int sunriseExtBrightness = 255;
     int emptyTankDistance = 200;
     int fullTankDistance = 50;
+
+    // Hardware scale settings
+    float scaleFactor1 = 0.0f;
+    float scaleFactor2 = 0.0f;
 
     void doSave();
     xTaskHandle taskHandle;

--- a/src/display/plugins/HardwareScalePlugin.cpp
+++ b/src/display/plugins/HardwareScalePlugin.cpp
@@ -1,0 +1,57 @@
+#include "HardwareScalePlugin.h"
+#include <display/core/Controller.h>
+
+HardwareScalePlugin HardwareScales;
+
+HardwareScalePlugin::HardwareScalePlugin() = default;
+
+void HardwareScalePlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+
+    pluginManager->on("controller:ready", [this](Event const &) {
+        _isAvailable = this->controller->getSystemInfo().capabilities.hwScale;
+        _scaleFactor1 = this->controller->getSettings().getScaleFactor1();
+        _scaleFactor2 = this->controller->getSettings().getScaleFactor2();
+
+        ESP_LOGI(LOG_TAG, "Hardware scale available: %s", _isAvailable ? "true" : "false");
+
+        if (_scaleFactor1 != 0.0f && _scaleFactor2 != 0.0f) {
+            this->controller->getClientController()->sendScaleCalibration(_scaleFactor1, _scaleFactor2);
+            delay(50);
+        }
+        this->controller->getClientController()->sendScaleTare();
+
+        this->controller->setVolumetricOverride(_isAvailable);
+    });
+
+    pluginManager->on("controller:brew:start", [this](Event const &) {
+       onProcessStart();
+    });
+
+    pluginManager->on("controller:scale:measurement", [this](Event const &event) {
+        float value = event.getFloat("value");
+        ESP_LOGI(LOG_TAG, "Scale measurement: %.2f", value);
+        this->onMeasurement(value);
+    });
+
+    pluginManager->on("controller:scale:cal_update", [this](Event const &event) {
+        _scaleFactor1 = event.getFloat("scaleFactor1");
+        _scaleFactor2 = event.getFloat("scaleFactor2");
+        this->controller->getSettings().setScaleFactors(_scaleFactor1, _scaleFactor2);
+    });
+}
+
+void HardwareScalePlugin::onProcessStart() {
+    if (_isAvailable) {
+        ESP_LOGI(LOG_TAG, "Starting tare process for hardware scale");
+        controller->getClientController()->sendScaleTare();
+        delay(200);
+
+        ESP_LOGI(LOG_TAG, "Scale process start completed successfully");
+    }
+}
+
+void HardwareScalePlugin::onMeasurement(float value) {
+    this->_lastMeasurement = value;
+    controller->onVolumetricMeasurement(value, VolumetricMeasurementSource::BLUETOOTH);
+}

--- a/src/display/plugins/HardwareScalePlugin.cpp
+++ b/src/display/plugins/HardwareScalePlugin.cpp
@@ -41,6 +41,20 @@ void HardwareScalePlugin::setup(Controller *controller, PluginManager *pluginMan
     });
 }
 
+void HardwareScalePlugin::tare() {
+    if (_isAvailable) {
+        ESP_LOGI(LOG_TAG, "Taring hardware scale");
+        controller->getClientController()->sendScaleTare();
+    }
+}
+
+void HardwareScalePlugin::calibrate(uint8_t cell, float calibrationWeight) {
+    if (_isAvailable) {
+        ESP_LOGI(LOG_TAG, "Calibrating hardware scale: cell %d, weight %.2f", cell, calibrationWeight);
+        controller->getClientController()->sendCalibrateScale(cell, calibrationWeight);
+    }
+}
+
 void HardwareScalePlugin::onProcessStart() {
     if (_isAvailable) {
         ESP_LOGI(LOG_TAG, "Starting tare process for hardware scale");

--- a/src/display/plugins/HardwareScalePlugin.h
+++ b/src/display/plugins/HardwareScalePlugin.h
@@ -1,0 +1,36 @@
+#ifndef HARDWARESCALEPLUGIN_H
+#define HARDWARESCALEPLUGIN_H
+#include "../core/Plugin.h"
+#include <stdint.h>
+
+void on_scale_measurement(float value);
+
+class HardwareScalePlugin : public Plugin {
+  public:
+    HardwareScalePlugin();
+
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override {};
+    void tare();
+    void calibrate(uint8_t cell, float calibrationWeight);
+
+    bool isConnected() const {  return _isAvailable; }
+    float getWeight() const {
+        return _lastMeasurement;
+    }
+
+  private:
+    void onMeasurement(float value);
+    void onProcessStart();
+
+    const char *LOG_TAG = "HardwareScalePlugin";
+    bool _isAvailable;
+    float _lastMeasurement = 0.0f;
+    float _scaleFactor1 = 1.0f, _scaleFactor2 = 1.0f;
+
+    Controller *controller = nullptr;
+};
+
+extern HardwareScalePlugin HardwareScales;
+
+#endif // HARDWARESCALEPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -201,6 +201,14 @@ void WebUIPlugin::setupServer() {
                                 String msg;
                                 serializeJson(resp, msg);
                                 ws.text(client->id(), msg);
+                            } else if (msgType == "req:scale:tare") {
+                                if (HardwareScales.isConnected()) {
+                                    HardwareScales.tare();
+                                }
+                            } else if (msgType == "req:scale:calibrate") {
+                                if (HardwareScales.isConnected() && doc["cell"].is<uint8_t>() && doc["calWeight"].is<float>()) {
+                                    HardwareScales.calibrate(doc["cell"].as<uint8_t>(), doc["calWeight"].as<float>());
+                                }
                             }
                         }
                     }
@@ -541,43 +549,4 @@ void WebUIPlugin::sendAutotuneResult() {
     doc["pid"] = controller->getSettings().getPid();
     String message = doc.as<String>();
     ws.textAll(message);
-}
-
-void WebUIPlugin::handleScaleTare(AsyncWebServerRequest *request) {
-    if (request->method() != HTTP_POST) {
-        request->send(404);
-        return;
-    }
-    HardwareScales.tare();
-    JsonDocument doc;
-    doc["success"] = true;
-    AsyncResponseStream *response = request->beginResponseStream("application/json");
-    serializeJson(doc, *response);
-    request->send(response);
-}
-
-void WebUIPlugin::handleScaleCalibrate(AsyncWebServerRequest *request) {
-    if (request->method() != HTTP_POST) {
-        request->send(404);
-        return;
-    }
-    if (!request->hasArg("c")) {
-        request->send(400, "Missing cell index argument");
-        return;
-    } 
-    if (!request->hasArg("cw")) {
-        request->send(400, "Missing calibration weight argument");
-        return;
-    }
-
-    uint8_t cellIndex = request->arg("c").toInt();
-    float calibrationWeight = request->arg("cw").toFloat();
-    
-    HardwareScales.calibrate(cellIndex, calibrationWeight);
-
-    JsonDocument doc;
-    doc["success"] = true;
-    AsyncResponseStream *response = request->beginResponseStream("application/json");
-    serializeJson(doc, *response);
-    request->send(response);
 }

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -49,8 +49,6 @@ class WebUIPlugin : public Plugin {
     void updateOTAStatus(const String &version);
     void updateOTAProgress(uint8_t phase, int progress);
     void sendAutotuneResult();
-    void handleScaleTare(AsyncWebServerRequest *request);
-    void handleScaleCalibrate(AsyncWebServerRequest *request);
 
     GitHubOTA *ota = nullptr;
     AsyncWebServer server;

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -49,6 +49,8 @@ class WebUIPlugin : public Plugin {
     void updateOTAStatus(const String &version);
     void updateOTAProgress(uint8_t phase, int progress);
     void sendAutotuneResult();
+    void handleScaleTare(AsyncWebServerRequest *request);
+    void handleScaleCalibrate(AsyncWebServerRequest *request);
 
     GitHubOTA *ota = nullptr;
     AsyncWebServer server;

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -49,6 +49,13 @@ function getChartData(data) {
           yAxisID: 'y1',
           data: data.map((i, idx) => ({ x: i.timestamp.toISOString(), y: i.currentFlow })),
         },
+        {
+          label: 'Current Weight',
+          borderColor: '#A0522D',
+          pointStyle: false,
+          yAxisID: 'y1',
+          data: data.map((i, idx) => ({ x: i.timestamp.toISOString(), y: i.currentWeight })),
+        }
       ],
     },
     options: {

--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -23,6 +23,7 @@ const modeMap = {
 };
 
 const status = computed(() => machine.value.status);
+const hwScale = computed(() => machine.value.capabilities.hardwareScale);
 
 export function Home() {
   const apiService = useContext(ApiServiceContext);
@@ -84,6 +85,16 @@ export function Home() {
                 <dd className="text-sm font-medium text-slate-500">Pressure</dd>
               </dl>
             </div>
+            {hwScale.value && (
+              <div className="p-6 sm:col-span-12 md:col-span-4">
+                <dl>
+                  <dt className="text-xl md:text-2xl font-bold">
+                    {status.value.currentWeight?.toFixed(1) || 0} g
+                  </dt>
+                  <dd className="text-sm font-medium text-slate-500">Weight</dd>
+                </dl>
+              </div>
+            )}
             <div className="p-6 sm:col-span-12 md:col-span-4">
               <dl>
                 <dt className="text-xl md:text-2xl font-bold">

--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -36,6 +36,12 @@ export function Home() {
     },
     [apiService]
   );
+  const tareScale = useCallback(() => {
+    apiService.send({
+      tp: 'req:scale:tare',
+    });
+  }, [apiService]);
+
   const mode = machine.value.status.mode;
 
   return (
@@ -89,7 +95,7 @@ export function Home() {
               <div className="p-6 sm:col-span-12 md:col-span-4">
                 <dl>
                   <dt className="text-xl md:text-2xl font-bold">
-                    {status.value.currentWeight?.toFixed(1) || 0} g
+                    {status.value.currentWeight?.toFixed(1) || 0}g <a class="btn" href="" onClick={() => tareScale()}><i className="fa-solid fa-scale-unbalanced ml-2"></i></a>
                   </dt>
                   <dd className="text-sm font-medium text-slate-500">Weight</dd>
                 </dl>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -8,6 +8,7 @@ import { computed } from '@preact/signals';
 import { machine } from '../../services/ApiService.js';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
+const hwScale = computed(() => machine.value.capabilities.hardwareScale);
 
 export function Settings() {
   const [submitting, setSubmitting] = useState(false);
@@ -670,6 +671,47 @@ export function Settings() {
               max="1000"
               value={formData.fullTankDistance}
               onChange={onChange('fullTankDistance')}
+            />
+          </div>
+        </Card>
+      )}
+      {hwScale.value && (
+        <Card xs={12} lg={6} title="Hardware Scale Settings">
+          <div>
+            <span>Set the calibration factors for the hardware scale</span>
+          </div>
+          <div>
+            <label htmlFor="scaleFactor1" className="block font-medium text-gray-700 dark:text-gray-400">
+              Load Cell 1 Scale Factor
+            </label>
+            <input
+              id="scaleFactor1"
+              name="scaleFactor1"
+              type="number"
+              className="input-field"
+              placeholder="200.00"
+              min="-50000.00"
+              max="50000.00"
+              step="0.01"
+              value={formData.scaleFactor1}
+              onChange={onChange('scaleFactor1')}
+            />
+          </div>
+          <div>
+            <label htmlFor="scaleFactor2" className="block font-medium text-gray-700 dark:text-gray-400">
+              Load Cell 2 Scale Factor
+            </label>
+            <input
+              id="scaleFactor2"
+              name="scaleFactor2"
+              type="number"
+              className="input-field"
+              placeholder="200.00"
+              min="-50000.00"
+              max="50000.00"
+              step="0.01"
+              value={formData.scaleFactor2}
+              onChange={onChange('scaleFactor2')}
             />
           </div>
         </Card>

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -157,6 +157,7 @@ export default class ApiService {
       currentPressure: message.pr,
       targetPressure: message.pt,
       currentFlow: message.fl,
+      currentWeight: message.cw,
       mode: message.m,
       selectedProfile: message.p,
       brewTarget: message.bt || 0,
@@ -177,6 +178,7 @@ export default class ApiService {
         dimming: message.cd,
         pressure: message.cp,
         ledControl: message.led,
+        hardwareScale: message.hs,
       },
       history: [...machine.value.history, historyEntry],
     };
@@ -199,6 +201,7 @@ export const machine = signal({
   capabilities: {
     pressure: false,
     dimming: false,
+    hardwareScale: false,
   },
   history: [],
 });


### PR DESCRIPTION
A WIP implementation of the Hardware Scales mod. 

## Overview

What's included:

-  [x] Integration of two HX711 modules with shared clock line (tested on GM Pro v1)
  -  [x] Taring of scales
  - [x] Calibrating individual load cells
  - [x] Basic reading averaging
  - [ ] HX711 power down   
- [x] Integration of Hardware scale into display firmware
  - [x] HardwareScalePlugin added
  - [ ] Combine with BLEScalePlugin / adjust BLEScalePlugin
  - [x] Hardware scale calibration factors settings
  - [ ] WebUI for performing scale calibration
  - [ ] Add tare button to WebUI dashboard?
  - [ ] Add live weight display to brewing "start" screen?
  - [ ] Add tare button to brewing "start" screen?  

## Open questions / Feedback needed

Some notes, and places I'd like some feedback:

1. Feedback on changes to the WebUI would be especially appreciated; my experience with React is quite low 🙈
2. I added the display of the current weight to the status and chart views on the webui home page, mostly out of convenience for testing as the currently weight doesn't show anywhere else.
3. I have the new code for LED / ToF commented out of the controller startup, as their use of the 5-pin port interferes with the HX711's. The HX711 uses a two wire serial (SPI like) signalling protocol, which isn't compatible with the I2C that is being used on other expansion boards.
4. I'm currently piggybacking on the BLE volumetric measurement source. A third source could be added rather easily, but  for the sake of proving out the rest of implementation, I took the easy path forward. 
5. I currently have the BLEScalePlugin disabled in (commented out the register plugin call) in the display firmware. Right now the BLEScalePlugin makes the assumption that it is the only source of enabling and disabling volumetric overrides, and updates the status of the override in its runloop. I see two possible paths forward here:
  a. Combine the BLEScalePlugin and the HardwareScalePlugin into a single plugin that allows for only one type of scale to be active at a time.
  b. Change the type of the volumetric override from a bool to an enum that indicates what the source of the override is, then in the setVolumetricOverride method, check to  see if the source of the change request matches the currently configured one, something like:
```C++
enum VolumetricOverrideSource {
    NONE,
    BLUETOOTH,
    HARDWARE_SCALE,
};

void setVolumetricOverride(bool override, VolumetricOverrideSource source) {
    if (_override == source || _override == NONE) {
       _override = override ? source : NONE;
    }
}

```

## Testing

I've completed all my testing on a GCP E24 with GM Pro v1.

### Test setup:
- Hardware scale mod, using mostly standard parts found in the printables project (I had to narrow up the low profile drip tray adapter to fit the LP drip tray I purchased from Aliexpress).
- Hardware scales with two discrete "green" HX711 boards.
  - HX711 boards modified with a 4.7K/10K voltage divider on the DT lines to ensure that we don't expose the ESP32 on the controller board to more than ~3.4V. Alternatively a bi-directional MOSFET type level shifter could be used, but without easy access to a 3.3V source, the voltage divider is simpler to implement.

### Test notes:
- The predictive scale feature is rather aggressive in my testing, and I've had to lower its time interval to 200ms to not dramatically undershoot the target weights.