### PR TITLE
Use alert warning consistently

### DIFF
--- a/web/src/pages/Autotune/index.jsx
+++ b/web/src/pages/Autotune/index.jsx
@@ -48,7 +48,7 @@ export function Autotune() {
                   <Spinner size={8} />
                   <span className='text-lg font-medium'>Autotune in Progress</span>
                 </div>
-                <div className='alert alert-info max-w-md'>
+                <div className='alert alert-warning max-w-md'>
                   <span>
                     Please wait while the system optimizes your PID settings. This may take up to 30
                     seconds.

--- a/web/src/pages/Scales/index.jsx
+++ b/web/src/pages/Scales/index.jsx
@@ -140,7 +140,7 @@ export function Scales() {
 
       {scaleData.length > 0 && (
         <div className='space-y-4 lg:col-span-12'>
-          <div className='alert alert-info'>
+          <div className='alert alert-warning'>
             <span>
               Scales are automatically refreshed every 10 seconds. Use the scan button to discover
               new devices.

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -767,7 +767,7 @@ export function Settings() {
         </div>
 
         <div className='pt-4 lg:col-span-10'>
-          <div className='alert alert-info'>
+          <div className='alert alert-warning'>
             <span>Some options like WiFi, NTP and managing Plugins require a restart.</span>
           </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated alert styling from “info” to “warning” on the Autotune progress notice to improve visual emphasis.
  * Switched bottom alerts on Scales and Settings pages from “info” to “warning” for consistent presentation.
  * These are visual-only changes; messages, behavior, and page structure remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->