### PR TITLE
Auto-warmup scheduler with per-day scheduling

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -19,6 +19,7 @@
 #include <display/plugins/SmartGrindPlugin.h>
 #include <display/plugins/WebUIPlugin.h>
 #include <display/plugins/mDNSPlugin.h>
+#include <display/plugins/AutoWakeupPlugin.h>
 
 const String LOG_TAG = F("Controller");
 
@@ -52,6 +53,7 @@ void Controller::setup() {
     pluginManager->registerPlugin(&ShotHistory);
     pluginManager->registerPlugin(&BLEScales);
     pluginManager->registerPlugin(new LedControlPlugin());
+    pluginManager->registerPlugin(new AutoWakeupPlugin());
     pluginManager->setup(this);
 
     pluginManager->on("profiles:profile:save", [this](Event const &event) {

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -6,8 +6,41 @@
 #include <Preferences.h>
 #include <display/core/constants.h>
 #include <display/core/utils.h>
+#include <vector>
 
 #define PREFERENCES_KEY "controller"
+
+struct AutoWakeupSchedule {
+    String time;  // HH:MM format
+    bool days[7]; // [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
+    
+    AutoWakeupSchedule() : time("07:00") {
+        // Default to all days enabled
+        for (int i = 0; i < 7; i++) {
+            days[i] = true;
+        }
+    }
+    
+    AutoWakeupSchedule(const String &timeStr) : time(timeStr) {
+        // Default to all days enabled
+        for (int i = 0; i < 7; i++) {
+            days[i] = true;
+        }
+    }
+    
+    bool isDayEnabled(int dayOfWeek) const {
+        // dayOfWeek: 1=Monday, 2=Tuesday, ..., 7=Sunday
+        if (dayOfWeek < 1 || dayOfWeek > 7) return false;
+        return days[dayOfWeek - 1];
+    }
+    
+    void setDayEnabled(int dayOfWeek, bool enabled) {
+        // dayOfWeek: 1=Monday, 2=Tuesday, ..., 7=Sunday
+        if (dayOfWeek >= 1 && dayOfWeek <= 7) {
+            days[dayOfWeek - 1] = enabled;
+        }
+    }
+};
 
 class Settings;
 using SettingsCallback = std::function<void(Settings *)>;
@@ -80,6 +113,8 @@ class Settings {
     int getSunriseExtBrightness() const { return sunriseExtBrightness; }
     int getEmptyTankDistance() const { return emptyTankDistance; }
     int getFullTankDistance() const { return fullTankDistance; }
+    bool isAutoWakeupEnabled() const { return autowakeupEnabled; }
+    std::vector<AutoWakeupSchedule> getAutoWakeupSchedules() const { return autowakeupSchedules; }    
     void setTargetBrewTemp(int target_brew_temp);
     void setTargetSteamTemp(int target_steam_temp);
     void setTargetWaterTemp(int target_water_temp);
@@ -142,6 +177,8 @@ class Settings {
     void setSunriseExtBrightness(int sunrise_ext_brightness);
     void setEmptyTankDistance(int empty_tank_distance);
     void setFullTankDistance(int full_tank_distance);
+    void setAutoWakeupEnabled(bool enabled);
+    void setAutoWakeupSchedules(const std::vector<AutoWakeupSchedule> &schedules);    
 
   private:
     Preferences preferences;
@@ -159,6 +196,8 @@ class Settings {
     double grindDelay = 1000.0;
     bool delayAdjust = true;
     int startupMode = MODE_STANDBY;
+    bool autowakeupEnabled = false;
+    std::vector<AutoWakeupSchedule> autowakeupSchedules;
     int standbyTimeout = DEFAULT_STANDBY_TIMEOUT_MS;
     String pid = DEFAULT_PID;
     String pumpModelCoeffs = DEFAULT_PUMP_MODEL_COEFFS;

--- a/src/display/plugins/AutoWakeupPlugin.cpp
+++ b/src/display/plugins/AutoWakeupPlugin.cpp
@@ -1,0 +1,111 @@
+#include "AutoWakeupPlugin.h"
+#include <display/core/constants.h>
+#include <esp_log.h>
+
+const String LOG_TAG = F("AutoWakeupPlugin");
+
+AutoWakeupPlugin::AutoWakeupPlugin() {}
+
+void AutoWakeupPlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+    this->pluginManager = pluginManager;
+    this->settings = &controller->getSettings();
+    
+    ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup plugin initialized");
+    
+    // Listen for settings changes to log configuration
+    pluginManager->on("settings:changed", [this](const Event &event) {
+        if (settings->isAutoWakeupEnabled()) {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup enabled with %d schedule(s)", 
+                     settings->getAutoWakeupSchedules().size());
+        } else {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup disabled");
+        }
+    });
+}
+
+void AutoWakeupPlugin::loop() {
+    if (!settings->isAutoWakeupEnabled() || settings->getAutoWakeupSchedules().empty()) {
+        return;
+    }
+    
+    unsigned long now = millis();
+    
+    // Check every minute
+    if (now - lastAutoWakeupCheck > AUTO_WAKEUP_CHECK_INTERVAL) {
+        lastAutoWakeupCheck = now;
+        
+        if (isTimeValid()) {
+            checkAutoWakeup();
+        }
+    }
+}
+
+void AutoWakeupPlugin::checkAutoWakeup() {
+    // Only attempt if in standby mode
+    if (controller->getMode() != MODE_STANDBY) {
+        return;
+    }
+    
+    String currentTime = getCurrentTimeString();
+    int currentDayOfWeek = getCurrentDayOfWeek(); // 1=Monday, 7=Sunday
+    
+    // Don't check the same minute twice
+    if (lastCheckedTime == currentTime) {
+        return;
+    }
+    lastCheckedTime = currentTime;
+    
+    // Check if current time and day matches any of the schedules
+    for (const AutoWakeupSchedule &schedule : settings->getAutoWakeupSchedules()) {
+        if (schedule.time == currentTime && schedule.isDayEnabled(currentDayOfWeek)) {
+            ESP_LOGI(LOG_TAG.c_str(), "Auto-wakeup schedule matched (time: %s, day: %d), switching to brew mode", 
+                     schedule.time.c_str(), currentDayOfWeek);
+            
+            controller->setMode(MODE_BREW);
+            
+            // Trigger plugin events
+            pluginManager->trigger("autowakeup:activated", "time", schedule.time);
+            
+            return; // Only trigger once per minute
+        }
+    }
+}
+
+bool AutoWakeupPlugin::isTimeValid() {
+    // Check if we have a valid time (year > 2020 means NTP has synced)
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    
+    return timeinfo.tm_year > (2020 - 1900);
+}
+
+String AutoWakeupPlugin::getCurrentTimeString() {
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    
+    // Format current time as HH:MM
+    char currentTime[6];
+    strftime(currentTime, sizeof(currentTime), "%H:%M", &timeinfo);
+    
+    return String(currentTime);
+}
+
+int AutoWakeupPlugin::getCurrentDayOfWeek() {
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    
+    // Convert tm_wday (0=Sunday, 1=Monday, ..., 6=Saturday) to our format (1=Monday, ..., 7=Sunday)
+    int dayOfWeek = timeinfo.tm_wday;
+    if (dayOfWeek == 0) {
+        return 7; // Sunday
+    } else {
+        return dayOfWeek; // Monday=1, Tuesday=2, ..., Saturday=6
+    }
+}

--- a/src/display/plugins/AutoWakeupPlugin.h
+++ b/src/display/plugins/AutoWakeupPlugin.h
@@ -1,0 +1,31 @@
+#ifndef AUTO_WAKEUP_PLUGIN_H
+#define AUTO_WAKEUP_PLUGIN_H
+
+#include <display/core/Plugin.h>
+#include <display/core/Controller.h>
+#include <display/core/PluginManager.h>
+#include <display/core/Settings.h>
+#include <ctime>
+
+class AutoWakeupPlugin : public Plugin {
+public:
+    AutoWakeupPlugin();
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+private:
+    Controller *controller;
+    PluginManager *pluginManager;
+    Settings *settings;
+    
+    unsigned long lastAutoWakeupCheck = 0;
+    String lastCheckedTime = "";
+    static const unsigned long AUTO_WAKEUP_CHECK_INTERVAL = 30000; // 1 minute
+    
+    void checkAutoWakeup();
+    bool isTimeValid();
+    String getCurrentTimeString();
+    int getCurrentDayOfWeek();
+};
+
+#endif // AUTO_WAKEUP_PLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -449,8 +449,51 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setEmptyTankDistance(request->arg("emptyTankDistance").toInt());
             if (request->hasArg("fullTankDistance"))
                 settings->setFullTankDistance(request->arg("fullTankDistance").toInt());
+            settings->setAutoWakeupEnabled(request->hasArg("autowakeupEnabled"));
+            if (request->hasArg("autowakeupSchedules")) {
+                // Handle schedule format with days
+                String schedulesStr = request->arg("autowakeupSchedules");
+                std::vector<AutoWakeupSchedule> schedules;
+                
+                if (schedulesStr.length() > 0) {
+                    // Split semicolon-separated schedules
+                    int start = 0;
+                    int end = schedulesStr.indexOf(';');
+                    
+                    while (end != -1 || start < schedulesStr.length()) {
+                        String scheduleStr = (end != -1) ? schedulesStr.substring(start, end) : schedulesStr.substring(start);
+                        
+                        int pipePos = scheduleStr.indexOf('|');
+                        if (pipePos != -1) {
+                            String timeStr = scheduleStr.substring(0, pipePos);
+                            String daysStr = scheduleStr.substring(pipePos + 1);
+                            
+                            AutoWakeupSchedule schedule;
+                            schedule.time = timeStr;
+                            
+                            if (daysStr.length() == 7) {
+                                for (int i = 0; i < 7; i++) {
+                                    schedule.days[i] = (daysStr.charAt(i) == '1');
+                                }
+                            }
+                            
+                            schedules.push_back(schedule);
+                        }
+                        
+                        if (end == -1) break;
+                        start = end + 1;
+                        end = schedulesStr.indexOf(';', start);
+                    }
+                }
+                
+                if (schedules.empty()) {
+                    schedules.push_back(AutoWakeupSchedule("07:00")); // Default fallback
+                }
+                settings->setAutoWakeupSchedules(schedules);
+            }
             settings->save(true);
         });
+        pluginManager->trigger("settings:changed");
         controller->setTargetTemp(controller->getTargetTemp());
         controller->setPumpModelCoeffs();
     }
@@ -501,6 +544,22 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["sunriseExtBrightness"] = settings.getSunriseExtBrightness();
     doc["emptyTankDistance"] = settings.getEmptyTankDistance();
     doc["fullTankDistance"] = settings.getFullTankDistance();
+    // Add auto-wakeup settings to response
+    doc["autowakeupEnabled"] = settings.isAutoWakeupEnabled();
+    
+    // Add schedule format with days
+    std::vector<AutoWakeupSchedule> autowakeupSchedules = settings.getAutoWakeupSchedules();
+    String schedulesStr = "";
+    for (size_t i = 0; i < autowakeupSchedules.size(); i++) {
+        if (i > 0) schedulesStr += ";";
+        schedulesStr += autowakeupSchedules[i].time + "|";
+        
+        // Convert days array to 7-bit string
+        for (int j = 0; j < 7; j++) {
+            schedulesStr += autowakeupSchedules[i].days[j] ? "1" : "0";
+        }
+    }
+    doc["autowakeupSchedules"] = schedulesStr;    
     serializeJson(doc, *response);
     request->send(response);
 

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -1,8 +1,103 @@
 import homekitImage from '../../assets/homekit.png';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 
-export function PluginCard({ formData, onChange }) {
+export function PluginCard({ 
+  formData, 
+  onChange, 
+  autowakeupSchedules, 
+  addAutoWakeupSchedule, 
+  removeAutoWakeupSchedule, 
+  updateAutoWakeupTime, 
+  updateAutoWakeupDay 
+}) {
   return (
     <div className='space-y-4'>
+      <div className='bg-base-200 rounded-lg p-4'>
+        <div className='flex items-center justify-between'>
+          <span className='text-xl font-medium'>Automatic Wakeup Schedule</span>
+          <input
+            id='autowakeupEnabled'
+            name='autowakeupEnabled'
+            value='autowakeupEnabled'
+            type='checkbox'
+            className='toggle toggle-primary'
+            checked={!!formData.autowakeupEnabled}
+            onChange={onChange('autowakeupEnabled')}
+            aria-label='Enable Auto Wakeup'
+          />
+        </div>
+        {formData.autowakeupEnabled && (
+          <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
+            <p className='text-sm opacity-70'>
+              Automatically switch to brew mode at specified time(s) of day.
+            </p>
+            <div className='form-control'>
+              <label className='mb-2 block text-sm font-medium'>
+                Auto Wakeup Schedule
+              </label>
+              <div className='space-y-2'>
+                {autowakeupSchedules?.map((schedule, scheduleIndex) => (
+                  <div key={scheduleIndex} className='flex items-center gap-1 flex-wrap'>
+                    {/* Time input */}
+                    <input
+                      type='time'
+                      className='input input-bordered input-sm w-auto min-w-0 pr-6'
+                      value={schedule.time}
+                      onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
+                      disabled={!formData.autowakeupEnabled}
+                    />
+
+                    {/* Days toggle buttons */}
+                    <div className='join' role='group' aria-label='Days of week selection'>
+                      {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((dayLabel, dayIndex) => (
+                        <button
+                          key={dayIndex}
+                          type='button'
+                          className={`join-item btn btn-xs ${schedule.days[dayIndex] ? 'btn-primary' : 'btn-outline'}`}
+                          onClick={() => updateAutoWakeupDay(scheduleIndex, dayIndex, !schedule.days[dayIndex])}
+                          disabled={!formData.autowakeupEnabled}
+                          aria-pressed={schedule.days[dayIndex]}
+                          aria-label={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
+                          title={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
+                        >
+                          {dayLabel}
+                        </button>
+                      ))}
+                    </div>
+
+                    {/* Delete button */}
+                    {autowakeupSchedules.length > 1 ? (
+                      <button
+                        type='button'
+                        onClick={() => removeAutoWakeupSchedule(scheduleIndex)}
+                        className='btn btn-ghost btn-xs'
+                        disabled={!formData.autowakeupEnabled}
+                        title='Delete this schedule'
+                      >
+                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
+                      </button>
+                    ) : (
+                      <div className='btn btn-ghost btn-xs opacity-30 cursor-not-allowed' title='Cannot delete the last schedule'>
+                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
+                      </div>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type='button'
+                  onClick={addAutoWakeupSchedule}
+                  className='btn btn-primary btn-sm'
+                  disabled={!formData.autowakeupEnabled}
+                >
+                  Add Schedule
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className='bg-base-200 rounded-lg p-4'>
         <div className='flex items-center justify-between'>
           <span className='text-xl font-medium'>Homekit</span>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -322,89 +322,6 @@ export function Settings() {
               />
             </div>
 
-            <div className='divider'>Auto Wakeup Schedule</div>
-            <div className='mb-2 text-sm opacity-70'>
-              Automatically switch to brew mode at specified time(s) of day. 
-            </div>
-
-            <div className='form-control'>
-              <label className='label cursor-pointer'>
-                <span className='label-text'>Enable Auto Wakeup</span>
-                <input
-                  id='autowakeupEnabled'
-                  name='autowakeupEnabled'
-                  value='autowakeupEnabled'
-                  type='checkbox'
-                  className='toggle toggle-primary'
-                  checked={!!formData.autowakeupEnabled}
-                  onChange={onChange('autowakeupEnabled')}
-                />
-              </label>
-            </div>
-
-            <div className='form-control'>
-              <label className='mb-2 block text-sm font-medium'>
-                Auto Warmup Schedule
-              </label>
-              <div className='space-y-2'>
-                {autowakeupSchedules.map((schedule, scheduleIndex) => (
-                  <div key={scheduleIndex} className='flex items-center gap-3 flex-wrap'>
-                    {/* Time input */}
-                    <input
-                      type='time'
-                      className='input input-bordered input-sm w-auto min-w-0 pr-6'
-                      value={schedule.time}
-                      onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
-                      disabled={!formData.autowakeupEnabled}
-                    />
-
-                    {/* Days toggle buttons */}
-                    <div className='join' role='group' aria-label='Days of week selection'>
-                      {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((dayLabel, dayIndex) => (
-                        <button
-                          key={dayIndex}
-                          type='button'
-                          className={`join-item btn btn-xs ${schedule.days[dayIndex] ? 'btn-primary' : 'btn-outline'}`}
-                          onClick={() => updateAutoWakeupDay(scheduleIndex, dayIndex, !schedule.days[dayIndex])}
-                          disabled={!formData.autowakeupEnabled}
-                          aria-pressed={schedule.days[dayIndex]}
-                          aria-label={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
-                          title={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
-                        >
-                          {dayLabel}
-                        </button>
-                      ))}
-                    </div>
-
-                    {/* Delete button */}
-                    {autowakeupSchedules.length > 1 ? (
-                      <button
-                        type='button'
-                        onClick={() => removeAutoWakeupSchedule(scheduleIndex)}
-                        className='btn btn-ghost btn-xs'
-                        disabled={!formData.autowakeupEnabled}
-                        title='Delete this schedule'
-                      >
-                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
-                      </button>
-                    ) : (
-                      <div className='btn btn-ghost btn-xs opacity-30 cursor-not-allowed' title='Cannot delete the last schedule'>
-                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
-                      </div>
-                    )}
-                  </div>
-                ))}
-                <button
-                  type='button'
-                  onClick={addAutoWakeupSchedule}
-                  className='btn btn-primary btn-sm'
-                  disabled={!formData.autowakeupEnabled}
-                >
-                  Add Schedule
-                </button>
-              </div>
-            </div>
-
             <div className='divider'>Predictive scale delay</div>
             <div className='mb-2 text-sm opacity-70'>
               Shuts off the process ahead of time based on the flow rate to account for any dripping
@@ -945,7 +862,15 @@ export function Settings() {
           )}
 
           <Card sm={10} title='Plugins'>
-            <PluginCard formData={formData} onChange={onChange} />
+            <PluginCard 
+              formData={formData} 
+              onChange={onChange}
+              autowakeupSchedules={autowakeupSchedules}
+              addAutoWakeupSchedule={addAutoWakeupSchedule}
+              removeAutoWakeupSchedule={removeAutoWakeupSchedule}
+              updateAutoWakeupTime={updateAutoWakeupTime}
+              updateAutoWakeupDay={updateAutoWakeupDay}
+            />
           </Card>
         </div>
 

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -12,6 +12,7 @@ import { downloadJson } from '../../utils/download.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
 const pressureAvailable = computed(() => machine.value.capabilities.pressure);
@@ -21,6 +22,9 @@ export function Settings() {
   const [gen] = useState(0);
   const [formData, setFormData] = useState({});
   const [currentTheme, setCurrentTheme] = useState('light');
+  const [autowakeupSchedules, setAutoWakeupSchedules] = useState([
+    { time: '07:00', days: [true, true, true, true, true, true, true] } // Default: all days enabled
+  ]);
   const { isLoading, data: fetchedSettings } = useQuery(`settings/${gen}`, async () => {
     const response = await fetch(`/api/settings`);
     const data = await response.json();
@@ -41,10 +45,36 @@ export function Settings() {
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
       };
+      
+      // Initialize auto-wakeup schedules
+      if (fetchedSettings.autowakeupSchedules) {
+        // Parse new schedule format: "time1|days1;time2|days2"
+        const schedules = [];
+        if (typeof fetchedSettings.autowakeupSchedules === 'string' && fetchedSettings.autowakeupSchedules.trim()) {
+          const scheduleStrings = fetchedSettings.autowakeupSchedules.split(';');
+          for (const scheduleStr of scheduleStrings) {
+            const [time, daysStr] = scheduleStr.split('|');
+            if (time && daysStr && daysStr.length === 7) {
+              const days = daysStr.split('').map(d => d === '1');
+              schedules.push({ time, days });
+            }
+          }
+        }
+        if (schedules.length === 0) {
+          schedules.push({ time: '07:00', days: [true, true, true, true, true, true, true] });
+        }
+        setAutoWakeupSchedules(schedules);
+      } else {
+        setAutoWakeupSchedules([{ time: '07:00', days: [true, true, true, true, true, true, true] }]);
+      }
+      
       setFormData(settingsWithToggle);
     } else {
       setFormData({});
+      setAutoWakeupSchedules([{ time: '07:00', days: [true, true, true, true, true, true, true] }]);
     }
+
+    
   }, [fetchedSettings]);
 
   // Initialize theme
@@ -79,6 +109,9 @@ export function Settings() {
       if (key === 'clock24hFormat') {
         value = !formData.clock24hFormat;
       }
+      if (key === 'autowakeupEnabled') {
+        value = !formData.autowakeupEnabled;
+      }      
       if (key === 'standbyDisplayEnabled') {
         value = !formData.standbyDisplayEnabled;
         // Set standby brightness to 0 when toggle is off
@@ -102,6 +135,32 @@ export function Settings() {
     };
   };
 
+  const addAutoWakeupSchedule = () => {
+    setAutoWakeupSchedules([...autowakeupSchedules, { 
+      time: '07:00', 
+      days: [true, true, true, true, true, true, true] 
+    }]);
+  };
+
+  const removeAutoWakeupSchedule = (index) => {
+    if (autowakeupSchedules.length > 1) {
+      const newSchedules = autowakeupSchedules.filter((_, i) => i !== index);
+      setAutoWakeupSchedules(newSchedules);
+    }
+  };
+
+  const updateAutoWakeupTime = (index, value) => {
+    const newSchedules = [...autowakeupSchedules];
+    newSchedules[index].time = value;
+    setAutoWakeupSchedules(newSchedules);
+  };
+
+  const updateAutoWakeupDay = (scheduleIndex, dayIndex, enabled) => {
+    const newSchedules = [...autowakeupSchedules];
+    newSchedules[scheduleIndex].days[dayIndex] = enabled;
+    setAutoWakeupSchedules(newSchedules);
+  };  
+
   const onSubmit = useCallback(
     async (e, restart = false) => {
       e.preventDefault();
@@ -109,6 +168,12 @@ export function Settings() {
       const form = formRef.current;
       const formDataToSubmit = new FormData(form);
       formDataToSubmit.set('steamPumpPercentage', formData.steamPumpPercentage);
+
+      // Add auto-wakeup schedules
+      const schedulesStr = autowakeupSchedules.map(schedule => 
+        `${schedule.time}|${schedule.days.map(d => d ? '1' : '0').join('')}`
+      ).join(';');
+      formDataToSubmit.set('autowakeupSchedules', schedulesStr);
 
       // Ensure standbyBrightness is included even when the field is disabled
       if (!formData.standbyDisplayEnabled) {
@@ -134,7 +199,7 @@ export function Settings() {
       setFormData(updatedData);
       setSubmitting(false);
     },
-    [setFormData, formRef, formData],
+    [setFormData, formRef, formData, autowakeupSchedules],
   );
 
   const onExport = useCallback(() => {
@@ -255,6 +320,89 @@ export function Settings() {
                 value={formData.standbyTimeout}
                 onChange={onChange('standbyTimeout')}
               />
+            </div>
+
+            <div className='divider'>Auto Warmup Schedule</div>
+            <div className='mb-2 text-sm opacity-70'>
+              Automatically switch to brew mode at specific time(s) of day. 
+            </div>
+
+            <div className='form-control'>
+              <label className='label cursor-pointer'>
+                <span className='label-text'>Enable Auto Warmup</span>
+                <input
+                  id='autowakeupEnabled'
+                  name='autowakeupEnabled'
+                  value='autowakeupEnabled'
+                  type='checkbox'
+                  className='toggle toggle-primary'
+                  checked={!!formData.autowakeupEnabled}
+                  onChange={onChange('autowakeupEnabled')}
+                />
+              </label>
+            </div>
+
+            <div className='form-control'>
+              <label className='mb-2 block text-sm font-medium'>
+                Auto Warmup Schedule
+              </label>
+              <div className='space-y-2'>
+                {autowakeupSchedules.map((schedule, scheduleIndex) => (
+                  <div key={scheduleIndex} className='flex items-center gap-3 flex-wrap'>
+                    {/* Time input */}
+                    <input
+                      type='time'
+                      className='input input-bordered input-sm w-28'
+                      value={schedule.time}
+                      onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
+                      disabled={!formData.autowakeupEnabled}
+                    />
+
+                    {/* Days toggle buttons */}
+                    <div className='join' role='group' aria-label='Days of week selection'>
+                      {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((dayLabel, dayIndex) => (
+                        <button
+                          key={dayIndex}
+                          type='button'
+                          className={`join-item btn btn-xs ${schedule.days[dayIndex] ? 'btn-primary' : 'btn-outline'}`}
+                          onClick={() => updateAutoWakeupDay(scheduleIndex, dayIndex, !schedule.days[dayIndex])}
+                          disabled={!formData.autowakeupEnabled}
+                          aria-pressed={schedule.days[dayIndex]}
+                          aria-label={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
+                          title={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][dayIndex]}
+                        >
+                          {dayLabel}
+                        </button>
+                      ))}
+                    </div>
+
+                    {/* Delete button */}
+                    {autowakeupSchedules.length > 1 ? (
+                      <button
+                        type='button'
+                        onClick={() => removeAutoWakeupSchedule(scheduleIndex)}
+                        className='btn btn-ghost btn-xs'
+                        disabled={!formData.autowakeupEnabled}
+                        title='Delete this schedule'
+                      >
+                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
+                      </button>
+                    ) : (
+                      <div className='btn btn-ghost btn-xs opacity-30 cursor-not-allowed' title='Cannot delete the last schedule'>
+                        <FontAwesomeIcon icon={faTrashCan} className='text-xs'/>
+                      </div>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type='button'
+                  onClick={addAutoWakeupSchedule}
+                  className='btn btn-primary btn-sm'
+                  disabled={!formData.autowakeupEnabled}
+                >
+                  Add Schedule
+                </button>
+              </div>
             </div>
 
             <div className='divider'>Predictive scale delay</div>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -322,14 +322,14 @@ export function Settings() {
               />
             </div>
 
-            <div className='divider'>Auto Warmup Schedule</div>
+            <div className='divider'>Auto Wakeup Schedule</div>
             <div className='mb-2 text-sm opacity-70'>
-              Automatically switch to brew mode at specific time(s) of day. 
+              Automatically switch to brew mode at specified time(s) of day. 
             </div>
 
             <div className='form-control'>
               <label className='label cursor-pointer'>
-                <span className='label-text'>Enable Auto Warmup</span>
+                <span className='label-text'>Enable Auto Wakeup</span>
                 <input
                   id='autowakeupEnabled'
                   name='autowakeupEnabled'
@@ -352,7 +352,7 @@ export function Settings() {
                     {/* Time input */}
                     <input
                       type='time'
-                      className='input input-bordered input-sm w-auto min-w-0'
+                      className='input input-bordered input-sm w-auto min-w-0 pr-6'
                       value={schedule.time}
                       onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
                       disabled={!formData.autowakeupEnabled}

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -352,7 +352,7 @@ export function Settings() {
                     {/* Time input */}
                     <input
                       type='time'
-                      className='input input-bordered input-sm w-24'
+                      className='input input-bordered input-sm w-auto min-w-0'
                       value={schedule.time}
                       onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
                       disabled={!formData.autowakeupEnabled}

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -352,7 +352,7 @@ export function Settings() {
                     {/* Time input */}
                     <input
                       type='time'
-                      className='input input-bordered input-sm w-28'
+                      className='input input-bordered input-sm w-24'
                       value={schedule.time}
                       onChange={(e) => updateAutoWakeupTime(scheduleIndex, e.target.value)}
                       disabled={!formData.autowakeupEnabled}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -151,18 +151,3 @@
 }
 
 @source inline("{,sm:,md:,lg:,xl:}col-span-{1..12}");
-
-/* Hide time input clock icon */
-input[type="time"]::-webkit-calendar-picker-indicator {
-  display: none;
-}
-
-input[type="time"]::-webkit-inner-spin-button,
-input[type="time"]::-webkit-outer-spin-button {
-  display: none;
-}
-
-/* Firefox */
-input[type="time"] {
-  -moz-appearance: textfield;
-}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -151,3 +151,18 @@
 }
 
 @source inline("{,sm:,md:,lg:,xl:}col-span-{1..12}");
+
+/* Hide time input clock icon */
+input[type="time"]::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
+input[type="time"]::-webkit-inner-spin-button,
+input[type="time"]::-webkit-outer-spin-button {
+  display: none;
+}
+
+/* Firefox */
+input[type="time"] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
This is a version of PR https://github.com/jniebuhr/gaggimate/pull/384 but with per-day scheduling ability

<img width="864" height="796" alt="image" src="https://github.com/user-attachments/assets/cbacfd5b-2369-4a0e-a882-cc2bd7a3c8ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto Wakeup: device can auto-wake to brew on schedules (requires valid device time/NTP).
  * Configure multiple schedules (time + per-day selection); a default 07:00 schedule is created if none exist.
  * Global enable/disable for Auto Wakeup; settings are persisted and restored.
  * Web Settings page: toggle and schedule editor (add/remove, time input, day toggles); cannot delete last schedule.
  * UI uses trash icon for deletes; schedules submitted/returned as compact time|days strings.
  * Activation events emitted when a scheduled wake occurs; duplicate activations avoided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->