### PR TITLE
Add move up/down functionality and persist profile order

### DIFF
--- a/docs/websocket-api.yaml
+++ b/docs/websocket-api.yaml
@@ -84,6 +84,29 @@ components:
           description: Indicates pressure capability
         cd:
           type: boolean
+          description: Persist a new ordering of profile IDs.
+          direction: client->server
+          payload:
+            type: object
+            required: [tp, order]
+            properties:
+              tp:
+                type: string
+                enum: ['req:profiles:reorder']
+              order:
+                type: array
+                description: Array of profile IDs in desired order (all known IDs).
+                items:
+                  type: string
+          response:
+            type: object
+            properties:
+              tp:
+                type: string
+                enum: ['res:profiles:reorder']
+              rid:
+                type: string
+              # No additional fields; success implied
           description: Indicates dimming capability
       required: [tp]
     OtaSettingsPayload:

--- a/docs/websocket-api.yaml
+++ b/docs/websocket-api.yaml
@@ -36,6 +36,7 @@ channels:
           - $ref: '#/components/messages/ProfilesSelectResponse'
           - $ref: '#/components/messages/ProfilesFavoriteResponse'
           - $ref: '#/components/messages/ProfilesUnfavoriteResponse'
+          - $ref: '#/components/messages/ProfilesReorderResponse'
     publish:
       description: Messages sent from the client to the server.
       message:
@@ -50,6 +51,7 @@ channels:
           - $ref: '#/components/messages/ProfilesSelectRequest'
           - $ref: '#/components/messages/ProfilesFavoriteRequest'
           - $ref: '#/components/messages/ProfilesUnfavoriteRequest'
+          - $ref: '#/components/messages/ProfilesReorderRequest'
 components:
   schemas:
     StatusPayload:
@@ -84,29 +86,6 @@ components:
           description: Indicates pressure capability
         cd:
           type: boolean
-          description: Persist a new ordering of profile IDs.
-          direction: client->server
-          payload:
-            type: object
-            required: [tp, order]
-            properties:
-              tp:
-                type: string
-                enum: ['req:profiles:reorder']
-              order:
-                type: array
-                description: Array of profile IDs in desired order (all known IDs).
-                items:
-                  type: string
-          response:
-            type: object
-            properties:
-              tp:
-                type: string
-                enum: ['res:profiles:reorder']
-              rid:
-                type: string
-              # No additional fields; success implied
           description: Indicates dimming capability
       required: [tp]
     OtaSettingsPayload:
@@ -375,3 +354,30 @@ components:
           id:
             type: string
         required: [tp, id]
