### PR TITLE
Add Flush to WebUI

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -194,6 +194,8 @@ void WebUIPlugin::setupServer() {
                                 String msg;
                                 serializeJson(resp, msg);
                                 ws.text(client->id(), msg);
+                            } else if (msgType == "req:flush:start") {
+                                handleFlushStart(client->id(), doc);
                             }
                         }
                     }
@@ -527,4 +529,17 @@ void WebUIPlugin::sendAutotuneResult() {
     doc["pid"] = controller->getSettings().getPid();
     String message = doc.as<String>();
     ws.textAll(message);
+}
+
+void WebUIPlugin::handleFlushStart(uint32_t clientId, JsonDocument &request) {
+    controller->onFlush();
+
+    JsonDocument response;
+    response["tp"] = "res:flush:start";
+    response["rid"] = request["rid"];
+    response["success"] = true;
+
+    String msg;
+    serializeJson(response, msg);
+    ws.text(clientId, msg);
 }

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -39,6 +39,7 @@ class WebUIPlugin : public Plugin {
     void handleOTAStart(uint32_t clientId, JsonDocument &request);
     void handleAutotuneStart(uint32_t clientId, JsonDocument &request);
     void handleProfileRequest(uint32_t clientId, JsonDocument &request);
+    void handleFlushStart(uint32_t clientId, JsonDocument &request);
 
     // HTTP handlers
     void handleSettings(AsyncWebServerRequest *request) const;

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -14,11 +14,10 @@ function formatDuration(duration) {
 }
 
 const BrewProgress = props => {
-  const { processInfo } = props;
+  const { processInfo, isFlushing } = props;
   const active = !!processInfo.a;
   const progress = (processInfo.pp / processInfo.pt) * 100.0;
   const elapsed = Math.floor(processInfo.e / 1000);
-  const isFlushing = processInfo.l === 'Flush';
 
   return (
     <div className='flex w-full flex-col items-center justify-center space-y-4 px-4'>
@@ -195,7 +194,7 @@ const ProcessControls = props => {
       {shouldExpand && (
         <>
           <div className='flex flex-1 items-center justify-center'>
-            {(active || finished) && brew && <BrewProgress processInfo={processInfo} />}
+            {(active || finished) && brew && <BrewProgress processInfo={processInfo} isFlushing={isFlushing} />}
             {!brew && (
               <div className='space-y-2 text-center'>
                 <div className='text-xl font-bold sm:text-2xl'>

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -14,7 +14,7 @@ function formatDuration(duration) {
 }
 
 const BrewProgress = props => {
-  const { processInfo, isFlushing } = props;
+  const { processInfo } = props;
   const active = !!processInfo.a;
   const progress = (processInfo.pp / processInfo.pt) * 100.0;
   const elapsed = Math.floor(processInfo.e / 1000);
@@ -50,7 +50,7 @@ const BrewProgress = props => {
           </div>
         </>
       )}
-      {!active && !isFlushing && (
+      {!active && (
         <div className='space-y-2 text-center'>
           <div className='text-base-content text-xl font-bold sm:text-2xl'>Finished</div>
           <div className='text-base-content text-2xl font-bold sm:text-3xl'>
@@ -194,7 +194,7 @@ const ProcessControls = props => {
       {shouldExpand && (
         <>
           <div className='flex flex-1 items-center justify-center'>
-            {(active || finished) && brew && <BrewProgress processInfo={processInfo} isFlushing={isFlushing} />}
+            {(active || finished) && brew && <BrewProgress processInfo={processInfo} />}
             {!brew && (
               <div className='space-y-2 text-center'>
                 <div className='text-xl font-bold sm:text-2xl'>
@@ -258,18 +258,19 @@ const ProcessControls = props => {
           </div>
         )}
         {(mode === 1 || mode === 3) && (
-          <div className='flex items-center gap-4'>
+          <div className='flex flex-col items-center gap-4 space-y-4'>
             <button className='btn btn-circle btn-lg btn-primary' onClick={handleButtonClick}>
               <i className={`text-2xl ${getButtonIcon()}`} />
             </button>
-
-            {brew && !isFlushing && (
-              <button
-                className='btn btn-circle btn-lg btn-secondary'
+            
+            {brew && !active && !finished && (
+              <button 
+                className='btn rounded-full text-base-content/60 hover:text-base-content transition-color duration-200 text-sm'
                 onClick={startFlush}
                 title="Click to flush water"
               >
-                <i className='fa-solid fa-tint text-2xl' />
+                <i className='fa-solid fa-tint' />
+                Flush
               </button>
             )}
           </div>


### PR DESCRIPTION
Add Flush functionality to WebUI

This is the brew tab

<img width="1612" height="805" alt="image" src="https://github.com/user-attachments/assets/04755108-ebcd-400e-9d6b-ae76de1715c9" />

When flush button is clicked it looks like this:

<img width="1318" height="608" alt="image" src="https://github.com/user-attachments/assets/1489917e-4583-4902-a8e1-48e0982b9f64" />

When the flush is stopped, it returns to initial screen without a need for pushing pause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secondary "Flush" button (droplet icon, tooltip) in Brew/Water modes to start a water flush and receive a per-client acknowledgment.

* **UI Improvements**
  * Primary action and Flush button are now stacked vertically in the primary action area when applicable.
  * Flushing state is visibly tracked to prevent accidental interactions.

* **Bug Fixes**
  * “Finished” status no longer appears while a flush is active; flush-related errors reset the state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->