### PR TITLE
Shot history notes

### DIFF
--- a/docs/shot-notes-api.md
+++ b/docs/shot-notes-api.md
@@ -1,0 +1,186 @@
+# Shot Notes API Extension
+
+This document describes the new shot notes functionality added to the ShotHistoryPlugin.
+
+## Enhanced Shot History API
+
+The existing shot history API endpoints have been enhanced to automatically include notes data when available.
+
+### Get Shot History List
+**Request Type:** `req:history:list`
+
+**Response:**
+```json
+{
+  "tp": "res:history:list",
+  "rid": "unique-request-id",
+  "history": [
+    {
+      "id": "000001",
+      "history": "1,Profile Name,1692123456\n0,85.0,84.5,9.0,8.7,2.1,2.0,1.8,0.0,0.0,0.0\n...",
+      "notes": {
+        "id": "000001",
+        "rating": 4,
+        "doseIn": 18.5,
+        "doseOut": 37.2,
+        "ratio": 2.01,
+        "grindSetting": "2.5",
+        "balanceTaste": "balanced",
+        "notes": "Great shot with nice crema and balanced flavor",
+        "timestamp": 1692123456
+      }
+    }
+  ]
+}
+```
+
+### Get Single Shot History
+**Request Type:** `req:history:get`
+
+**Response:**
+```json
+{
+  "tp": "res:history:get",
+  "rid": "unique-request-id",
+  "history": "1,Profile Name,1692123456\n0,85.0,84.5,9.0,8.7,2.1,2.0,1.8,0.0,0.0,0.0\n...",
+  "notes": {
+    "id": "000001",
+    "rating": 4,
+    "doseIn": 18.5,
+    "doseOut": 37.2,
+    "ratio": 2.01,
+    "grindSetting": "2.5",
+    "balanceTaste": "balanced",
+    "notes": "Great shot with nice crema and balanced flavor",
+    "timestamp": 1692123456
+  }
+}
+```
+
+## New Shot Notes API Endpoints
+
+### Get Shot Notes
+**Request Type:** `req:history:notes:get`
+
+**Request:**
+```json
+{
+  "tp": "req:history:notes:get",
+  "id": "000001",
+  "rid": "unique-request-id"
+}
+```
+
+**Response:**
+```json
+{
+  "tp": "res:history:notes:get",
+  "rid": "unique-request-id",
+  "notes": {
+    "id": "000001",
+    "rating": 4,
+    "doseIn": 18.5,
+    "doseOut": 37.2,
+    "ratio": 2.01,
+    "grindSetting": "2.5",
+    "balanceTaste": "balanced",
+    "notes": "Great shot with nice crema and balanced flavor",
+    "timestamp": 1692123456
+  }
+}
+```
+
+### Save Shot Notes
+**Request Type:** `req:history:notes:save`
+
+**Request:**
+```json
+{
+  "tp": "req:history:notes:save",
+  "id": "000001",
+  "rid": "unique-request-id",
+  "notes": {
+    "id": "000001",
+    "rating": 4,
+    "doseIn": 18.5,
+    "doseOut": 37.2,
+    "ratio": 2.01,
+    "grindSetting": "2.5",
+    "balanceTaste": "balanced",
+    "notes": "Great shot with nice crema and balanced flavor"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "tp": "res:history:notes:save",
+  "rid": "unique-request-id",
+  "msg": "Ok"
+}
+```
+
+## File Structure
+
+For each shot ID (e.g., "000001"), two files are created:
+- `/h/000001.dat` - Contains shot history data (existing)
+- `/h/000001.json` - Contains shot notes data (new)
+
+## Frontend Implementation
+
+The new `ShotNotesCard` component provides:
+- Star rating system (1-5 stars)
+- Dose in/out fields with automatic ratio calculation
+- Grind setting input
+- Balance/taste selector (bitter, balanced, sour)
+- Free-form notes text area
+- Edit/save functionality
+
+The dose out field is automatically pre-populated with the final volume measurement from the shot data.
+
+### Enhanced Export Functionality
+
+The shot history export has been enhanced to automatically include notes data:
+- Export filename: `{shot-id}-complete.json`
+- Contains both shot history data and notes data in a single JSON file
+- Notes are automatically included if they exist for the shot
+- Maintains backward compatibility - shots without notes export normally
+
+### Export Data Structure
+
+```json
+{
+  "id": "000001",
+  "version": "1",
+  "profile": "Profile Name",
+  "timestamp": 1692123456,
+  "duration": 30000,
+  "volume": 37.2,
+  "samples": [...],
+  "notes": {
+    "id": "000001",
+    "rating": 4,
+    "doseIn": 18.5,
+    "doseOut": 37.2,
+    "ratio": 2.01,
+    "grindSetting": "2.5",
+    "balanceTaste": "balanced",
+    "notes": "Great shot with nice crema and balanced flavor",
+    "timestamp": 1692123456
+  }
+}
+```
+
+## Schema
+
+The shot notes follow the schema defined in `/schema/shot_notes.json`:
+- `id`: Shot ID (required)
+- `rating`: Star rating 0-5
+- `doseIn`: Input dose in grams
+- `doseOut`: Output dose in grams
+- `ratio`: Calculated ratio (doseOut/doseIn)
+- `grindSetting`: String description of grind setting
+- `balanceTaste`: One of "bitter", "balanced", "sour"
+- `notes`: Free-form text notes
+- `timestamp`: When notes were last updated

