### PR TITLE
feat: Implement AMOLED black theme override functionality

### DIFF
--- a/src/display/drivers/common/LV_Helper.cpp
+++ b/src/display/drivers/common/LV_Helper.cpp
@@ -19,6 +19,52 @@ static lv_indev_drv_t indev_drv;
 static lv_color_t *buf = NULL;
 static lv_color_t *buf1 = NULL;
 
+static lv_color_filter_dsc_t s_map_filter;
+static lv_style_t            s_map_style;
+static lv_theme_t            s_theme;
+static lv_theme_t           *s_parent_theme;
+
+static lv_color_t map_color_cb(const lv_color_filter_dsc_t *dsc,
+                               lv_color_t c, lv_opa_t opa)
+{
+    LV_UNUSED(dsc); LV_UNUSED(opa);
+    if (c.full == lv_color_hex(0x131313).full) {
+        return lv_color_black();
+    }
+    return c;
+}
+
+static void theme_apply_cb(lv_theme_t *th, lv_obj_t *obj)
+{
+    LV_UNUSED(th);
+    if (s_parent_theme && s_parent_theme->apply_cb) {
+        s_parent_theme->apply_cb(s_parent_theme, obj);
+    }
+
+    if (lv_obj_get_parent(obj) == NULL) {
+        lv_obj_add_style(obj, &s_map_style, 0);
+    }
+}
+
+void enable_amoled_black_theme_override(lv_disp_t *disp)
+{
+    lv_color_filter_dsc_init(&s_map_filter, map_color_cb);
+
+    lv_style_init(&s_map_style);
+    lv_style_set_color_filter_dsc(&s_map_style, &s_map_filter);
+    lv_style_set_color_filter_opa(&s_map_style, LV_OPA_COVER);
+
+    // we need to copy because of editing parent theme directly causes crash
+    s_parent_theme = lv_disp_get_theme(disp);
+    s_theme = *s_parent_theme;
+    s_theme.apply_cb = theme_apply_cb;
+
+    lv_disp_set_theme(disp, &s_theme);
+
+    // apply immediately to the current active screen
+    lv_obj_add_style(lv_scr_act(), &s_map_style, 0);
+}
+
 /* Display flushing */
 static void disp_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color_t *color_p) {
     static_cast<Display *>(disp_drv->user_data)->pushColors(area->x1, area->y1, area->x2 + 1, area->y2 + 1, (uint16_t *)color_p);

--- a/src/display/drivers/common/LV_Helper.h
+++ b/src/display/drivers/common/LV_Helper.h
@@ -11,6 +11,7 @@
 #include <Arduino.h>
 #include <lvgl.h>
 
+void enable_amoled_black_theme_override(lv_disp_t *disp);
 void beginLvglHelper(Display &board, bool debug = false);
 String lvgl_helper_get_fs_filename(String filename);
 const char *lvgl_helper_get_fs_filename(const char *filename);

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -748,6 +748,10 @@ void DefaultUI::applyTheme() {
     if (newThemeMode != currentThemeMode) {
         currentThemeMode = newThemeMode;
         ui_theme_set(currentThemeMode);
+
+        if(LilyGoTDisplayDriver::getInstance() == panelDriver && currentThemeMode == UI_THEME_DEFAULT) {
+            enable_amoled_black_theme_override(lv_disp_get_default());
+        }
     }
 }
 

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -108,7 +108,7 @@ class DefaultUI {
     int profileLoaded = 0;
     Profile currentProfileChoice{};
     std::vector<String> favoritedProfiles;
-    int currentThemeMode = 0; // Track current theme mode
+    int currentThemeMode = -1; // Force applyTheme on first loop
 
     // Screen change
     lv_obj_t **targetScreen = &ui_InitScreen;


### PR DESCRIPTION
Added a new function `enable_amoled_black_theme_override` to apply a black theme for AMOLED displays. This includes a color filter callback and a style application callback. The theme override is triggered in `DefaultUI::applyTheme` when switching to the default theme mode. Updated header files accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AMOLED black theme override for deeper blacks on supported displays.
  * Automatically applies the override when using the LilyGo T-Display driver with the default theme.
* **Refactor**
  * Adjusted initial theme state to force theme application on first launch, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->