### PR TITLE
Add static ip support to settings

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -153,6 +153,29 @@ void Controller::setupInfos() {
 void Controller::setupWifi() {
     if (settings.getWifiSsid() != "" && settings.getWifiPassword() != "") {
         WiFi.mode(WIFI_STA);
+        
+        // Configure static IP if enabled
+        if (settings.isStaticIpEnabled() && !settings.getStaticIp().isEmpty()) {
+            IPAddress ip, netmask, gateway, dns;
+            
+            if (ip.fromString(settings.getStaticIp()) && 
+                netmask.fromString(settings.getStaticNetmask()) && 
+                gateway.fromString(settings.getStaticGateway())) {
+                
+                if (settings.getStaticDns().isEmpty() || !dns.fromString(settings.getStaticDns())) {
+                    dns = gateway; // Use gateway as DNS if no DNS specified
+                }
+                
+                ESP_LOGI(LOG_TAG, "Configuring static IP: %s", settings.getStaticIp().c_str());
+                WiFi.config(ip, gateway, netmask, dns);
+            } else {
+                ESP_LOGE(LOG_TAG, "Invalid static IP configuration, using DHCP");
+            }
+        } else {
+            // Reset to DHCP
+            WiFi.config(0U, 0U, 0U);
+        }
+        
         WiFi.begin(settings.getWifiSsid(), settings.getWifiPassword());
         WiFi.setTxPower(WIFI_POWER_19_5dBm);
         WiFi.setAutoReconnect(true);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -21,6 +21,11 @@ Settings::Settings() {
     pumpModelCoeffs = preferences.getString("pmc", DEFAULT_PUMP_MODEL_COEFFS);
     wifiSsid = preferences.getString("ws", "");
     wifiPassword = preferences.getString("wp", "");
+    staticIpEnabled = preferences.getBool("si_e", false);
+    staticIp = preferences.getString("si_ip", "");
+    staticNetmask = preferences.getString("si_nm", "255.255.255.0");
+    staticGateway = preferences.getString("si_gw", "");
+    staticDns = preferences.getString("si_dns", "");
     mdnsName = preferences.getString("mn", DEFAULT_MDNS_NAME);
     homekit = preferences.getBool("hk", false);
     volumetricTarget = preferences.getBool("vt", false);
@@ -187,6 +192,31 @@ void Settings::setWifiSsid(const String &wifiSsid) {
 
 void Settings::setWifiPassword(const String &wifiPassword) {
     this->wifiPassword = wifiPassword;
+    save();
+}
+
+void Settings::setStaticIpEnabled(bool staticIpEnabled) {
+    this->staticIpEnabled = staticIpEnabled;
+    save();
+}
+
+void Settings::setStaticIp(const String &staticIp) {
+    this->staticIp = staticIp;
+    save();
+}
+
+void Settings::setStaticNetmask(const String &staticNetmask) {
+    this->staticNetmask = staticNetmask;
+    save();
+}
+
+void Settings::setStaticGateway(const String &staticGateway) {
+    this->staticGateway = staticGateway;
+    save();
+}
+
+void Settings::setStaticDns(const String &staticDns) {
+    this->staticDns = staticDns;
     save();
 }
 
@@ -403,6 +433,11 @@ void Settings::doSave() {
     preferences.putString("pmc", pumpModelCoeffs);
     preferences.putString("ws", wifiSsid);
     preferences.putString("wp", wifiPassword);
+    preferences.putBool("si_e", staticIpEnabled);
+    preferences.putString("si_ip", staticIp);
+    preferences.putString("si_nm", staticNetmask);
+    preferences.putString("si_gw", staticGateway);
+    preferences.putString("si_dns", staticDns);
     preferences.putString("mn", mdnsName);
     preferences.putBool("hk", homekit);
     preferences.putBool("vt", volumetricTarget);

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -41,6 +41,11 @@ class Settings {
     String getPumpModelCoeffs() const { return pumpModelCoeffs; }
     String getWifiSsid() const { return wifiSsid; }
     String getWifiPassword() const { return wifiPassword; }
+    bool isStaticIpEnabled() const { return staticIpEnabled; }
+    String getStaticIp() const { return staticIp; }
+    String getStaticNetmask() const { return staticNetmask; }
+    String getStaticGateway() const { return staticGateway; }
+    String getStaticDns() const { return staticDns; }
     String getMdnsName() const { return mdnsName; }
     bool isHomekit() const { return homekit; }
     bool isVolumetricTarget() const { return volumetricTarget; }
@@ -98,6 +103,11 @@ class Settings {
     void setPumpModelCoeffs(const String &pumpModelCoeffs);
     void setWifiSsid(const String &wifiSsid);
     void setWifiPassword(const String &wifiPassword);
+    void setStaticIpEnabled(bool staticIpEnabled);
+    void setStaticIp(const String &staticIp);
+    void setStaticNetmask(const String &staticNetmask);
+    void setStaticGateway(const String &staticGateway);
+    void setStaticDns(const String &staticDns);
     void setMdnsName(const String &mdnsName);
     void setHomekit(bool homekit);
     void setVolumetricTarget(bool volumetric_target);
@@ -158,6 +168,11 @@ class Settings {
     String pumpModelCoeffs = DEFAULT_PUMP_MODEL_COEFFS;
     String wifiSsid = "";
     String wifiPassword = "";
+    bool staticIpEnabled = false;
+    String staticIp = "";
+    String staticNetmask = "255.255.255.0";
+    String staticGateway = "";
+    String staticDns = "";
     String mdnsName = DEFAULT_MDNS_NAME;
     String savedScale = "";
     bool homekit = false;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -333,6 +333,15 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setMdnsName(request->arg("mdnsName"));
             if (request->hasArg("wifiPassword") && request->arg("wifiPassword") != "---unchanged---")
                 settings->setWifiPassword(request->arg("wifiPassword"));
+            settings->setStaticIpEnabled(request->hasArg("staticIpEnabled"));
+            if (request->hasArg("staticIp"))
+                settings->setStaticIp(request->arg("staticIp"));
+            if (request->hasArg("staticNetmask"))
+                settings->setStaticNetmask(request->arg("staticNetmask"));
+            if (request->hasArg("staticGateway"))
+                settings->setStaticGateway(request->arg("staticGateway"));
+            if (request->hasArg("staticDns"))
+                settings->setStaticDns(request->arg("staticDns"));
             settings->setHomekit(request->hasArg("homekit"));
             settings->setBoilerFillActive(request->hasArg("boilerFillActive"));
             if (request->hasArg("startupFillTime"))
@@ -410,6 +419,11 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["pumpModelCoeffs"] = settings.getPumpModelCoeffs();
     doc["wifiSsid"] = settings.getWifiSsid();
     doc["wifiPassword"] = apMode ? "---unchanged---" : settings.getWifiPassword();
+    doc["staticIpEnabled"] = settings.isStaticIpEnabled();
+    doc["staticIp"] = settings.getStaticIp();
+    doc["staticNetmask"] = settings.getStaticNetmask();
+    doc["staticGateway"] = settings.getStaticGateway();
+    doc["staticDns"] = settings.getStaticDns();
     doc["mdnsName"] = settings.getMdnsName();
     doc["temperatureOffset"] = String(settings.getTemperatureOffset());
     doc["pressureScaling"] = String(settings.getPressureScaling());

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -87,6 +87,9 @@ export function Settings() {
         setFormData(newFormData);
         return;
       }
+      if (key === 'staticIpEnabled') {
+        value = !formData.staticIpEnabled;
+      }
       if (key === 'dashboardLayout') {
         setDashboardLayout(value);
       }
@@ -403,6 +406,88 @@ export function Settings() {
                 value={formData.wifiPassword}
                 onChange={onChange('wifiPassword')}
               />
+            </div>
+
+            <div className='divider'>Network Configuration</div>
+            <div className='form-control'>
+              <label className='label cursor-pointer'>
+                <span className='label-text'>Use Static IP</span>
+                <input
+                  id='staticIpEnabled'
+                  name='staticIpEnabled'
+                  value='staticIpEnabled'
+                  type='checkbox'
+                  className='toggle toggle-primary'
+                  checked={!!formData.staticIpEnabled}
+                  onChange={onChange('staticIpEnabled')}
+                />
+              </label>
+            </div>
+
+            <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+              <div className='form-control'>
+                <label htmlFor='staticIp' className='mb-2 block text-sm font-medium'>
+                  Static IP Address
+                </label>
+                <input
+                  id='staticIp'
+                  name='staticIp'
+                  type='text'
+                  className='input input-bordered w-full'
+                  placeholder='192.168.1.100'
+                  value={formData.staticIp}
+                  onChange={onChange('staticIp')}
+                  disabled={!formData.staticIpEnabled}
+                />
+              </div>
+              <div className='form-control'>
+                <label htmlFor='staticNetmask' className='mb-2 block text-sm font-medium'>
+                  Subnet Mask
+                </label>
+                <input
+                  id='staticNetmask'
+                  name='staticNetmask'
+                  type='text'
+                  className='input input-bordered w-full'
+                  placeholder='255.255.255.0'
+                  value={formData.staticNetmask}
+                  onChange={onChange('staticNetmask')}
+                  disabled={!formData.staticIpEnabled}
+                />
+              </div>
+            </div>
+
+            <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+              <div className='form-control'>
+                <label htmlFor='staticGateway' className='mb-2 block text-sm font-medium'>
+                  Gateway
+                </label>
+                <input
+                  id='staticGateway'
+                  name='staticGateway'
+                  type='text'
+                  className='input input-bordered w-full'
+                  placeholder='192.168.1.1'
+                  value={formData.staticGateway}
+                  onChange={onChange('staticGateway')}
+                  disabled={!formData.staticIpEnabled}
+                />
+              </div>
+              <div className='form-control'>
+                <label htmlFor='staticDns' className='mb-2 block text-sm font-medium'>
+                  DNS Server
+                </label>
+                <input
+                  id='staticDns'
+                  name='staticDns'
+                  type='text'
+                  className='input input-bordered w-full'
+                  placeholder='8.8.8.8'
+                  value={formData.staticDns}
+                  onChange={onChange('staticDns')}
+                  disabled={!formData.staticIpEnabled}
+                />
+              </div>
             </div>
 
             <div className='form-control'>


### PR DESCRIPTION
This PR adds new settings for static IP address. This is particularly useful for setups where the router does not support static IPs and mDNS does not work. This allows me to define a hardcoded hostname and ensure that Gaggimate's IP stays the same.

I tested this settings by manually flashing the firmware on the controller and the display:
- I verified that "Gaggimate" AP works as expected. 
- Once the wifi configuration is setup, I verified that both DHCP and static IP work as expected.
- Export settings option correctly includes static IP configurations.

<img width="350" src="https://github.com/user-attachments/assets/20e5086f-2ee3-414f-bcac-24f6b3da6d37" />
<img width="350" src="https://github.com/user-attachments/assets/af0c928c-b35c-4d17-a82c-ff5918866aff" />