+    ProfilesReorderRequest:
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['req:profiles:reorder']
+          rid:
+            type: string
+          order:
+            type: array
+            items:
+              type: string
+            description: Full ordered list of profile IDs.
+        required: [tp, order]
+
+    ProfilesReorderResponse:
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['res:profiles:reorder']
+          rid:
+            type: string
+          # No error field; success implied
+        required: [tp]

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -110,7 +110,8 @@ std::vector<String> ProfileManager::listProfiles() {
     std::vector<String> ordered;
     auto stored = _settings.getProfileOrder();
     for (auto const &id : stored) {
-        if (std::find(uuids.begin(), uuids.end(), id) != uuids.end()) {
+        if (std::find(uuids.begin(), uuids.end(), id) != uuids.end() &&
+            std::find(ordered.begin(), ordered.end(), id) == ordered.end()) {
             ordered.push_back(id);
         }
     }

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -106,7 +106,20 @@ std::vector<String> ProfileManager::listProfiles() {
         }
         file = root.openNextFile();
     }
-    return uuids;
+
+    std::vector<String> ordered;
+    auto stored = _settings.getProfileOrder();
+    for (auto const &id : stored) {
+        if (std::find(uuids.begin(), uuids.end(), id) != uuids.end()) {
+            ordered.push_back(id);
+        }
+    }
+    for (auto const &id : uuids) {
+        if (std::find(ordered.begin(), ordered.end(), id) == ordered.end()) {
+            ordered.push_back(id);
+        }
+    }
+    return ordered;
 }
 
 bool ProfileManager::loadProfile(const String &uuid, Profile &outProfile) {

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -1,6 +1,7 @@
 #include "Settings.h"
 
 #include <utility>
+#include <algorithm>
 
 Settings::Settings() {
     preferences.begin(PREFERENCES_KEY, true);
@@ -317,14 +318,17 @@ void Settings::removeFavoritedProfile(String profile) {
 
 void Settings::setProfileOrder(std::vector<String> profile_order) {
     std::vector<String> cleaned;
+    cleaned.reserve(profile_order.size());
     for (auto &id : profile_order) {
-        if (!id.isEmpty() &&
-            std::find(cleaned.begin(), cleaned.end(), id) == cleaned.end()) {
+        if (id.isEmpty()) continue;
+        if (std::find(cleaned.begin(), cleaned.end(), id) == cleaned.end()) {
             cleaned.emplace_back(std::move(id));
         }
     }
+
     profileOrder = std::move(cleaned);
     save();
+
 }
 
 void Settings::setMainBrightness(int main_brightness) {

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -316,7 +316,14 @@ void Settings::removeFavoritedProfile(String profile) {
 }
 
 void Settings::setProfileOrder(std::vector<String> profile_order) {
-    profileOrder = std::move(profile_order);
+    std::vector<String> cleaned;
+    for (auto &id : profile_order) {
+        if (!id.isEmpty() &&
+            std::find(cleaned.begin(), cleaned.end(), id) == cleaned.end()) {
+            cleaned.emplace_back(std::move(id));
+        }
+    }
+    profileOrder = std::move(cleaned);
     save();
 }
 

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -49,6 +49,7 @@ Settings::Settings() {
     selectedProfile = preferences.getString("sp", "");
     profilesMigrated = preferences.getBool("pm", false);
     favoritedProfiles = explode(preferences.getString("fp", ""), ',');
+    profileOrder = explode(preferences.getString("po", ""), ',');
     steamPumpPercentage = preferences.getFloat("spp", DEFAULT_STEAM_PUMP_PERCENTAGE);
     historyIndex = preferences.getInt("hi", 0);
 
@@ -314,6 +315,11 @@ void Settings::removeFavoritedProfile(String profile) {
     save();
 }
 
+void Settings::setProfileOrder(std::vector<String> profile_order) {
+    profileOrder = std::move(profile_order);
+    save();
+}
+
 void Settings::setMainBrightness(int main_brightness) {
     mainBrightness = main_brightness;
     save();
@@ -436,6 +442,7 @@ void Settings::doSave() {
     preferences.putBool("pm", profilesMigrated);
     preferences.putBool("mb", momentaryButtons);
     preferences.putString("fp", implode(favoritedProfiles, ","));
+    preferences.putString("po", implode(profileOrder, ","));
     preferences.putFloat("spp", steamPumpPercentage);
     preferences.putInt("hi", historyIndex);
 

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -64,6 +64,7 @@ class Settings {
     String getSelectedProfile() const { return selectedProfile; }
     bool isProfilesMigrated() const { return profilesMigrated; }
     std::vector<String> getFavoritedProfiles() const { return favoritedProfiles; }
+    std::vector<String> getProfileOrder() const { return profileOrder; }
     int getMainBrightness() const { return mainBrightness; }
     int getStandbyBrightness() const { return standbyBrightness; }
     int getStandbyBrightnessTimeout() const { return standbyBrightnessTimeout; }
@@ -124,6 +125,7 @@ class Settings {
     void setFavoritedProfiles(std::vector<String> favorited_profiles);
     void addFavoritedProfile(String profile);
     void removeFavoritedProfile(String profile);
+    void setProfileOrder(std::vector<String> profile_order);
     void setMainBrightness(int main_brightness);
     void setStandbyBrightness(int standby_brightness);
     void setStandbyBrightnessTimeout(int standby_brightness_timeout);
@@ -182,6 +184,7 @@ class Settings {
     bool clock24hFormat = true;
     String otaChannel = DEFAULT_OTA_CHANNEL;
     std::vector<String> favoritedProfiles;
+    std::vector<String> profileOrder; // persisted profile ordering
     float steamPumpPercentage = DEFAULT_STEAM_PUMP_PERCENTAGE;
     int historyIndex = 0;
 

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -333,6 +333,17 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
     } else if (type == "req:profiles:unfavorite") {
         auto id = request["id"].as<String>();
         controller->getSettings().removeFavoritedProfile(id);
+    } else if (type == "req:profiles:reorder") {
+        // Expect an array of profile IDs in desired order
+        if (request["order"].is<JsonArray>()) {
+            std::vector<String> order;
+            for (JsonVariant v : request["order"].as<JsonArray>()) {
+                if (v.is<String>()) {
+                    order.emplace_back(v.as<String>());
+                }
+            }
+            controller->getSettings().setProfileOrder(order);
+        }
     }
 
     String msg;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -8,6 +8,7 @@
 
 #include "BLEScalePlugin.h"
 #include "ShotHistoryPlugin.h"
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -339,7 +340,10 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
             std::vector<String> order;
             for (JsonVariant v : request["order"].as<JsonArray>()) {
                 if (v.is<String>()) {
-                    order.emplace_back(v.as<String>());
+                    String id = v.as<String>();
+                    if (!id.isEmpty() && std::find(order.begin(), order.end(), id) == order.end()) {
+                        order.emplace_back(std::move(id));
+                    }
                 }
             }
             controller->getSettings().setProfileOrder(order);

--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -97,6 +97,7 @@ function ProfileCard({
               disabled={isFirst}
               className='btn btn-xs btn-ghost'
               aria-label={`Move ${data.label} up`}
+              aria-disabled={isFirst}
               title='Move up'
             >
               <i className='fa fa-arrow-up' aria-hidden='true' />
@@ -106,6 +107,7 @@ function ProfileCard({
               disabled={isLast}
               className='btn btn-xs btn-ghost'
               aria-label={`Move ${data.label} down`}
+              aria-disabled={isLast}
               title='Move down'
             >
               <i className='fa fa-arrow-down' aria-hidden='true' />


### PR DESCRIPTION
Implement functionality to reorder profile cards with move up and down options. Ensure the new order persists across sessions by saving the profile order in settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorder profiles in the UI with Move Up / Move Down controls.
  * Local reordering is debounced to batch updates and reduce requests.
  * Custom profile order is saved and restored across sessions, and displayed instead of discovery order.

* **Documentation**
  * WebSocket API docs updated with new request/response messages to support profile reorder persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->