--- a/schema/shot_notes.json
+++ b/schema/shot_notes.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Shot Notes Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "description": "Shot ID matching the .dat file",
+      "type": "string"
+    },
+    "rating": {
+      "description": "Star rating out of 5",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "doseIn": {
+      "description": "Dose in grams",
+      "type": "number",
+      "minimum": 0
+    },
+    "doseOut": {
+      "description": "Dose out in grams",
+      "type": "number",
+      "minimum": 0
+    },
+    "ratio": {
+      "description": "Ratio (dose out / dose in)",
+      "type": "number",
+      "minimum": 0
+    },
+    "grindSetting": {
+      "description": "Grind setting as string",
+      "type": "string"
+    },
+    "balanceTaste": {
+      "description": "Balance/taste selector",
+      "type": "string",
+      "enum": ["bitter", "balanced", "sour"]
+    },
+    "notes": {
+      "description": "User notes",
+      "type": "string"
+    },
+    "timestamp": {
+      "description": "Timestamp when notes were last updated",
+      "type": "integer"
+    }
+  },
+  "required": ["id"]
+}

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -163,12 +163,12 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
             response["error"] = "not found";
         }
     } else if (type == "req:history:delete") {
-        String id = request["id"].as<String>();
+        auto id = request["id"].as<String>();
         SPIFFS.remove("/h/" + id + ".dat");
         SPIFFS.remove("/h/" + id + ".json"); // Also remove notes file if it exists
         response["msg"] = "Ok";
     } else if (type == "req:history:notes:get") {
-        String id = request["id"].as<String>();
+        auto id = request["id"].as<String>();
         JsonDocument notes;
         loadNotes(id, notes);
         response["notes"] = notes;

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -173,10 +173,11 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         loadNotes(id, notes);
         response["notes"] = notes;
     } else if (type == "req:history:notes:save") {
-        String id = request["id"].as<String>();
-        SPIFFS.remove("/h/" + id + ".dat");
-        SPIFFS.remove("/h/" + id + ".json"); // Also remove notes file if it exists
-        response["msg"] = "Ok";
+        const String id = request["id"].as<String>();
+        const JsonDocument& notesDoc = request["notes"];
+        
+        saveNotes(id, notesDoc);
+
     } 
 }
 

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -67,6 +67,7 @@ void ShotHistoryPlugin::record() {
         unsigned long duration = millis() - shotStart;
         if (duration <= 7500) { // Exclude failed shots and flushes
             SPIFFS.remove("/h/" + currentId + ".dat");
+            SPIFFS.remove("/h/" + currentId + ".json"); // Also remove notes file if it exists
         } else {
             controller->getSettings().setHistoryIndex(controller->getSettings().getHistoryIndex() + 1);
             cleanupHistory();

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -176,18 +176,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         SPIFFS.remove("/h/" + id + ".dat");
         SPIFFS.remove("/h/" + id + ".json"); // Also remove notes file if it exists
         response["msg"] = "Ok";
-    } else if (type == "req:history:notes:get") {
-        String id = request["id"].as<String>();
-        JsonDocument notes;
-        loadNotes(id, notes);
-        response["notes"] = notes;
-    } else if (type == "req:history:notes:save") {
-        String id = request["id"].as<String>();
-        JsonDocument notes = request["notes"];
-        notes["timestamp"] = getTime();
-        saveNotes(id, notes);
-        response["msg"] = "Ok";
-    }
+    } 
 }
 
 void ShotHistoryPlugin::saveNotes(const String &id, const JsonDocument &notes) {

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -130,8 +130,16 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
                     auto name = String(file.name());
                     int start = name.lastIndexOf('/') + 1;
                     int end = name.lastIndexOf('.');
-                    o["id"] = name.substring(start, end);
+                    String id = name.substring(start, end);
+                    o["id"] = id;
                     o["history"] = file.readString();
+                    
+                    // Also include notes if they exist
+                    JsonDocument notes;
+                    loadNotes(id, notes);
+                    if (!notes.isNull() && notes.size() > 0) {
+                        o["notes"] = notes;
+                    }
                 }
                 file = root.openNextFile();
             }
