### PR TITLE
Schedule Warmup/Brew

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -477,7 +477,6 @@ void Controller::lowerGrindTarget() {
 }
 
 void Controller::updateControl() {
-    unsigned long now = millis();
     float targetTemp = getTargetTemp();
     if (targetTemp > .0f) {
         targetTemp = targetTemp + static_cast<float>(settings.getTemperatureOffset());

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -504,7 +504,7 @@ void Controller::updateControl() {
     targetPressure = 0.0f;
     targetFlow = 0.0f;
     clientController.sendOutputControl(isActive() && currentProcess->isRelayActive(),
-                                       isActive() ? currentProcess->getPumpValue() : 0, targetTemp);                                     
+                                       isActive() ? currentProcess->getPumpValue() : 0, targetTemp);
 }
 
 void Controller::activate() {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -49,13 +49,11 @@ void Controller::setup() {
     if (settings.isHomeAssistant()) {
         pluginManager->registerPlugin(new MQTTPlugin());
     }
-    if (settings.isAutoWakeupEnabled()) {
-        pluginManager->registerPlugin(new AutoWakeupPlugin());
-    }    
     pluginManager->registerPlugin(new WebUIPlugin());
     pluginManager->registerPlugin(&ShotHistory);
     pluginManager->registerPlugin(&BLEScales);
     pluginManager->registerPlugin(new LedControlPlugin());
+    pluginManager->registerPlugin(new AutoWakeupPlugin());
     pluginManager->setup(this);
 
     pluginManager->on("profiles:profile:save", [this](Event const &event) {

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -159,13 +159,7 @@ class Controller {
 
     xTaskHandle taskHandle;
 
-    static void loopTask(void *arg);
-    
-    // Scheduled auto brew
-    
-    unsigned long lastAutoWakeupCheck = 0;
-    String lastCheckedTime = "";    
-
+    static void loopTask(void *arg); 
 };
 
 #endif // CONTROLLER_H

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -118,7 +118,6 @@ class Controller {
     void handleSteamButton(int steamButtonStatus);
     void handleProfileUpdate();
 
-    void checkAutoBrew();
     // Private Attributes
 #ifndef GAGGIMATE_HEADLESS
     DefaultUI *ui = nullptr;
@@ -164,7 +163,7 @@ class Controller {
     
     // Scheduled auto brew
     
-    unsigned long lastAutoBrewCheck = 0;
+    unsigned long lastAutoWakeupCheck = 0;
     String lastCheckedTime = "";    
 
 };

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -118,6 +118,7 @@ class Controller {
     void handleSteamButton(int steamButtonStatus);
     void handleProfileUpdate();
 
+    void checkAutoBrew();
     // Private Attributes
 #ifndef GAGGIMATE_HEADLESS
     DefaultUI *ui = nullptr;
@@ -160,6 +161,12 @@ class Controller {
     xTaskHandle taskHandle;
 
     static void loopTask(void *arg);
+    
+    // Scheduled auto brew
+    
+    unsigned long lastAutoBrewCheck = 0;
+    String lastCheckedTime = "";    
+
 };
 
 #endif // CONTROLLER_H

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -54,6 +54,9 @@ Settings::Settings() {
     steamPumpPercentage = preferences.getFloat("spp", DEFAULT_STEAM_PUMP_PERCENTAGE);
     steamPumpCutoff = preferences.getFloat("spc", DEFAULT_STEAM_PUMP_CUTOFF);
     historyIndex = preferences.getInt("hi", 0);
+    autoBrewEnabled = preferences.getBool("ab_en", false);
+    String timesStr = preferences.getString("ab_times", "07:00");
+    autoBrewTimes = explode(timesStr, ',');    
 
     // Display settings
     mainBrightness = preferences.getInt("main_b", 16);
@@ -407,6 +410,16 @@ void Settings::setFullTankDistance(int full_tank_distance) {
     save();
 }
 
+void Settings::setAutoBrewEnabled(bool enabled) {
+    autoBrewEnabled = enabled;
+    save();
+}
+
+void Settings::setAutoBrewTimes(const std::vector<String> &times) {
+    autoBrewTimes = times;
+    save();
+}
+
 void Settings::doSave() {
     if (!dirty) {
         return;
@@ -463,6 +476,8 @@ void Settings::doSave() {
     preferences.putFloat("spp", steamPumpPercentage);
     preferences.putFloat("spc", steamPumpCutoff);
     preferences.putInt("hi", historyIndex);
+    preferences.putBool("ab_en", autoBrewEnabled);
+    preferences.putString("ab_times", implode(autoBrewTimes, ","));    
 
     // Display settings
     preferences.putInt("main_b", mainBrightness);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -56,7 +56,28 @@ Settings::Settings() {
     historyIndex = preferences.getInt("hi", 0);
     autoBrewEnabled = preferences.getBool("ab_en", false);
     String timesStr = preferences.getString("ab_times", "07:00");
-    autoBrewTimes = explode(timesStr, ',');    
+    autoBrewTimes.clear();
+    if (timesStr.length() > 0) {
+        int start = 0;
+        int end = timesStr.indexOf(',');
+        while (end != -1) {
+            String time = timesStr.substring(start, end);
+            time.trim();
+            if (time.length() > 0) {
+                autoBrewTimes.push_back(time);
+            }
+            start = end + 1;
+            end = timesStr.indexOf(',', start);
+        }
+        String lastTime = timesStr.substring(start);
+        lastTime.trim();
+        if (lastTime.length() > 0) {
+            autoBrewTimes.push_back(lastTime);
+        }
+    }
+    if (autoBrewTimes.empty()) {
+        autoBrewTimes.push_back("07:00");
+    }
 
     // Display settings
     mainBrightness = preferences.getInt("main_b", 16);
@@ -477,7 +498,12 @@ void Settings::doSave() {
     preferences.putFloat("spc", steamPumpCutoff);
     preferences.putInt("hi", historyIndex);
     preferences.putBool("ab_en", autoBrewEnabled);
-    preferences.putString("ab_times", implode(autoBrewTimes, ","));    
+    String timesForSave = "";
+    for (size_t i = 0; i < autoBrewTimes.size(); i++) {
+        if (i > 0) timesForSave += ",";
+        timesForSave += autoBrewTimes[i];
+    }
+    preferences.putString("ab_times", timesForSave);   
 
     // Display settings
     preferences.putInt("main_b", mainBrightness);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -54,9 +54,9 @@ Settings::Settings() {
     steamPumpPercentage = preferences.getFloat("spp", DEFAULT_STEAM_PUMP_PERCENTAGE);
     steamPumpCutoff = preferences.getFloat("spc", DEFAULT_STEAM_PUMP_CUTOFF);
     historyIndex = preferences.getInt("hi", 0);
-    autoBrewEnabled = preferences.getBool("ab_en", false);
+    autowakeupEnabled = preferences.getBool("ab_en", false);
     String timesStr = preferences.getString("ab_times", "07:00");
-    autoBrewTimes.clear();
+    autowakeupTimes.clear();
     if (timesStr.length() > 0) {
         int start = 0;
         int end = timesStr.indexOf(',');
@@ -64,7 +64,7 @@ Settings::Settings() {
             String time = timesStr.substring(start, end);
             time.trim();
             if (time.length() > 0) {
-                autoBrewTimes.push_back(time);
+                autowakeupTimes.push_back(time);
             }
             start = end + 1;
             end = timesStr.indexOf(',', start);
@@ -72,11 +72,11 @@ Settings::Settings() {
         String lastTime = timesStr.substring(start);
         lastTime.trim();
         if (lastTime.length() > 0) {
-            autoBrewTimes.push_back(lastTime);
+            autowakeupTimes.push_back(lastTime);
         }
     }
-    if (autoBrewTimes.empty()) {
-        autoBrewTimes.push_back("07:00");
+    if (autowakeupTimes.empty()) {
+        autowakeupTimes.push_back("07:00");
     }
 
     // Display settings
@@ -431,13 +431,13 @@ void Settings::setFullTankDistance(int full_tank_distance) {
     save();
 }
 
-void Settings::setAutoBrewEnabled(bool enabled) {
-    autoBrewEnabled = enabled;
+void Settings::setAutoWakeupEnabled(bool enabled) {
+    autowakeupEnabled = enabled;
     save();
 }
 
-void Settings::setAutoBrewTimes(const std::vector<String> &times) {
-    autoBrewTimes = times;
+void Settings::setAutoWakeupTimes(const std::vector<String> &times) {
+    autowakeupTimes = times;
     save();
 }
 
@@ -497,11 +497,11 @@ void Settings::doSave() {
     preferences.putFloat("spp", steamPumpPercentage);
     preferences.putFloat("spc", steamPumpCutoff);
     preferences.putInt("hi", historyIndex);
-    preferences.putBool("ab_en", autoBrewEnabled);
+    preferences.putBool("ab_en", autowakeupEnabled);
     String timesForSave = "";
-    for (size_t i = 0; i < autoBrewTimes.size(); i++) {
+    for (size_t i = 0; i < autowakeupTimes.size(); i++) {
         if (i > 0) timesForSave += ",";
-        timesForSave += autoBrewTimes[i];
+        timesForSave += autowakeupTimes[i];
     }
     preferences.putString("ab_times", timesForSave);   
 

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -6,6 +6,7 @@
 #include <Preferences.h>
 #include <display/core/constants.h>
 #include <display/core/utils.h>
+#include <vector>
 
 #define PREFERENCES_KEY "controller"
 

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -81,8 +81,8 @@ class Settings {
     int getSunriseExtBrightness() const { return sunriseExtBrightness; }
     int getEmptyTankDistance() const { return emptyTankDistance; }
     int getFullTankDistance() const { return fullTankDistance; }
-    bool isAutoBrewEnabled() const { return autoBrewEnabled; }
-    std::vector<String> getAutoBrewTimes() const { return autoBrewTimes; }    
+    bool isAutoWakeupEnabled() const { return autowakeupEnabled; }
+    std::vector<String> getAutoWakeupTimes() const { return autowakeupTimes; }    
     void setTargetBrewTemp(int target_brew_temp);
     void setTargetSteamTemp(int target_steam_temp);
     void setTargetWaterTemp(int target_water_temp);
@@ -145,8 +145,8 @@ class Settings {
     void setSunriseExtBrightness(int sunrise_ext_brightness);
     void setEmptyTankDistance(int empty_tank_distance);
     void setFullTankDistance(int full_tank_distance);
-    void setAutoBrewEnabled(bool enabled);
-    void setAutoBrewTimes(const std::vector<String> &times);    
+    void setAutoWakeupEnabled(bool enabled);
+    void setAutoWakeupTimes(const std::vector<String> &times);    
 
   private:
     Preferences preferences;
@@ -164,8 +164,8 @@ class Settings {
     double grindDelay = 1000.0;
     bool delayAdjust = true;
     int startupMode = MODE_STANDBY;
-    bool autoBrewEnabled = false;
-    std::vector<String> autoBrewTimes;
+    bool autowakeupEnabled = false;
+    std::vector<String> autowakeupTimes;
     int standbyTimeout = DEFAULT_STANDBY_TIMEOUT_MS;
     String pid = DEFAULT_PID;
     String pumpModelCoeffs = DEFAULT_PUMP_MODEL_COEFFS;

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -80,6 +80,8 @@ class Settings {
     int getSunriseExtBrightness() const { return sunriseExtBrightness; }
     int getEmptyTankDistance() const { return emptyTankDistance; }
     int getFullTankDistance() const { return fullTankDistance; }
+    bool isAutoBrewEnabled() const { return autoBrewEnabled; }
+    std::vector<String> getAutoBrewTimes() const { return autoBrewTimes; }    
     void setTargetBrewTemp(int target_brew_temp);
     void setTargetSteamTemp(int target_steam_temp);
     void setTargetWaterTemp(int target_water_temp);
@@ -142,6 +144,8 @@ class Settings {
     void setSunriseExtBrightness(int sunrise_ext_brightness);
     void setEmptyTankDistance(int empty_tank_distance);
     void setFullTankDistance(int full_tank_distance);
+    void setAutoBrewEnabled(bool enabled);
+    void setAutoBrewTimes(const std::vector<String> &times);    
 
   private:
     Preferences preferences;
@@ -159,6 +163,8 @@ class Settings {
     double grindDelay = 1000.0;
     bool delayAdjust = true;
     int startupMode = MODE_STANDBY;
+    bool autoBrewEnabled = false;
+    std::vector<String> autoBrewTimes;
     int standbyTimeout = DEFAULT_STANDBY_TIMEOUT_MS;
     String pid = DEFAULT_PID;
     String pumpModelCoeffs = DEFAULT_PUMP_MODEL_COEFFS;

--- a/src/display/plugins/AutoWakeupPlugin.cpp
+++ b/src/display/plugins/AutoWakeupPlugin.cpp
@@ -1,0 +1,96 @@
+#include "AutoWakeupPlugin.h"
+#include <display/core/constants.h>
+#include <esp_log.h>
+
+const String LOG_TAG = F("AutoWakeupPlugin");
+
+AutoWakeupPlugin::AutoWakeupPlugin() {}
+
+void AutoWakeupPlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+    this->pluginManager = pluginManager;
+    this->settings = &controller->getSettings();
+    
+    ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup plugin initialized");
+    
+    // Listen for settings changes to log configuration
+    pluginManager->on("settings:changed", [this](const Event &event) {
+        if (settings->isAutoWakeupEnabled()) {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup enabled with %d time(s)", 
+                     settings->getAutoWakeupTimes().size());
+        } else {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup disabled");
+        }
+    });
+}
+
+void AutoWakeupPlugin::loop() {
+    if (!settings->isAutoWakeupEnabled() || settings->getAutoWakeupTimes().empty()) {
+        return;
+    }
+    
+    unsigned long now = millis();
+    
+    // Check every minute
+    if (now - lastAutoWakeupCheck > AUTO_WAKEUP_CHECK_INTERVAL) {
+        lastAutoWakeupCheck = now;
+        
+        if (isTimeValid()) {
+            checkAutoWakeup();
+        }
+    }
+}
+
+void AutoWakeupPlugin::checkAutoWakeup() {
+    // Only attempt if in standby mode
+    if (controller->getMode() != MODE_STANDBY) {
+        return;
+    }
+    
+    String currentTime = getCurrentTimeString();
+    
+    // Don't check the same minute twice
+    if (lastCheckedTime == currentTime) {
+        return;
+    }
+    lastCheckedTime = currentTime;
+    
+    // Check if current time matches any of the target times
+    for (const String &targetTime : settings->getAutoWakeupTimes()) {
+        if (targetTime == currentTime) {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup time reached (%s), switching to brew mode", 
+                     targetTime.c_str());
+            
+            controller->setMode(MODE_BREW);
+            
+            // Trigger plugin events
+            pluginManager->trigger("autowakeup:activated", "time", targetTime);
+            pluginManager->trigger("controller:auto-brew:activated", "time", targetTime);
+            
+            return; // Only trigger once per minute
+        }
+    }
+}
+
+bool AutoWakeupPlugin::isTimeValid() {
+    // Check if we have a valid time (year > 2020 means NTP has synced)
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    
+    return timeinfo.tm_year > (2020 - 1900);
+}
+
+String AutoWakeupPlugin::getCurrentTimeString() {
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    
+    // Format current time as HH:MM
+    char currentTime[6];
+    strftime(currentTime, sizeof(currentTime), "%H:%M", &timeinfo);
+    
+    return String(currentTime);
+}

--- a/src/display/plugins/AutoWakeupPlugin.cpp
+++ b/src/display/plugins/AutoWakeupPlugin.cpp
@@ -65,7 +65,6 @@ void AutoWakeupPlugin::checkAutoWakeup() {
             
             // Trigger plugin events
             pluginManager->trigger("autowakeup:activated", "time", targetTime);
-            pluginManager->trigger("controller:auto-brew:activated", "time", targetTime);
             
             return; // Only trigger once per minute
         }

--- a/src/display/plugins/AutoWakeupPlugin.h
+++ b/src/display/plugins/AutoWakeupPlugin.h
@@ -1,0 +1,30 @@
+#ifndef AUTO_WAKEUP_PLUGIN_H
+#define AUTO_WAKEUP_PLUGIN_H
+
+#include <display/core/Plugin.h>
+#include <display/core/Controller.h>
+#include <display/core/PluginManager.h>
+#include <display/core/Settings.h>
+#include <ctime>
+
+class AutoWakeupPlugin : public Plugin {
+public:
+    AutoWakeupPlugin();
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+private:
+    Controller *controller;
+    PluginManager *pluginManager;
+    Settings *settings;
+    
+    unsigned long lastAutoWakeupCheck = 0;
+    String lastCheckedTime = "";
+    static const unsigned long AUTO_WAKEUP_CHECK_INTERVAL = 30000; // 1 minute
+    
+    void checkAutoWakeup();
+    bool isTimeValid();
+    String getCurrentTimeString();
+};
+
+#endif // AUTO_WAKEUP_PLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -437,9 +437,9 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setEmptyTankDistance(request->arg("emptyTankDistance").toInt());
             if (request->hasArg("fullTankDistance"))
                 settings->setFullTankDistance(request->arg("fullTankDistance").toInt());
-            settings->setAutoBrewEnabled(request->hasArg("autoBrewEnabled"));
-            if (request->hasArg("autoBrewTimes")) {
-                String timesStr = request->arg("autoBrewTimes");
+            settings->setAutoWakeupEnabled(request->hasArg("autowakeupEnabled"));
+            if (request->hasArg("autowakeupTimes")) {
+                String timesStr = request->arg("autowakeupTimes");
                 std::vector<String> times;
                 if (timesStr.length() > 0) {
                     // Split comma-separated times
@@ -464,10 +464,11 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 if (times.empty()) {
                     times.push_back("07:00"); // Default fallback
                 }
-                settings->setAutoBrewTimes(times);
-            }                
+                settings->setAutoWakeupTimes(times);
+            }
             settings->save(true);
         });
+        pluginManager->trigger("settings:changed");
         controller->setTargetTemp(controller->getTargetTemp());
         controller->setPumpModelCoeffs();
     }
@@ -519,16 +520,16 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["emptyTankDistance"] = settings.getEmptyTankDistance();
     doc["fullTankDistance"] = settings.getFullTankDistance();
     // Add auto-brew settings to response
-    doc["autoBrewEnabled"] = settings.isAutoBrewEnabled();
+    doc["autowakeupEnabled"] = settings.isAutoWakeupEnabled();
     
     // Convert vector of times to comma-separated string
-    std::vector<String> autoBrewTimes = settings.getAutoBrewTimes();
+    std::vector<String> autowakeupTimes = settings.getAutoWakeupTimes();
     String timesStr = "";
-    for (size_t i = 0; i < autoBrewTimes.size(); i++) {
+    for (size_t i = 0; i < autowakeupTimes.size(); i++) {
         if (i > 0) timesStr += ",";
-        timesStr += autoBrewTimes[i];
+        timesStr += autowakeupTimes[i];
     }
-    doc["autoBrewTimes"] = timesStr;    
+    doc["autowakeupTimes"] = timesStr;    
     serializeJson(doc, *response);
     request->send(response);
 

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -519,7 +519,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["sunriseExtBrightness"] = settings.getSunriseExtBrightness();
     doc["emptyTankDistance"] = settings.getEmptyTankDistance();
     doc["fullTankDistance"] = settings.getFullTankDistance();
-    // Add auto-brew settings to response
+    // Add auto-wakeup settings to response
     doc["autowakeupEnabled"] = settings.isAutoWakeupEnabled();
     
     // Convert vector of times to comma-separated string

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -21,6 +21,7 @@ export function Settings() {
   const [gen] = useState(0);
   const [formData, setFormData] = useState({});
   const [currentTheme, setCurrentTheme] = useState('light');
+  const [autoBrewTimes, setAutoBrewTimes] = useState(['07:00']);
   const { isLoading, data: fetchedSettings } = useQuery(`settings/${gen}`, async () => {
     const response = await fetch(`/api/settings`);
     const data = await response.json();

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -296,14 +296,14 @@ export function Settings() {
               />
             </div>
 
-            <div className='divider'>Auto Brew</div>
+            <div className='divider'>Auto Warmup Schedule</div>
             <div className='mb-2 text-sm opacity-70'>
-              Automatically switch to brew mode at specific times
+              Automatically switch to brew mode at specific time(s) each day. 
             </div>
 
             <div className='form-control'>
               <label className='label cursor-pointer'>
-                <span className='label-text'>Enable Auto Brew</span>
+                <span className='label-text'>Enable Auto Warmup</span>
                 <input
                   id='autoBrewEnabled'
                   name='autoBrewEnabled'
@@ -318,7 +318,7 @@ export function Settings() {
 
             <div className='form-control'>
               <label className='mb-2 block text-sm font-medium'>
-                Auto Brew Times
+                Auto Warmup Time(s)
               </label>
               <div className='space-y-2'>
                 {autoBrewTimes.map((time, index) => (

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -42,7 +42,7 @@ export function Settings() {
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
       };
-      // Initialize auto-brew times
+      // Initialize auto-wakeup times
       if (fetchedSettings.autowakeupTimes) {
         if (Array.isArray(fetchedSettings.autowakeupTimes)) {
           setAutoWakeupTimes(fetchedSettings.autowakeupTimes);
@@ -146,7 +146,7 @@ export function Settings() {
       const formDataToSubmit = new FormData(form);
       formDataToSubmit.set('steamPumpPercentage', formData.steamPumpPercentage);
 
-      // Add auto-brew times
+      // Add auto-wakeup times
       formDataToSubmit.set('autowakeupTimes', autowakeupTimes.join(','));
 
       // Ensure standbyBrightness is included even when the field is disabled

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -43,16 +43,24 @@ export function Settings() {
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
       };
       // Initialize auto-brew times
-      if (fetchedSettings.autoBrewTimes && Array.isArray(fetchedSettings.autoBrewTimes)) {
-        setAutoBrewTimes(fetchedSettings.autoBrewTimes);
-      } else if (fetchedSettings.autoBrewTimes && typeof fetchedSettings.autoBrewTimes === 'string') {
-        setAutoBrewTimes(fetchedSettings.autoBrewTimes.split(',').filter(t => t.trim()));
+      if (fetchedSettings.autoBrewTimes) {
+        if (Array.isArray(fetchedSettings.autoBrewTimes)) {
+          setAutoBrewTimes(fetchedSettings.autoBrewTimes);
+        } else if (typeof fetchedSettings.autoBrewTimes === 'string' && fetchedSettings.autoBrewTimes.trim()) {
+          setAutoBrewTimes(fetchedSettings.autoBrewTimes.split(',').filter(t => t.trim()));
+        } else {
+          setAutoBrewTimes(['07:00']); // Default fallback
+        }
+      } else {
+        setAutoBrewTimes(['07:00']); // Default fallback
       }      
       setFormData(settingsWithToggle);
     } else {
       setFormData({});
       setAutoBrewTimes(['07:00']);
     }
+
+    
   }, [fetchedSettings]);
 
   // Initialize theme

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -21,7 +21,7 @@ export function Settings() {
   const [gen] = useState(0);
   const [formData, setFormData] = useState({});
   const [currentTheme, setCurrentTheme] = useState('light');
-  const [autoBrewTimes, setAutoBrewTimes] = useState(['07:00']);
+  const [autowakeupTimes, setAutoWakeupTimes] = useState(['07:00']);
   const { isLoading, data: fetchedSettings } = useQuery(`settings/${gen}`, async () => {
     const response = await fetch(`/api/settings`);
     const data = await response.json();
@@ -43,21 +43,21 @@ export function Settings() {
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
       };
       // Initialize auto-brew times
-      if (fetchedSettings.autoBrewTimes) {
-        if (Array.isArray(fetchedSettings.autoBrewTimes)) {
-          setAutoBrewTimes(fetchedSettings.autoBrewTimes);
-        } else if (typeof fetchedSettings.autoBrewTimes === 'string' && fetchedSettings.autoBrewTimes.trim()) {
-          setAutoBrewTimes(fetchedSettings.autoBrewTimes.split(',').filter(t => t.trim()));
+      if (fetchedSettings.autowakeupTimes) {
+        if (Array.isArray(fetchedSettings.autowakeupTimes)) {
+          setAutoWakeupTimes(fetchedSettings.autowakeupTimes);
+        } else if (typeof fetchedSettings.autowakeupTimes === 'string' && fetchedSettings.autowakeupTimes.trim()) {
+          setAutoWakeupTimes(fetchedSettings.autowakeupTimes.split(',').filter(t => t.trim()));
         } else {
-          setAutoBrewTimes(['07:00']); // Default fallback
+          setAutoWakeupTimes(['07:00']); // Default fallback
         }
       } else {
-        setAutoBrewTimes(['07:00']); // Default fallback
+        setAutoWakeupTimes(['07:00']); // Default fallback
       }      
       setFormData(settingsWithToggle);
     } else {
       setFormData({});
-      setAutoBrewTimes(['07:00']);
+      setAutoWakeupTimes(['07:00']);
     }
 
     
@@ -95,8 +95,8 @@ export function Settings() {
       if (key === 'clock24hFormat') {
         value = !formData.clock24hFormat;
       }
-      if (key === 'autoBrewEnabled') {
-        value = !formData.autoBrewEnabled;
+      if (key === 'autowakeupEnabled') {
+        value = !formData.autowakeupEnabled;
       }      
       if (key === 'standbyDisplayEnabled') {
         value = !formData.standbyDisplayEnabled;
@@ -121,21 +121,21 @@ export function Settings() {
     };
   };
 
-  const addAutoBrewTime = () => {
-    setAutoBrewTimes([...autoBrewTimes, '07:00']);
+  const addAutoWakeupTime = () => {
+    setAutoWakeupTimes([...autowakeupTimes, '07:00']);
   };
 
-  const removeAutoBrewTime = (index) => {
-    if (autoBrewTimes.length > 1) {
-      const newTimes = autoBrewTimes.filter((_, i) => i !== index);
-      setAutoBrewTimes(newTimes);
+  const removeAutoWakeupTime = (index) => {
+    if (autowakeupTimes.length > 1) {
+      const newTimes = autowakeupTimes.filter((_, i) => i !== index);
+      setAutoWakeupTimes(newTimes);
     }
   };
 
-  const updateAutoBrewTime = (index, value) => {
-    const newTimes = [...autoBrewTimes];
+  const updateAutoWakeupTime = (index, value) => {
+    const newTimes = [...autowakeupTimes];
     newTimes[index] = value;
-    setAutoBrewTimes(newTimes);
+    setAutoWakeupTimes(newTimes);
   };  
 
   const onSubmit = useCallback(
@@ -147,7 +147,7 @@ export function Settings() {
       formDataToSubmit.set('steamPumpPercentage', formData.steamPumpPercentage);
 
       // Add auto-brew times
-      formDataToSubmit.set('autoBrewTimes', autoBrewTimes.join(','));
+      formDataToSubmit.set('autowakeupTimes', autowakeupTimes.join(','));
 
       // Ensure standbyBrightness is included even when the field is disabled
       if (!formData.standbyDisplayEnabled) {
@@ -173,7 +173,7 @@ export function Settings() {
       setFormData(updatedData);
       setSubmitting(false);
     },
-    [setFormData, formRef, formData, autoBrewTimes],
+    [setFormData, formRef, formData, autowakeupTimes],
   );
 
   const onExport = useCallback(() => {
@@ -305,13 +305,13 @@ export function Settings() {
               <label className='label cursor-pointer'>
                 <span className='label-text'>Enable Auto Warmup</span>
                 <input
-                  id='autoBrewEnabled'
-                  name='autoBrewEnabled'
-                  value='autoBrewEnabled'
+                  id='autowakeupEnabled'
+                  name='autowakeupEnabled'
+                  value='autowakeupEnabled'
                   type='checkbox'
                   className='toggle toggle-primary'
-                  checked={!!formData.autoBrewEnabled}
-                  onChange={onChange('autoBrewEnabled')}
+                  checked={!!formData.autowakeupEnabled}
+                  onChange={onChange('autowakeupEnabled')}
                 />
               </label>
             </div>
@@ -321,21 +321,21 @@ export function Settings() {
                 Auto Warmup Time(s)
               </label>
               <div className='space-y-2'>
-                {autoBrewTimes.map((time, index) => (
+                {autowakeupTimes.map((time, index) => (
                   <div key={index} className='flex items-center gap-2'>
                     <input
                       type='time'
                       className='input input-bordered flex-1'
                       value={time}
-                      onChange={(e) => updateAutoBrewTime(index, e.target.value)}
-                      disabled={!formData.autoBrewEnabled}
+                      onChange={(e) => updateAutoWakeupTime(index, e.target.value)}
+                      disabled={!formData.autowakeupEnabled}
                     />
-                    {autoBrewTimes.length > 1 && (
+                    {autowakeupTimes.length > 1 && (
                       <button
                         type='button'
-                        onClick={() => removeAutoBrewTime(index)}
+                        onClick={() => removeAutoWakeupTime(index)}
                         className='btn btn-ghost btn-sm'
-                        disabled={!formData.autoBrewEnabled}
+                        disabled={!formData.autowakeupEnabled}
                       >
                         <i className='fa fa-trash' />
                       </button>
@@ -344,9 +344,9 @@ export function Settings() {
                 ))}
                 <button
                   type='button'
-                  onClick={addAutoBrewTime}
+                  onClick={addAutoWakeupTime}
                   className='btn btn-ghost btn-sm'
-                  disabled={!formData.autoBrewEnabled}
+                  disabled={!formData.autowakeupEnabled}
                 >
                   <i className='fa fa-plus mr-1' />
                   Add Time


### PR DESCRIPTION
This adds the ability to schedule the GaggiMate to enter brew mode automatically one or more times a day. This effectively serves as an automatic 'warm up' scheduler as the machine will get up to temp based on the last selected profile. 

<img width="889" height="504" alt="image" src="https://github.com/user-attachments/assets/aad5c5ff-45b5-4956-b042-c11fe9a05325" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto Wakeup scheduling: device can automatically start warming/brewing from standby at configured times.
  * Settings UI & API: toggle to enable/disable Auto Wakeup and manage multiple times (add, edit, remove); schedule persists with sensible default "07:00".

* **Bug Fixes / Notes**
  * Prevents repeated activations within the same minute.
  * Duplicate UI block inserted in the settings page (non-functional).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->