### PR TITLE
Fix default created simple brew profile and explicitly set volumetric…

### DIFF
--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -82,6 +82,7 @@ void ProfileManager::migrate() {
     brewPhase.pumpSimple = 100;
     Target target{};
     target.type = TargetType::TARGET_TYPE_VOLUMETRIC;
+    target.operator_ = TargetOperator::GTE;
     target.value = _settings.getTargetVolume();
     brewPhase.targets.push_back(target);
     profile.phases.push_back(brewPhase);


### PR DESCRIPTION
… target operator to GTE.

The default brew profile created has no volumetric target operator set and defaults to LTE which causes the brew process to end immediately. This explicitly sets the operator to gte. Exported json from default profile:

{
  "label": "Default",
  "type": "standard",
  "description": "Default profile generated from previous settings",
  "temperature": 90,
  "phases": [
    {
      "name": "Brew",
      "phase": "brew",
      "valve": 1,
      "duration": 25,
      "temperature": 0,
      "transition": {
        "type": "instant",
        "duration": 0,
        "adaptive": false
      },
      "pump": 100,
      "targets": [
        {
          "type": "volumetric",
          **"operator": "lte",**
          "value": 36
        }
      ]
    }
  ]
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed incorrect evaluation of volumetric targets in migrated brew profiles that could occur due to an undefined comparison.
  - Ensures migrated profiles use “greater than or equal” logic for volumetric targets in the Brew phase, preventing unexpected stops or alerts.
  - Improves reliability and consistency of brews after importing older profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->