@@ -143,13 +151,61 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
             String data = file.readString();
             response["history"] = data;
             file.close();
+            
+            // Also include notes if they exist
+            JsonDocument notes;
+            loadNotes(id, notes);
+            if (!notes.isNull() && notes.size() > 0) {
+                response["notes"] = notes;
+            }
         } else {
             response["error"] = "not found";
         }
     } else if (type == "req:history:delete") {
-        auto id = request["id"].as<String>();
+        String id = request["id"].as<String>();
         SPIFFS.remove("/h/" + id + ".dat");
+        SPIFFS.remove("/h/" + id + ".json"); // Also remove notes file if it exists
         response["msg"] = "Ok";
+    } else if (type == "req:history:notes:get") {
+        String id = request["id"].as<String>();
+        JsonDocument notes;
+        loadNotes(id, notes);
+        response["notes"] = notes;
+    } else if (type == "req:history:notes:save") {
+        String id = request["id"].as<String>();
+        SPIFFS.remove("/h/" + id + ".dat");
+        SPIFFS.remove("/h/" + id + ".json"); // Also remove notes file if it exists
+        response["msg"] = "Ok";
+    } else if (type == "req:history:notes:get") {
+        String id = request["id"].as<String>();
+        JsonDocument notes;
+        loadNotes(id, notes);
+        response["notes"] = notes;
+    } else if (type == "req:history:notes:save") {
+        String id = request["id"].as<String>();
+        JsonDocument notes = request["notes"];
+        notes["timestamp"] = getTime();
+        saveNotes(id, notes);
+        response["msg"] = "Ok";
+    }
+}
+
+void ShotHistoryPlugin::saveNotes(const String &id, const JsonDocument &notes) {
+    File file = SPIFFS.open("/h/" + id + ".json", FILE_WRITE);
+    if (file) {
+        String notesStr;
+        serializeJson(notes, notesStr);
+        file.print(notesStr);
+        file.close();
+    }
+}
+
+void ShotHistoryPlugin::loadNotes(const String &id, JsonDocument &notes) {
+    File file = SPIFFS.open("/h/" + id + ".json", "r");
+    if (file) {
+        String notesStr = file.readString();
+        file.close();
+        deserializeJson(notes, notesStr);
     }
 }
 

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -21,6 +21,8 @@ class ShotHistoryPlugin : public Plugin {
     void handleRequest(JsonDocument &request, JsonDocument &response);
 
   private:
+    void saveNotes(const String &id, const JsonDocument &notes);
+    void loadNotes(const String &id, JsonDocument &notes);
     struct ShotSample {
         unsigned long t;
         float tt;

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -7,6 +7,7 @@ import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import ShotNotesCard from './ShotNotesCard.jsx';
 
 export default function HistoryCard({ shot, onDelete }) {
   const date = new Date(shot.timestamp * 1000);
@@ -56,6 +57,7 @@ export default function HistoryCard({ shot, onDelete }) {
       <div>
         <HistoryChart shot={shot} />
       </div>
+      <ShotNotesCard shot={shot} />
     </Card>
   );
 }

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -8,12 +8,22 @@ import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import ShotNotesCard from './ShotNotesCard.jsx';
+import { useState } from 'preact/hooks';
 
 export default function HistoryCard({ shot, onDelete }) {
+  const [shotNotes, setShotNotes] = useState(null);
   const date = new Date(shot.timestamp * 1000);
   const onExport = useCallback(() => {
-    downloadJson(shot, 'shot-' + shot.id + '.json');
-  });
+    const exportData = {
+      ...shot,
+      notes: shotNotes
+    };
+    downloadJson(exportData, 'shot-' + shot.id + '.json');
+  }, [shot, shotNotes]);
+
+  const handleNotesLoaded = useCallback((notes) => {
+    setShotNotes(notes);
+  }, []);
   return (
     <Card sm={12}>
       <div className='flex flex-row'>
@@ -57,7 +67,10 @@ export default function HistoryCard({ shot, onDelete }) {
       <div>
         <HistoryChart shot={shot} />
       </div>
-      <ShotNotesCard shot={shot} />
+      <ShotNotesCard 
+        shot={shot} 
+        onNotesLoaded={handleNotesLoaded}
+      />
     </Card>
   );
 }

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -24,6 +24,10 @@ export default function HistoryCard({ shot, onDelete }) {
   const handleNotesLoaded = useCallback((notes) => {
     setShotNotes(notes);
   }, []);
+
+  const handleNotesUpdate = useCallback((notes) => {
+    setShotNotes(notes);
+  }, []);
   return (
     <Card sm={12}>
       <div className='flex flex-row'>
@@ -70,6 +74,7 @@ export default function HistoryCard({ shot, onDelete }) {
       <ShotNotesCard 
         shot={shot} 
         onNotesLoaded={handleNotesLoaded}
+        onNotesUpdate={handleNotesUpdate}
       />
     </Card>
   );

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext, useCallback } from 'preact/hooks';
 import { ApiServiceContext } from '../../services/ApiService.js';
 
-export default function ShotNotesCard({ shot, onNotesUpdate }) {
+export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
   const apiService = useContext(ApiServiceContext);
   
   const [notes, setNotes] = useState({

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useContext } from 'preact/hooks';
+import { ApiServiceContext } from '../../services/ApiService.js';
+
+export default function ShotNotesCard({ shot, onNotesUpdate }) {
+  const apiService = useContext(ApiServiceContext);
+  
+  const [notes, setNotes] = useState({
+    id: shot.id,
+    rating: 0,
+    doseIn: '',
+    doseOut: '',
+    ratio: '',
+    grindSetting: '',
+    balanceTaste: 'balanced',
+    notes: '',
+  });
+  
+  const [loading, setLoading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Calculate ratio when doseIn or doseOut changes
+  useEffect(() => {
+    if (notes.doseIn && notes.doseOut) {
+      const ratio = (parseFloat(notes.doseOut) / parseFloat(notes.doseIn)).toFixed(2);
+      setNotes(prev => ({ ...prev, ratio }));
+    }
+  }, [notes.doseIn, notes.doseOut]);
+
+  // Load notes on component mount
+  useEffect(() => {
+    const loadNotes = async () => {
+      try {
+        const response = await apiService.request({ 
+          tp: 'req:history:notes:get', 
+          id: shot.id 
+        });
+        if (response.notes && Object.keys(response.notes).length > 0) {
+          // Load existing notes, but if doseOut is empty and shot.volume exists, use shot.volume
+          const loadedNotes = { ...response.notes };
+          if (!loadedNotes.doseOut && shot.volume) {
+            loadedNotes.doseOut = shot.volume.toFixed(1);
+          }
+          setNotes(prev => ({ ...prev, ...loadedNotes }));
+        } else {
+          // No existing notes, pre-populate doseOut with shot.volume if available
+          if (shot.volume) {
+            setNotes(prev => ({ ...prev, doseOut: shot.volume.toFixed(1) }));
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load notes:', error);
+        // Even if loading fails, pre-populate doseOut with shot.volume if available
+        if (shot.volume) {
+          setNotes(prev => ({ ...prev, doseOut: shot.volume.toFixed(1) }));
+        }
+      }
+    };
+    loadNotes();
+  }, [shot.id, shot.volume, apiService]);
+
+  const saveNotes = async () => {
+    setLoading(true);
+    try {
+      await apiService.request({
+        tp: 'req:history:notes:save',
+        id: shot.id,
+        notes: notes
+      });
+      setIsEditing(false);
+      if (onNotesUpdate) {
+        onNotesUpdate(notes);
+      }
+    } catch (error) {
+      console.error('Failed to save notes:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInputChange = (field, value) => {
+    setNotes(prev => ({ ...prev, [field]: value }));
+  };
+
+  const renderStars = (rating, editable = false) => {
+    const stars = [];
+    for (let i = 1; i <= 5; i++) {
+      stars.push(
+        <button
+          key={i}
+          type="button"
+          disabled={!editable}
+          onClick={() => editable && handleInputChange('rating', i)}
+          className={`text-lg ${i <= rating ? 'text-yellow-400' : 'text-gray-300'} ${
+            editable ? 'hover:text-yellow-300 cursor-pointer' : 'cursor-default'
+          }`}
+        >
+          ★
+        </button>
+      );
+    }
+    return stars;
+  };
+
+  const getTasteColor = (taste) => {
+    switch (taste) {
+      case 'bitter': return 'text-orange-600';
+      case 'sour': return 'text-yellow-600';
+      case 'balanced': return 'text-green-600';
+      default: return '';
+    }
+  };
+
+  return (
+    <div className="mt-6 border-t pt-6">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-semibold">Shot Notes</h3>
+        {!isEditing ? (
+          <button
+            onClick={() => setIsEditing(true)}
+            className="btn btn-sm btn-outline"
+          >
+            <span className="fa fa-edit mr-1"></span>
+            Edit
+          </button>
+        ) : (
+          <div className="flex gap-2">
+            <button
+              onClick={() => setIsEditing(false)}
+              className="btn btn-sm btn-ghost"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={saveNotes}
+              className="btn btn-sm btn-primary"
+              disabled={loading}
+            >
+              {loading ? (
+                <span className="loading loading-spinner loading-xs"></span>
+              ) : (
+                <>
+                  <span className="fa fa-save mr-1"></span>
+                  Save
+                </>
+              )}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Rating */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Rating
+          </label>
+          <div className="flex gap-1">
+            {renderStars(notes.rating, isEditing)}
+          </div>
+        </div>
+
+        {/* Dose In */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Dose In (g)
+          </label>
+          {isEditing ? (
+            <input
+              type="number"
+              step="0.1"
+              className="input input-bordered w-full"
+              value={notes.doseIn}
+              onChange={(e) => handleInputChange('doseIn', e.target.value)}
+              placeholder="18.0"
+            />
+          ) : (
+            <div className="input input-bordered w-full bg-base-200 cursor-default">
+              {notes.doseIn || '—'}
+            </div>
+          )}
+        </div>
+
+        {/* Dose Out */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Dose Out (g)
+          </label>
+          {isEditing ? (
+            <input
+              type="number"
+              step="0.1"
+              className="input input-bordered w-full"
+              value={notes.doseOut}
+              onChange={(e) => handleInputChange('doseOut', e.target.value)}
+              placeholder="36.0"
+            />
+          ) : (
+            <div className="input input-bordered w-full bg-base-200 cursor-default">
+              {notes.doseOut || '—'}
+            </div>
+          )}
+        </div>
+
+        {/* Ratio */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Ratio (1:{notes.ratio || '—'})
+          </label>
+          <div className="input input-bordered w-full bg-base-200 cursor-default">
+            {notes.ratio ? `1:${notes.ratio}` : '—'}
+          </div>
+        </div>
+
+        {/* Grind Setting */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Grind Setting
+          </label>
+          {isEditing ? (
+            <input
+              type="text"
+              className="input input-bordered w-full"
+              value={notes.grindSetting}
+              onChange={(e) => handleInputChange('grindSetting', e.target.value)}
+              placeholder="e.g., 2.5, Medium-Fine"
+            />
+          ) : (
+            <div className="input input-bordered w-full bg-base-200 cursor-default">
+              {notes.grindSetting || '—'}
+            </div>
+          )}
+        </div>
+
+        {/* Balance/Taste */}
+        <div className="form-control">
+          <label className="mb-2 block text-sm font-medium">
+            Balance/Taste
+          </label>
+          {isEditing ? (
+            <select
+              className="select select-bordered w-full"
+              value={notes.balanceTaste}
+              onChange={(e) => handleInputChange('balanceTaste', e.target.value)}
+            >
+              <option value="bitter">Bitter</option>
+              <option value="balanced">Balanced</option>
+              <option value="sour">Sour</option>
+            </select>
+          ) : (
+            <div className={`input input-bordered w-full bg-base-200 cursor-default capitalize ${getTasteColor(notes.balanceTaste)}`}>
+              {notes.balanceTaste}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Notes Text Area - Full Width */}
+      <div className="form-control mt-6">
+        <label className="mb-2 block text-sm font-medium">
+          Notes
+        </label>
+        {isEditing ? (
+          <textarea
+            className="textarea textarea-bordered w-full"
+            rows="4"
+            value={notes.notes}
+            onChange={(e) => handleInputChange('notes', e.target.value)}
+            placeholder="Tasting notes, brewing observations, etc..."
+          />
+        ) : (
+          <div className="textarea textarea-bordered w-full bg-base-200 cursor-default min-h-[6rem]">
+            {notes.notes || 'No notes added'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -77,6 +77,10 @@ export default function ShotNotesCard({ shot, onNotesUpdate }) {
         
         setNotes(loadedNotes);
         setInitialLoaded(true);
+        // Pass loaded notes to parent
+        if (onNotesLoaded) {
+          onNotesLoaded(loadedNotes);
+        }
       } catch (error) {
         console.error('Failed to load notes:', error);
         
@@ -94,6 +98,9 @@ export default function ShotNotesCard({ shot, onNotesUpdate }) {
         
         setNotes(defaultNotes);
         setInitialLoaded(true);
+        if (onNotesLoaded) {
+          onNotesLoaded(defaultNotes);
+        }        
       }
     };
     

--- a/web/src/pages/ShotHistory/utils.js
+++ b/web/src/pages/ShotHistory/utils.js
@@ -34,5 +34,10 @@ export function parseHistoryData(shot) {
     data.duration = lastSample.t;
     data.volume = lastSample.v;
   }
+  
+  if (shot.notes) {
+    data.notes = shot.notes;
+  }
+  
   return data;
 }


### PR DESCRIPTION
Adds editable notes to the shot history feature, allowing users to add and view notes for each shot. The notes are stored in a JSON file alongside the shot history data and can be edited through a new UI component.
The local export function also includes the notes in the exported JSON file.

<img width="1855" height="1582" alt="image" src="https://github.com/user-attachments/assets/da7ee230-26c7-47b4-b157-84e83fa33846" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Shot Notes UI: rate shots (1–5), enter dose in/out with auto ratio, grind setting, taste selector, and freeform notes; edit/save flow with doseOut pre-filled from final volume.
  - History list & detail now include per-shot notes; new endpoints to retrieve and save notes per shot.
  - Exports optionally produce “{shot-id}-complete.json” bundling history + notes (backward compatible).

- Bug Fixes
  - Notes removed for very short/invalid shots; deleting a shot clears both history and notes.

- Documentation
  - Added Shot Notes API docs and JSON Schema for note validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->