### PR TITLE
Add short timeout to switchover from BLE Volume to Estimated Volume

### DIFF
--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -85,6 +85,7 @@ class Controller {
     void onTargetChange(ProcessTarget target);
     void onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source);
     void setVolumetricOverride(bool override) { volumetricOverride = override; }
+    bool isBluetoothScaleHealthy() const;
     void onFlush();
     int getWaterLevel() const {
         float reversedLevel = static_cast<float>(settings.getEmptyTankDistance()) -
@@ -156,6 +157,10 @@ class Controller {
     bool processCompleted = false;
     bool steamReady = false;
     int error = 0;
+
+    // Bluetooth scale connection monitoring
+    unsigned long lastBluetoothMeasurement = 0;
+    static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 2000; // 2 second grace period
 
     xTaskHandle taskHandle;
 

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -160,7 +160,7 @@ class Controller {
 
     // Bluetooth scale connection monitoring
     unsigned long lastBluetoothMeasurement = 0;
-    static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 2000; // 2 second grace period
+    static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 1500; // 1.5 second grace period
 
     xTaskHandle taskHandle;
 


### PR DESCRIPTION
Adds a 1.5s delay to switchover from BLE Weight measurement to Estimated Flow measurement to help with early stops. 

Currently, switchover depends on volumetricOverride which relies on scale->isConnected() and may blip off due to BLE stack even though the communication resumes and weight measurements keep coming in. 


Tare delay increased to 200ms to allow BLE scale more time to tare at start of shot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of volumetric mode by prioritizing Bluetooth scale health over fallback estimations.
  * Reduced erroneous flow estimations when a healthy Bluetooth measurement is available.
  * Enhanced diagnostics for better issue tracing around volumetric measurements.

* **Behavior Changes**
  * Slightly increased prestart delay (only when volumetric mode is available) to improve activation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->