### PR TITLE
Return ordered favorites based on stored profile order

### DIFF
--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -198,12 +198,20 @@ void ProfileManager::loadSelectedProfile(Profile &outProfile) { loadProfile(_set
 
 std::vector<String> ProfileManager::getFavoritedProfiles(bool validate) {
     std::vector<String> favoritedProfiles;
+    auto stored = _settings.getProfileOrder();
     for (const String &profile : _settings.getFavoritedProfiles()) {
         if (!validate || profileExists(profile))
             favoritedProfiles.push_back(profile);
     }
-    if (favoritedProfiles.empty()) {
-        favoritedProfiles.push_back(_settings.getSelectedProfile());
+
+    std::vector<String> orderedFavorites;
+    for (const auto &id : stored) {
+        if (std::find(favoritedProfiles.begin(), favoritedProfiles.end(), id) != favoritedProfiles.end()) {
+            orderedFavorites.push_back(id);
+        }
     }
-    return favoritedProfiles;
+    if (orderedFavorites.empty()) {
+        orderedFavorites.push_back(_settings.getSelectedProfile());
+    }
+    return orderedFavorites;
 }

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -222,8 +222,7 @@ std::vector<String> ProfileManager::getFavoritedProfiles(bool validate) {
 
     if (result.empty()) {
         String sel = _settings.getSelectedProfile();
-        bool selValid =
-            (!validate) || (std::find(rawFavorites.begin(), rawFavorites.end(), sel) != rawFavorites.end()) || profileExists(sel);
+        bool selValid = (!validate) ||  profileExists(sel);
         if (selValid) {
             result.push_back(sel);
         }


### PR DESCRIPTION
Update the method to return favorited profiles in the order defined by the stored profile order, ensuring a consistent user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Favorites now display in your saved profile order for a consistent, predictable list.
  * The favorites list is built from your configured order and includes only profiles that exist or pass current validation rules.
  * Duplicate entries are prevented so each favorite appears once.
  * If no valid favorites are available, the selected profile is shown as a fallback (when valid).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->