### PR TITLE
feat: Implement AMOLED theme color override by recursive background setting

### DIFF
--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -18,6 +18,16 @@
 
 static EffectManager effect_mgr;
 
+void set_black_background_recursive(lv_obj_t *obj)
+{
+    lv_obj_set_style_bg_color(obj, lv_color_black(), LV_PART_MAIN | LV_STATE_DEFAULT);
+    
+    for (uint32_t i = 0; i < lv_obj_get_child_cnt(obj); i++) {
+        lv_obj_t *child = lv_obj_get_child(obj, i);
+        set_black_background_recursive(child);
+    }
+}
+
 int16_t calculate_angle(int set_temp, int range, int offset) {
     const double percentage = static_cast<double>(set_temp) / static_cast<double>(MAX_TEMP);
     return (percentage * ((double)range)) - range / 2 - offset;
@@ -229,6 +239,8 @@ void DefaultUI::loop() {
         if (lv_scr_act() == ui_StatusScreen)
             updateStatusScreen();
         effect_mgr.evaluate_all();
+        
+        override_theme_colors_for_amoled();
     }
 
     lv_task_handler();
@@ -773,5 +785,11 @@ void DefaultUI::profileLoopTask(void *arg) {
     while (true) {
         ui->loopProfiles();
         vTaskDelay(25 / portTICK_PERIOD_MS);
+    }
+}
+
+void DefaultUI::override_theme_colors_for_amoled() {
+    if (currentThemeMode == UI_THEME_DEFAULT && panelDriver == LilyGoTDisplayDriver::getInstance()) {
+        set_black_background_recursive(currentScreen);
     }
 }

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -58,6 +58,7 @@ class DefaultUI {
     void adjustDials(lv_obj_t *dials);
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
+    void override_theme_colors_for_amoled();
 
     int tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;


### PR DESCRIPTION
Add AMOLED black background override for T-Display panel to use pure black (0x000000) instead of dark gray (0x131313). The override is applied recursively to all UI elements and only affects the T-Display AMOLED panel when using the dark default theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic true-black background for supported AMOLED displays when using the default theme. Applies across the entire screen and all UI elements during rendering, improving contrast and potential power savings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->