### PR TITLE
Celcius / Fahrenheit units selection

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -349,10 +349,10 @@ void Controller::setTargetTemp(float temperature) {
         // Update current profile
         break;
     case MODE_STEAM:
-        settings.setTargetSteamTemp(static_cast<int>(temperature));
+        settings.setTargetSteamTemp(temperature);
         break;
     case MODE_WATER:
-        settings.setTargetWaterTemp(static_cast<int>(temperature));
+        settings.setTargetWaterTemp(temperature);
         break;
     default:;
     }
@@ -401,13 +401,15 @@ void Controller::setTargetGrindVolume(double volume) {
 
 void Controller::raiseTemp() {
     float temp = getTargetTemp();
-    temp = constrain(temp + 1.0f, MIN_TEMP, MAX_TEMP);
+    float increment = settings.isTemperatureUnitFahrenheit() ? (5.0f / 9.0f) : 1.0f; // 1°F = 1/1.8°C
+    temp = constrain(temp + increment, MIN_TEMP, MAX_TEMP);
     setTargetTemp(temp);
 }
 
 void Controller::lowerTemp() {
     float temp = getTargetTemp();
-    temp = constrain(temp - 1.0f, MIN_TEMP, MAX_TEMP);
+    float increment = settings.isTemperatureUnitFahrenheit() ? (5.0f / 9.0f) : 1.0f; // 1°F = 1/1.8°C
+    temp = constrain(temp - increment, MIN_TEMP, MAX_TEMP);
     setTargetTemp(temp);
 }
 

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -6,9 +6,35 @@
 Settings::Settings() {
     preferences.begin(PREFERENCES_KEY, true);
     startupMode = preferences.getInt("sm", MODE_STANDBY);
-    targetBrewTemp = preferences.getInt("tb", 90);
-    targetSteamTemp = preferences.getInt("ts", 145);
-    targetWaterTemp = preferences.getInt("tw", 80);
+    
+    // Migrate temperature settings from int to float if needed
+    if (preferences.isKey("tb_f")) {
+        targetBrewTemp = preferences.getFloat("tb_f", 90.0f);
+    } else {
+        // Migrate from old int value
+        targetBrewTemp = static_cast<float>(preferences.getInt("tb", 90));
+        preferences.putFloat("tb_f", targetBrewTemp);
+        preferences.remove("tb");
+    }
+    
+    if (preferences.isKey("ts_f")) {
+        targetSteamTemp = preferences.getFloat("ts_f", 145.0f);
+    } else {
+        // Migrate from old int value
+        targetSteamTemp = static_cast<float>(preferences.getInt("ts", 145));
+        preferences.putFloat("ts_f", targetSteamTemp);
+        preferences.remove("ts");
+    }
+    
+    if (preferences.isKey("tw_f")) {
+        targetWaterTemp = preferences.getFloat("tw_f", 80.0f);
+    } else {
+        // Migrate from old int value
+        targetWaterTemp = static_cast<float>(preferences.getInt("tw", 80));
+        preferences.putFloat("tw_f", targetWaterTemp);
+        preferences.remove("tw");
+    }
+    
     targetDuration = preferences.getInt("td", 25000);
     targetVolume = preferences.getInt("tv", 36);
     targetGrindVolume = preferences.getDouble("tgv", 18.0);
@@ -90,17 +116,17 @@ void Settings::save(bool noDelay) {
     dirty = true;
 }
 
-void Settings::setTargetBrewTemp(const int target_brew_temp) {
+void Settings::setTargetBrewTemp(const float target_brew_temp) {
     targetBrewTemp = target_brew_temp;
     save();
 }
 
-void Settings::setTargetSteamTemp(const int target_steam_temp) {
+void Settings::setTargetSteamTemp(const float target_steam_temp) {
     targetSteamTemp = target_steam_temp;
     save();
 }
 
-void Settings::setTargetWaterTemp(const int target_water_temp) {
+void Settings::setTargetWaterTemp(const float target_water_temp) {
     targetWaterTemp = target_water_temp;
     save();
 }
@@ -421,9 +447,9 @@ void Settings::doSave() {
     ESP_LOGI("Settings", "Saving settings");
     preferences.begin(PREFERENCES_KEY, false);
     preferences.putInt("sm", startupMode);
-    preferences.putInt("tb", targetBrewTemp);
-    preferences.putInt("ts", targetSteamTemp);
-    preferences.putInt("tw", targetWaterTemp);
+    preferences.putFloat("tb_f", targetBrewTemp);
+    preferences.putFloat("ts_f", targetSteamTemp);
+    preferences.putFloat("tw_f", targetWaterTemp);
     preferences.putInt("td", targetDuration);
     preferences.putInt("tv", targetVolume);
     preferences.putDouble("tgv", targetGrindVolume);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -47,6 +47,7 @@ Settings::Settings() {
     standbyTimeout = preferences.getInt("sbt", DEFAULT_STANDBY_TIMEOUT_MS);
     timezone = preferences.getString("tz", DEFAULT_TIMEZONE);
     clock24hFormat = preferences.getBool("clk_24h", true);
+    temperatureUnitFahrenheit = preferences.getBool("temp_f", false);
     selectedProfile = preferences.getString("sp", "");
     profilesMigrated = preferences.getBool("pm", false);
     favoritedProfiles = explode(preferences.getString("fp", ""), ',');
@@ -291,6 +292,11 @@ void Settings::setClockFormat(bool clock_24h_format) {
     save();
 }
 
+void Settings::setTemperatureUnit(bool fahrenheit) {
+    this->temperatureUnitFahrenheit = fahrenheit;
+    save();
+}
+
 void Settings::setSelectedProfile(String selected_profile) {
     this->selectedProfile = std::move(selected_profile);
     save();
@@ -454,6 +460,7 @@ void Settings::doSave() {
     preferences.putString("ha_pw", homeAssistantPassword);
     preferences.putString("tz", timezone);
     preferences.putBool("clk_24h", clock24hFormat);
+    preferences.putBool("temp_f", temperatureUnitFahrenheit);
     preferences.putString("sp", selectedProfile);
     preferences.putInt("sbt", standbyTimeout);
     preferences.putBool("pm", profilesMigrated);

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -61,6 +61,7 @@ class Settings {
     bool isMomentaryButtons() const { return momentaryButtons; }
     String getTimezone() const { return timezone; }
     bool isClock24hFormat() const { return clock24hFormat; }
+    bool isTemperatureUnitFahrenheit() const { return temperatureUnitFahrenheit; }
     String getSelectedProfile() const { return selectedProfile; }
     bool isProfilesMigrated() const { return profilesMigrated; }
     std::vector<String> getFavoritedProfiles() const { return favoritedProfiles; }
@@ -121,6 +122,7 @@ class Settings {
     void setMomentaryButtons(bool momentary_buttons);
     void setTimezone(String timezone);
     void setClockFormat(bool format_24h);
+    void setTemperatureUnit(bool fahrenheit);
     void setSelectedProfile(String selected_profile);
     void setProfilesMigrated(bool profiles_migrated);
     void setFavoritedProfiles(std::vector<String> favorited_profiles);
@@ -184,6 +186,7 @@ class Settings {
     bool momentaryButtons = false;
     String timezone = DEFAULT_TIMEZONE;
     bool clock24hFormat = true;
+    bool temperatureUnitFahrenheit = false;
     String otaChannel = DEFAULT_OTA_CHANNEL;
     std::vector<String> favoritedProfiles;
     std::vector<String> profileOrder; // persisted profile ordering

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -20,9 +20,9 @@ class Settings {
     void save(bool noDelay = false);
 
     // Getters and setters
-    int getTargetBrewTemp() const { return targetBrewTemp; }
-    int getTargetSteamTemp() const { return targetSteamTemp; }
-    int getTargetWaterTemp() const { return targetWaterTemp; }
+    float getTargetBrewTemp() const { return targetBrewTemp; }
+    float getTargetSteamTemp() const { return targetSteamTemp; }
+    float getTargetWaterTemp() const { return targetWaterTemp; }
     int getTemperatureOffset() const { return temperatureOffset; }
     float getPressureScaling() const { return pressureScaling; }
     int getTargetDuration() const { return targetDuration; }
@@ -81,9 +81,9 @@ class Settings {
     int getSunriseExtBrightness() const { return sunriseExtBrightness; }
     int getEmptyTankDistance() const { return emptyTankDistance; }
     int getFullTankDistance() const { return fullTankDistance; }
-    void setTargetBrewTemp(int target_brew_temp);
-    void setTargetSteamTemp(int target_steam_temp);
-    void setTargetWaterTemp(int target_water_temp);
+    void setTargetBrewTemp(float target_brew_temp);
+    void setTargetSteamTemp(float target_steam_temp);
+    void setTargetWaterTemp(float target_water_temp);
     void setTemperatureOffset(int temperature_offset);
     void setPressureScaling(float pressure_scaling);
     void setTargetDuration(int target_duration);
@@ -151,8 +151,8 @@ class Settings {
 
     String selectedProfile;
     bool profilesMigrated = false;
-    int targetSteamTemp = 155;
-    int targetWaterTemp = 80;
+    float targetSteamTemp = 155.0f;
+    float targetWaterTemp = 80.0f;
     int temperatureOffset = DEFAULT_TEMPERATURE_OFFSET;
     float pressureScaling = DEFAULT_PRESSURE_SCALING;
     double targetGrindVolume = 18;
@@ -195,7 +195,7 @@ class Settings {
     int historyIndex = 0;
 
     // Deprecated, use profiles
-    int targetBrewTemp = 93;
+    float targetBrewTemp = 93.0f;
     int targetDuration = 25000;
     int targetVolume = 36;
     int infuseBloomTime = 0;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -87,6 +87,7 @@ void WebUIPlugin::loop() {
         doc["bta"] = controller->isVolumetricAvailable() ? 1 : 0;
         doc["bt"] = controller->isVolumetricAvailable() && controller->getSettings().isVolumetricTarget() ? 1 : 0;
         doc["led"] = controller->getSystemInfo().capabilities.ledControl;
+        doc["tempUnit"] = controller->getSettings().isTemperatureUnitFahrenheit() ? 1 : 0;
 
         Process *process = controller->getProcess();
         if (process == nullptr) {
@@ -421,6 +422,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
             if (request->hasArg("timezone"))
                 settings->setTimezone(request->arg("timezone"));
             settings->setClockFormat(request->hasArg("clock24hFormat"));
+            settings->setTemperatureUnit(request->hasArg("temperatureUnitFahrenheit"));
             if (request->hasArg("standbyTimeout"))
                 settings->setStandbyTimeout(request->arg("standbyTimeout").toInt() * 1000);
             if (request->hasArg("mainBrightness"))
@@ -487,6 +489,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["delayAdjust"] = settings.isDelayAdjust();
     doc["timezone"] = settings.getTimezone();
     doc["clock24hFormat"] = settings.isClock24hFormat();
+    doc["temperatureUnitFahrenheit"] = settings.isTemperatureUnitFahrenheit();
     doc["standbyTimeout"] = settings.getStandbyTimeout() / 1000;
     doc["mainBrightness"] = settings.getMainBrightness();
     doc["standbyBrightness"] = settings.getStandbyBrightness();

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -374,9 +374,9 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
             if (request->hasArg("startupMode"))
                 settings->setStartupMode(request->arg("startupMode") == "brew" ? MODE_BREW : MODE_STANDBY);
             if (request->hasArg("targetSteamTemp"))
-                settings->setTargetSteamTemp(request->arg("targetSteamTemp").toInt());
+                settings->setTargetSteamTemp(request->arg("targetSteamTemp").toFloat());
             if (request->hasArg("targetWaterTemp"))
-                settings->setTargetWaterTemp(request->arg("targetWaterTemp").toInt());
+                settings->setTargetWaterTemp(request->arg("targetWaterTemp").toFloat());
             if (request->hasArg("temperatureOffset"))
                 settings->setTemperatureOffset(request->arg("temperatureOffset").toInt());
             if (request->hasArg("pressureScaling"))

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -422,7 +422,8 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
             if (request->hasArg("timezone"))
                 settings->setTimezone(request->arg("timezone"));
             settings->setClockFormat(request->hasArg("clock24hFormat"));
-            settings->setTemperatureUnit(request->hasArg("temperatureUnitFahrenheit"));
+            if (request->hasArg("temperatureUnitFahrenheit"))
+                settings->setTemperatureUnit(request->arg("temperatureUnitFahrenheit") == "true");
             if (request->hasArg("standbyTimeout"))
                 settings->setStandbyTimeout(request->arg("standbyTimeout").toInt() * 1000);
             if (request->hasArg("mainBrightness"))

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -13,6 +13,7 @@
 #include <display/ui/default/lvgl/ui_theme_manager.h>
 #include <display/ui/default/lvgl/ui_themes.h>
 #include <display/ui/utils/effects.h>
+#include <display/utils/temperatureConverter.h>
 
 #include "esp_sntp.h"
 
@@ -350,51 +351,107 @@ void DefaultUI::setupReactive() {
                           &mode);
     effect_mgr.use_effect([=] { return currentScreen == ui_MenuScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_MenuScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_MenuScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_StatusScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_StatusScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_StatusScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_BrewScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_BrewScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_BrewScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_GrindScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_GrindScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_GrindScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_SimpleProcessScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_SimpleProcessScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_SimpleProcessScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_ProfileScreen; },
                           [=]() {
-                              lv_arc_set_value(uic_ProfileScreen_dials_tempGauge, currentTemp);
-                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%d°C", currentTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              // Scale gauge value to 0-160 range regardless of display unit
+                              float gaugeValue = useFahrenheit ? 
+                                  (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
+                                  currentTemp;
+                              lv_arc_set_value(uic_ProfileScreen_dials_tempGauge, gaugeValue);
+                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%d%s", 
+                                  formatTemperatureForDisplay(currentTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                           },
                           &currentTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_MenuScreen; }, [=]() { adjustTempTarget(ui_MenuScreen_dials); },
                           &targetTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_StatusScreen; },
                           [=]() {
-                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%d°C", targetTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%d%s", 
+                                  formatTemperatureForDisplay(targetTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_StatusScreen_dials);
                           },
                           &targetTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_BrewScreen; },
                           [=]() {
-                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%d°C", targetTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%d%s", 
+                                  formatTemperatureForDisplay(targetTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_BrewScreen_dials);
                           },
                           &targetTemp);
@@ -402,7 +459,11 @@ void DefaultUI::setupReactive() {
                           &targetTemp);
     effect_mgr.use_effect([=] { return currentScreen == ui_SimpleProcessScreen; },
                           [=]() {
-                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%d°C", targetTemp);
+                              const Settings &settings = controller->getSettings();
+                              bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%d%s", 
+                                  formatTemperatureForDisplay(targetTemp, useFahrenheit), 
+                                  getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_SimpleProcessScreen_dials);
                           },
                           &targetTemp);
@@ -572,7 +633,11 @@ void DefaultUI::setupReactive() {
                 const auto minutes = static_cast<int>(currentProfileChoice.getTotalDuration() / 60.0 - 0.5);
                 const auto seconds = static_cast<int>(currentProfileChoice.getTotalDuration()) % 60;
                 lv_label_set_text_fmt(ui_ProfileScreen_targetDuration2, "%2d:%02d", minutes, seconds);
-                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%d°C", static_cast<int>(currentProfileChoice.temperature));
+                const Settings &settings = controller->getSettings();
+                bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%d%s", 
+                    formatTemperatureForDisplay(currentProfileChoice.temperature, useFahrenheit), 
+                    getTemperatureUnit(useFahrenheit));
                 unsigned int phaseCount = currentProfileChoice.getPhaseCount();
                 unsigned int stepCount = currentProfileChoice.phases.size();
                 lv_label_set_text_fmt(ui_ProfileScreen_stepsLabel, "%d step%s", stepCount, stepCount > 1 ? "s" : "");
@@ -787,7 +852,22 @@ void DefaultUI::adjustDials(lv_obj_t *dials) {
 inline void DefaultUI::adjustTempTarget(lv_obj_t *dials) {
     double gaugeAngle = pressureAvailable ? 124.0 : 304;
     double gaugeStart = pressureAvailable ? 118.0 : -62;
-    double percentage = static_cast<double>(targetTemp) / 160.0;
+    
+    const Settings &settings = controller->getSettings();
+    bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
+    
+    // Calculate percentage based on appropriate temperature scale
+    // Always use 0-160 as the gauge range (equivalent to 32-320°F)
+    double percentage;
+    if (useFahrenheit) {
+        // For Fahrenheit display, we need to scale the target position to match the gauge
+        // Since gauge shows Fahrenheit values but is scaled to 0-160 range
+        float targetTempF = formatTemperatureForDisplay(targetTemp, true);
+        percentage = (targetTempF - 32.0) / (320.0 - 32.0);
+    } else {
+        percentage = static_cast<double>(targetTemp) / 160.0;
+    }
+    
     lv_obj_t *tempTarget = ui_comp_get_child(dials, UI_COMP_DIALS_TEMPTARGET);
     adjustTarget(tempTarget, percentage, gaugeStart, gaugeAngle);
 }

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -52,7 +52,7 @@ void DefaultUI::updateTempStableFlag() {
         }
 
         const float avgError = totalError / TEMP_HISTORY_LENGTH;
-        const float errorMargin = max(2.0f, static_cast<float>(targetTemp) * 0.02f);
+        const float errorMargin = max(2.0f, targetTemp * 0.02f);
 
         isTemperatureStable = avgError < errorMargin && maxError <= errorMargin;
     }
@@ -96,7 +96,7 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("boiler:targetTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
+        float newTemp = event.getFloat("value");
         if (newTemp != targetTemp) {
             targetTemp = newTemp;
             rerender = true;
@@ -310,7 +310,7 @@ void DefaultUI::setupState() {
     active = controller->isActive();
     mode = controller->getMode();
     currentTemp = static_cast<int>(controller->getCurrentTemp());
-    targetTemp = static_cast<int>(controller->getTargetTemp());
+    targetTemp = controller->getTargetTemp();
     targetDuration = controller->getTargetDuration();
     targetVolume = settings.getTargetVolume();
     grindDuration = settings.getTargetGrindDuration();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -82,7 +82,7 @@ DefaultUI::DefaultUI(Controller *controller, PluginManager *pluginManager)
 void DefaultUI::init() {
     auto triggerRender = [this](Event const &) { rerender = true; };
     pluginManager->on("boiler:currentTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
+        float newTemp = event.getFloat("value");
         if (newTemp != currentTemp) {
             currentTemp = newTemp;
             rerender = true;
@@ -309,7 +309,7 @@ void DefaultUI::setupState() {
     grindActive = controller->isGrindActive();
     active = controller->isActive();
     mode = controller->getMode();
-    currentTemp = static_cast<int>(controller->getCurrentTemp());
+    currentTemp = controller->getCurrentTemp();
     targetTemp = controller->getTargetTemp();
     targetDuration = controller->getTargetDuration();
     targetVolume = settings.getTargetVolume();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -358,7 +358,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_MenuScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -372,7 +372,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_StatusScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -386,7 +386,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_BrewScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -400,7 +400,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_GrindScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -414,7 +414,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_SimpleProcessScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -428,7 +428,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_ProfileScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%d%s", 
+                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%.0f%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -439,7 +439,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%d%s", 
+                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%.0f%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_StatusScreen_dials);
@@ -449,7 +449,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%d%s", 
+                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%.0f%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_BrewScreen_dials);
@@ -461,7 +461,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%d%s", 
+                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%.0f%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_SimpleProcessScreen_dials);
@@ -635,7 +635,7 @@ void DefaultUI::setupReactive() {
                 lv_label_set_text_fmt(ui_ProfileScreen_targetDuration2, "%2d:%02d", minutes, seconds);
                 const Settings &settings = controller->getSettings();
                 bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%d%s", 
+                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%.0f%s", 
                     formatTemperatureForDisplay(currentProfileChoice.temperature, useFahrenheit), 
                     getTemperatureUnit(useFahrenheit));
                 unsigned int phaseCount = currentProfileChoice.getPhaseCount();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -358,7 +358,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_MenuScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_MenuScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -372,7 +372,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_StatusScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_StatusScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -386,7 +386,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_BrewScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_BrewScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -400,7 +400,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_GrindScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_GrindScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -414,7 +414,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_SimpleProcessScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_SimpleProcessScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -428,7 +428,7 @@ void DefaultUI::setupReactive() {
                                   (formatTemperatureForDisplay(currentTemp, true) - 32) * 160.0f / (320.0f - 32.0f) :
                                   currentTemp;
                               lv_arc_set_value(uic_ProfileScreen_dials_tempGauge, gaugeValue);
-                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%.0f%s", 
+                              lv_label_set_text_fmt(uic_ProfileScreen_dials_tempText, "%d%s", 
                                   formatTemperatureForDisplay(currentTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                           },
@@ -439,7 +439,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%.0f%s", 
+                              lv_label_set_text_fmt(ui_StatusScreen_targetTemp, "%d%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_StatusScreen_dials);
@@ -449,7 +449,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%.0f%s", 
+                              lv_label_set_text_fmt(ui_BrewScreen_targetTemp, "%d%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_BrewScreen_dials);
@@ -461,7 +461,7 @@ void DefaultUI::setupReactive() {
                           [=]() {
                               const Settings &settings = controller->getSettings();
                               bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%.0f%s", 
+                              lv_label_set_text_fmt(ui_SimpleProcessScreen_targetTemp, "%d%s", 
                                   formatTemperatureForDisplay(targetTemp, useFahrenheit), 
                                   getTemperatureUnit(useFahrenheit));
                               adjustTempTarget(ui_SimpleProcessScreen_dials);
@@ -635,7 +635,7 @@ void DefaultUI::setupReactive() {
                 lv_label_set_text_fmt(ui_ProfileScreen_targetDuration2, "%2d:%02d", minutes, seconds);
                 const Settings &settings = controller->getSettings();
                 bool useFahrenheit = settings.isTemperatureUnitFahrenheit();
-                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%.0f%s", 
+                lv_label_set_text_fmt(ui_ProfileScreen_targetTemp2, "%d%s", 
                     formatTemperatureForDisplay(currentProfileChoice.temperature, useFahrenheit), 
                     getTemperatureUnit(useFahrenheit));
                 unsigned int phaseCount = currentProfileChoice.getPhaseCount();

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -59,7 +59,7 @@ class DefaultUI {
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
 
-    int tempHistory[TEMP_HISTORY_LENGTH] = {0};
+    float tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;
     float prevTargetTemp = 0;
     bool isTempHistoryInitialized = false;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -61,7 +61,7 @@ class DefaultUI {
 
     int tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;
-    int prevTargetTemp = 0;
+    float prevTargetTemp = 0;
     bool isTempHistoryInitialized = false;
     int isTemperatureStable = false;
     unsigned long lastTempLog = 0;
@@ -93,7 +93,7 @@ class DefaultUI {
 
     int mode = MODE_STANDBY;
     int currentTemp = 0;
-    int targetTemp = 0;
+    float targetTemp = 0;
     int targetDuration = 0;
     int targetVolume = 0;
     int grindDuration = 0;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -92,7 +92,7 @@ class DefaultUI {
     unsigned long lastRender = 0;
 
     int mode = MODE_STANDBY;
-    int currentTemp = 0;
+    float currentTemp = 0;
     float targetTemp = 0;
     int targetDuration = 0;
     int targetVolume = 0;

--- a/src/display/utils/temperatureConverter.h
+++ b/src/display/utils/temperatureConverter.h
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef TEMPERATURE_CONVERTER_H
+#define TEMPERATURE_CONVERTER_H
+
+#include <cmath>
+
+/**
+ * Convert Celsius to Fahrenheit
+ * @param celsius Temperature in Celsius
+ * @return Temperature in Fahrenheit
+ */
+inline float celsiusToFahrenheit(float celsius) {
+    return (celsius * 9.0f / 5.0f) + 32.0f;
+}
+
+/**
+ * Convert Fahrenheit to Celsius
+ * @param fahrenheit Temperature in Fahrenheit
+ * @return Temperature in Celsius
+ */
+inline float fahrenheitToCelsius(float fahrenheit) {
+    return (fahrenheit - 32.0f) * 5.0f / 9.0f;
+}
+
+/**
+ * Format temperature display with appropriate unit
+ * @param tempCelsius Temperature in Celsius (from backend)
+ * @param useFahrenheit Whether to display in Fahrenheit
+ * @param precision Number of decimal places (default: 0)
+ * @return Formatted temperature value for display
+ */
+inline int formatTemperatureForDisplay(float tempCelsius, bool useFahrenheit, int precision = 0) {
+    if (useFahrenheit) {
+        float tempF = celsiusToFahrenheit(tempCelsius);
+        return static_cast<int>(std::round(tempF));
+    }
+    return static_cast<int>(std::round(tempCelsius));
+}
+
+/**
+ * Get temperature unit symbol
+ * @param useFahrenheit Whether to use Fahrenheit
+ * @return Unit symbol
+ */
+inline const char* getTemperatureUnit(bool useFahrenheit) {
+    return useFahrenheit ? "°F" : "°C";
+}
+
+#endif // TEMPERATURE_CONVERTER_H

--- a/src/display/utils/temperatureConverter.h
+++ b/src/display/utils/temperatureConverter.h
@@ -29,12 +29,11 @@ inline float fahrenheitToCelsius(float fahrenheit) {
  * @param precision Number of decimal places (default: 0)
  * @return Formatted temperature value for display
  */
-inline int formatTemperatureForDisplay(float tempCelsius, bool useFahrenheit, int precision = 0) {
+inline float formatTemperatureForDisplay(float tempCelsius, bool useFahrenheit, int precision = 0) {
     if (useFahrenheit) {
-        float tempF = celsiusToFahrenheit(tempCelsius);
-        return static_cast<int>(std::round(tempF));
+        return celsiusToFahrenheit(tempCelsius);
     }
-    return static_cast<int>(std::round(tempCelsius));
+    return tempCelsius;
 }
 
 /**

--- a/src/display/utils/temperatureConverter.h
+++ b/src/display/utils/temperatureConverter.h
@@ -29,11 +29,13 @@ inline float fahrenheitToCelsius(float fahrenheit) {
  * @param precision Number of decimal places (default: 0)
  * @return Formatted temperature value for display
  */
-inline float formatTemperatureForDisplay(float tempCelsius, bool useFahrenheit, int precision = 0) {
+inline int formatTemperatureForDisplay(float tempCelsius, bool useFahrenheit, int precision = 0) {
     if (useFahrenheit) {
-        return celsiusToFahrenheit(tempCelsius);
+        float tempF = celsiusToFahrenheit(tempCelsius);
+        // Add 0.5 for proper rounding to handle cases like 194.999... -> 195
+        return static_cast<int>(tempF + 0.5f);
     }
-    return tempCelsius;
+    return static_cast<int>(tempCelsius + 0.5f);
 }
 
 /**

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -2,27 +2,39 @@ import { machine } from '../services/ApiService.js';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { Chart } from 'chart.js';
 import { ChartComponent } from './Chart.jsx';
+import { 
+  formatTemperatureValue, 
+  getTemperatureUnit 
+} from '../utils/temperatureConverter.js';
 
 function getChartData(data) {
   let end = new Date();
   let start = new Date(end.getTime() - 300000);
+  const useFahrenheit = machine.value.status.temperatureUnitFahrenheit;
+  
   return {
     type: 'line',
     data: {
       datasets: [
         {
-          label: 'Current Temperature',
+          label: `Current Temperature (${getTemperatureUnit(useFahrenheit)})`,
           borderColor: '#F0561D',
           pointStyle: false,
-          data: data.map(i => ({ x: i.timestamp.toISOString(), y: i.currentTemperature })),
+          data: data.map(i => ({ 
+            x: i.timestamp.toISOString(), 
+            y: formatTemperatureValue(i.currentTemperature, useFahrenheit, 1)
+          })),
         },
         {
-          label: 'Target Temperature',
+          label: `Target Temperature (${getTemperatureUnit(useFahrenheit)})`,
           fill: true,
           borderColor: '#731F00',
           borderDash: [6, 6],
           pointStyle: false,
-          data: data.map(i => ({ x: i.timestamp.toISOString(), y: i.targetTemperature })),
+          data: data.map(i => ({ 
+            x: i.timestamp.toISOString(), 
+            y: formatTemperatureValue(i.targetTemperature, useFahrenheit, 1)
+          })),
         },
         {
           label: 'Current Pressure',
@@ -92,14 +104,14 @@ function getChartData(data) {
       scales: {
         y: {
           type: 'linear',
-          min: 0,
-          max: 160,
+          min: useFahrenheit ? 32 : 0,
+          max: useFahrenheit ? 320 : 160,
           ticks: {
             font: {
               size: window.innerWidth < 640 ? 10 : 12,
             },
             callback: value => {
-              return `${value} °C`;
+              return `${value} ${getTemperatureUnit(useFahrenheit)}`;
             },
           },
         },

--- a/web/src/pages/Autotune/index.jsx
+++ b/web/src/pages/Autotune/index.jsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useCallback, useContext } from 'preact/hooks';
-import { ApiServiceContext } from '../../services/ApiService.js';
+import { ApiServiceContext, machine } from '../../services/ApiService.js';
 import { OverviewChart } from '../../components/OverviewChart.jsx';
 import { Spinner } from '../../components/Spinner.jsx';
 import Card from '../../components/Card.jsx';
+import { 
+  formatTemperatureValue, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
 
 export function Autotune() {
   const apiService = useContext(ApiServiceContext);
@@ -78,7 +82,7 @@ export function Autotune() {
             <div className='space-y-4'>
               <div className='alert alert-warning'>
                 <span>
-                  Please ensure the boiler temperature is below 50°C before starting the autotune
+                  Please ensure the boiler temperature is below {formatTemperatureValue(50, machine.value.status.temperatureUnitFahrenheit, 0)} before starting the autotune
                   process.
                 </span>
               </div>

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -12,6 +12,10 @@ import { faRectangleList } from '@fortawesome/free-solid-svg-icons/faRectangleLi
 import { faTint } from '@fortawesome/free-solid-svg-icons/faTint';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
+import { 
+  formatTemperature, 
+  formatTemperatureValue 
+} from '../../utils/temperatureConverter.js';
 
 const status = computed(() => machine.value.status);
 
@@ -178,11 +182,10 @@ const ProcessControls = props => {
         <div className='flex flex-row items-center gap-2 text-center text-base sm:text-left sm:text-lg'>
           <FontAwesomeIcon icon={faThermometerHalf} className='text-base-content/60' />
           <span className='text-base-content'>
-            {status.value.currentTemperature.toFixed(1) || 0}
+            {formatTemperatureValue(status.value.currentTemperature, status.value.temperatureUnitFahrenheit, 1)}
           </span>
           <span className='text-success font-semibold'>
-            {' '}
-            / {status.value.targetTemperature || 0}°C
+            / {formatTemperature(status.value.targetTemperature, status.value.temperatureUnitFahrenheit)}
           </span>
         </div>
         <div className='flex flex-row items-center gap-2 text-center text-base sm:text-right sm:text-lg'>

--- a/web/src/pages/ProfileEdit/ExtendedPhase.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedPhase.jsx
@@ -1,11 +1,25 @@
 import { ExtendedPhaseTarget, TargetTypes } from './ExtendedPhaseTarget.jsx';
 import { isNumber } from 'chart.js/helpers';
-import { useCallback } from 'preact/hooks';
+import { useCallback, useEffect } from 'preact/hooks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { 
+  convertCelsiusToDisplay, 
+  convertInputToCelsius, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
+import { machine } from '../../services/ApiService.js';
 
 export function ExtendedPhase({ phase, index, onChange, onRemove, pressureAvailable }) {
+  // Load settings on component mount
+  useEffect(() => {
+  }, []);
+
   const onFieldChange = (field, value) => {
+    // Handle temperature conversion for temperature field
+    if (field === 'temperature') {
+      value = convertInputToCelsius(value, machine.value.status.temperatureUnitFahrenheit);
+    }
     onChange({
       ...phase,
       [field]: value,
@@ -111,7 +125,7 @@ export function ExtendedPhase({ phase, index, onChange, onRemove, pressureAvaila
         </div>
         <div className='form-control'>
           <label htmlFor={`phase-${index}-temperature`} className='mb-2 block text-sm font-medium'>
-            Temperature (0 = Default)
+            Temperature (0 = Default) ({getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)})
           </label>
           <div className='input-group'>
             <label htmlFor={`phase-${index}-temperature`} className='input w-full'>
@@ -119,13 +133,15 @@ export function ExtendedPhase({ phase, index, onChange, onRemove, pressureAvaila
                 id={`phase-${index}-target`}
                 className='grow'
                 type='number'
-                value={phase.temperature || 0}
-                onChange={e => onFieldChange('temperature', parseFloat(e.target.value))}
+                value={convertCelsiusToDisplay(phase.temperature || 0, machine.value.status.temperatureUnitFahrenheit)}
+                onChange={e => onFieldChange('temperature', parseFloat(e.target.value) || 0)}
                 aria-label='Target temperature'
                 min='0'
                 step='0.1'
               />
-              <span aria-label='celsius'>°C</span>
+              <span aria-label={machine.value.status.temperatureUnitFahrenheit ? 'fahrenheit' : 'celsius'}>
+                {getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)}
+              </span>
             </label>
           </div>
         </div>

--- a/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
@@ -1,19 +1,33 @@
 import Card from '../../components/Card.jsx';
 import { Spinner } from '../../components/Spinner.jsx';
 import { ExtendedProfileChart } from '../../components/ExtendedProfileChart.jsx';
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { ExtendedPhase } from './ExtendedPhase.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+import { 
+  convertCelsiusToDisplay, 
+  convertInputToCelsius, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
+import { machine } from '../../services/ApiService.js';
 
 export function ExtendedProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
   const [currentPhaseIndex, setCurrentPhaseIndex] = useState(0);
 
+  // Load settings on component mount
+  useEffect(() => {
+  }, []);
+
   const onFieldChange = (field, value) => {
+    // Handle temperature conversion for temperature field
+    if (field === 'temperature') {
+      value = convertInputToCelsius(value, machine.value.status.temperatureUnitFahrenheit);
+    }
     onChange({
       ...data,
       [field]: value,
@@ -105,7 +119,7 @@ export function ExtendedProfileForm(props) {
           </div>
           <div className='form-control'>
             <label htmlFor='temperature' className='mb-2 block text-sm font-medium'>
-              Temperature
+              Temperature ({getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)})
             </label>
             <div className='input-group'>
               <label htmlFor='temperature' className='input w-full'>
@@ -114,14 +128,16 @@ export function ExtendedProfileForm(props) {
                   name='temperature'
                   type='number'
                   className='grow'
-                  value={data?.temperature}
+                  value={convertCelsiusToDisplay(data?.temperature, machine.value.status.temperatureUnitFahrenheit)}
                   onChange={e => onFieldChange('temperature', e.target.value)}
-                  aria-label='Temperature in degrees Celsius'
+                  aria-label={`Temperature in degrees ${machine.value.status.temperatureUnitFahrenheit ? 'Fahrenheit' : 'Celsius'}`}
                   min='0'
-                  max='150'
+                  max={machine.value.status.temperatureUnitFahrenheit ? '302' : '150'}
                   step='0.1'
                 />
-                <span aria-label='degrees Celsius'>°C</span>
+                <span aria-label={`degrees ${machine.value.status.temperatureUnitFahrenheit ? 'Fahrenheit' : 'Celsius'}`}>
+                  {getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)}
+                </span>
               </label>
             </div>
           </div>

--- a/web/src/pages/ProfileEdit/StandardProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/StandardProfileForm.jsx
@@ -5,11 +5,27 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+import { useEffect } from 'preact/hooks';
+import { 
+  convertCelsiusToDisplay, 
+  convertInputToCelsius, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
+import { machine } from '../../services/ApiService.js';
 
 export function StandardProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
 
+  // Load settings on component mount
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
   const onFieldChange = (field, value) => {
+    // Handle temperature conversion for temperature field
+    if (field === 'temperature') {
+      value = convertInputToCelsius(value, machine.value.status.temperatureUnitFahrenheit);
+    }
     onChange({
       ...data,
       [field]: value,
@@ -92,7 +108,7 @@ export function StandardProfileForm(props) {
           </div>
           <div className='form-control'>
             <label htmlFor='temperature' className='mb-2 block text-sm font-medium'>
-              Temperature
+              Temperature ({getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)})
             </label>
             <div className='input-group'>
               <label htmlFor='temperature' className='input w-full'>
@@ -101,14 +117,16 @@ export function StandardProfileForm(props) {
                   name='temperature'
                   type='number'
                   className='grow'
-                  value={data?.temperature}
+                  value={convertCelsiusToDisplay(data?.temperature, machine.value.status.temperatureUnitFahrenheit)}
                   onChange={e => onFieldChange('temperature', e.target.value)}
-                  aria-label='Temperature in degrees Celsius'
+                  aria-label={`Temperature in degrees ${machine.value.status.temperatureUnitFahrenheit ? 'Fahrenheit' : 'Celsius'}`}
                   min='0'
-                  max='150'
+                  max={machine.value.status.temperatureUnitFahrenheit ? '302' : '150'}
                   step='0.1'
                 />
-                <span aria-label='degrees Celsius'>°C</span>
+                <span aria-label={`degrees ${machine.value.status.temperatureUnitFahrenheit ? 'Fahrenheit' : 'Celsius'}`}>
+                  {getTemperatureUnit(machine.value.status.temperatureUnitFahrenheit)}
+                </span>
               </label>
             </div>
           </div>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -149,6 +149,9 @@ export function Settings() {
       const formDataToSubmit = new FormData(form);
       formDataToSubmit.set('steamPumpPercentage', formData.steamPumpPercentage);
       
+      // Explicitly set the temperature unit boolean value
+      formDataToSubmit.set('temperatureUnitFahrenheit', formData.temperatureUnitFahrenheit ? 'true' : 'false');
+      
       // Convert temperature values to Celsius for backend
       formDataToSubmit.set('targetSteamTemp', 
         convertInputToCelsius(formData.targetSteamTemp, formData.temperatureUnitFahrenheit));

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -12,6 +12,11 @@ import { downloadJson } from '../../utils/download.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
+import { 
+  convertCelsiusToDisplay, 
+  convertInputToCelsius, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
 const pressureAvailable = computed(() => machine.value.capabilities.pressure);
@@ -40,6 +45,19 @@ export function Settings() {
             ? fetchedSettings.standbyDisplayEnabled
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
+        // Convert temperature values for display based on user preference
+        targetSteamTemp: convertCelsiusToDisplay(
+          fetchedSettings.targetSteamTemp, 
+          fetchedSettings.temperatureUnitFahrenheit
+        ),
+        targetWaterTemp: convertCelsiusToDisplay(
+          fetchedSettings.targetWaterTemp, 
+          fetchedSettings.temperatureUnitFahrenheit
+        ),
+        temperatureOffset: convertCelsiusToDisplay(
+          fetchedSettings.temperatureOffset, 
+          fetchedSettings.temperatureUnitFahrenheit
+        ),
       };
       setFormData(settingsWithToggle);
     } else {
@@ -79,6 +97,27 @@ export function Settings() {
       if (key === 'clock24hFormat') {
         value = !formData.clock24hFormat;
       }
+      if (key === 'temperatureUnitFahrenheit') {
+        const newUseFahrenheit = !formData.temperatureUnitFahrenheit;
+        // Convert existing temperature values when unit changes
+        setFormData({
+          ...formData,
+          temperatureUnitFahrenheit: newUseFahrenheit,
+          targetSteamTemp: convertCelsiusToDisplay(
+            convertInputToCelsius(formData.targetSteamTemp, formData.temperatureUnitFahrenheit),
+            newUseFahrenheit
+          ),
+          targetWaterTemp: convertCelsiusToDisplay(
+            convertInputToCelsius(formData.targetWaterTemp, formData.temperatureUnitFahrenheit),
+            newUseFahrenheit
+          ),
+          temperatureOffset: convertCelsiusToDisplay(
+            convertInputToCelsius(formData.temperatureOffset, formData.temperatureUnitFahrenheit),
+            newUseFahrenheit
+          ),
+        });
+        return;
+      }
       if (key === 'standbyDisplayEnabled') {
         value = !formData.standbyDisplayEnabled;
         // Set standby brightness to 0 when toggle is off
@@ -109,6 +148,14 @@ export function Settings() {
       const form = formRef.current;
       const formDataToSubmit = new FormData(form);
       formDataToSubmit.set('steamPumpPercentage', formData.steamPumpPercentage);
+      
+      // Convert temperature values to Celsius for backend
+      formDataToSubmit.set('targetSteamTemp', 
+        convertInputToCelsius(formData.targetSteamTemp, formData.temperatureUnitFahrenheit));
+      formDataToSubmit.set('targetWaterTemp', 
+        convertInputToCelsius(formData.targetWaterTemp, formData.temperatureUnitFahrenheit));
+      formDataToSubmit.set('temperatureOffset', 
+        convertInputToCelsius(formData.temperatureOffset, formData.temperatureUnitFahrenheit));
 
       // Ensure standbyBrightness is included even when the field is disabled
       if (!formData.standbyDisplayEnabled) {
@@ -129,6 +176,19 @@ export function Settings() {
       const updatedData = {
         ...data,
         standbyDisplayEnabled: data.standbyBrightness > 0 ? formData.standbyDisplayEnabled : false,
+        // Convert temperature values for display based on user preference
+        targetSteamTemp: convertCelsiusToDisplay(
+          data.targetSteamTemp, 
+          data.temperatureUnitFahrenheit
+        ),
+        targetWaterTemp: convertCelsiusToDisplay(
+          data.targetWaterTemp, 
+          data.temperatureUnitFahrenheit
+        ),
+        temperatureOffset: convertCelsiusToDisplay(
+          data.temperatureOffset, 
+          data.temperatureUnitFahrenheit
+        ),
       };
 
       setFormData(updatedData);
@@ -192,15 +252,33 @@ export function Settings() {
         <div className='grid grid-cols-1 gap-4 lg:grid-cols-10'>
           <Card sm={10} lg={5} title='Temperature settings'>
             <div className='form-control'>
+              <label className='label cursor-pointer'>
+                <span className='label-text'>Temperature Unit</span>
+                <div className='flex items-center gap-2'>
+                  <span className={`text-sm ${!formData.temperatureUnitFahrenheit ? 'font-bold' : ''}`}>°C</span>
+                  <input
+                    id='temperatureUnitFahrenheit'
+                    name='temperatureUnitFahrenheit'
+                    value='temperatureUnitFahrenheit'
+                    type='checkbox'
+                    className='toggle toggle-primary'
+                    checked={!!formData.temperatureUnitFahrenheit}
+                    onChange={onChange('temperatureUnitFahrenheit')}
+                  />
+                  <span className={`text-sm ${formData.temperatureUnitFahrenheit ? 'font-bold' : ''}`}>°F</span>
+                </div>
+              </label>
+            </div>
+            <div className='form-control'>
               <label htmlFor='targetSteamTemp' className='mb-2 block text-sm font-medium'>
-                Default Steam Temperature (°C)
+                Default Steam Temperature ({getTemperatureUnit(formData.temperatureUnitFahrenheit)})
               </label>
               <input
                 id='targetSteamTemp'
                 name='targetSteamTemp'
                 type='number'
                 className='input input-bordered w-full'
-                placeholder='135'
+                placeholder={formData.temperatureUnitFahrenheit ? '275' : '135'}
                 value={formData.targetSteamTemp}
                 onChange={onChange('targetSteamTemp')}
               />
@@ -208,14 +286,14 @@ export function Settings() {
 
             <div className='form-control'>
               <label htmlFor='targetWaterTemp' className='mb-2 block text-sm font-medium'>
-                Default Water Temperature (°C)
+                Default Water Temperature ({getTemperatureUnit(formData.temperatureUnitFahrenheit)})
               </label>
               <input
                 id='targetWaterTemp'
                 name='targetWaterTemp'
                 type='number'
                 className='input input-bordered w-full'
-                placeholder='80'
+                placeholder={formData.temperatureUnitFahrenheit ? '176' : '80'}
                 value={formData.targetWaterTemp}
                 onChange={onChange('targetWaterTemp')}
               />
@@ -256,6 +334,7 @@ export function Settings() {
                 onChange={onChange('standbyTimeout')}
               />
             </div>
+
 
             <div className='divider'>Predictive scale delay</div>
             <div className='mb-2 text-sm opacity-70'>
@@ -488,7 +567,7 @@ export function Settings() {
 
             <div className='form-control'>
               <label htmlFor='temperatureOffset' className='mb-2 block text-sm font-medium'>
-                Temperature Offset
+                Temperature Offset ({getTemperatureUnit(formData.temperatureUnitFahrenheit)})
               </label>
               <input
                 id='temperatureOffset'
@@ -496,7 +575,7 @@ export function Settings() {
                 type='number'
                 inputMode='decimal'
                 className='input input-bordered w-full'
-                placeholder='0 °C'
+                placeholder={formData.temperatureUnitFahrenheit ? '0 °F' : '0 °C'}
                 min='0'
                 step='any'
                 value={formData.temperatureOffset}

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -100,8 +100,6 @@ function getChartData(data) {
       scales: {
         y: {
           type: 'linear',
-          min: useFahrenheit ? 32 : 0,
-          max: useFahrenheit ? 320 : 160,
           ticks: {
             callback: value => {
               return `${value} ${getTemperatureUnit(useFahrenheit)}`;

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -1,25 +1,38 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { ChartComponent } from '../../components/Chart.jsx';
+import { 
+  formatTemperatureValue, 
+  getTemperatureUnit 
+} from '../../utils/temperatureConverter.js';
+import { machine } from '../../services/ApiService.js';
 
 function getChartData(data) {
   let start = 0;
+  const useFahrenheit = machine.value.status.temperatureUnitFahrenheit;
+  
   return {
     type: 'line',
     data: {
       datasets: [
         {
-          label: 'Current Temperature',
+          label: `Current Temperature (${getTemperatureUnit(useFahrenheit)})`,
           borderColor: '#F0561D',
           pointStyle: false,
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.ct })),
+          data: data.map((i, idx) => ({ 
+            x: (i.t / 1000).toFixed(1), 
+            y: formatTemperatureValue(i.ct, useFahrenheit, 1)
+          })),
         },
         {
-          label: 'Target Temperature',
+          label: `Target Temperature (${getTemperatureUnit(useFahrenheit)})`,
           fill: true,
           borderColor: '#731F00',
           borderDash: [6, 6],
           pointStyle: false,
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.tt })),
+          data: data.map((i, idx) => ({ 
+            x: (i.t / 1000).toFixed(1), 
+            y: formatTemperatureValue(i.tt, useFahrenheit, 1)
+          })),
         },
         {
           label: 'Current Pressure',
@@ -87,9 +100,11 @@ function getChartData(data) {
       scales: {
         y: {
           type: 'linear',
+          min: useFahrenheit ? 32 : 0,
+          max: useFahrenheit ? 320 : 160,
           ticks: {
             callback: value => {
-              return `${value} °C`;
+              return `${value} ${getTemperatureUnit(useFahrenheit)}`;
             },
             font: {
               size: window.innerWidth < 640 ? 10 : 12,

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -165,6 +165,7 @@ export default class ApiService {
       brewTarget: message.bt || 0,
       volumetricAvailable: message.bta || false,
       process: message.process || null,
+      temperatureUnitFahrenheit: message.tempUnit || false,
       timestamp: new Date(),
     };
     const historyEntry = { ...newStatus };
@@ -199,6 +200,7 @@ export const machine = signal({
     mode: 0,
     selectedProfile: '',
     process: null,
+    temperatureUnitFahrenheit: false,
   },
   capabilities: {
     pressure: false,

--- a/web/src/utils/temperatureConverter.js
+++ b/web/src/utils/temperatureConverter.js
@@ -6,19 +6,19 @@
 /**
  * Convert Celsius to Fahrenheit
  * @param {number} celsius - Temperature in Celsius
- * @returns {number} Temperature in Fahrenheit
+ * @returns {number} Temperature in Fahrenheit (rounded to nearest integer)
  */
 export function celsiusToFahrenheit(celsius) {
-  return (celsius * 9) / 5 + 32;
+  return Math.round((celsius * 9) / 5 + 32);
 }
 
 /**
  * Convert Fahrenheit to Celsius
  * @param {number} fahrenheit - Temperature in Fahrenheit
- * @returns {number} Temperature in Celsius
+ * @returns {number} Temperature in Celsius (rounded to nearest integer)
  */
 export function fahrenheitToCelsius(fahrenheit) {
-  return ((fahrenheit - 32) * 5) / 9;
+  return Math.round(((fahrenheit - 32) * 5) / 9);
 }
 
 /**
@@ -39,7 +39,7 @@ export function formatTemperature(tempCelsius, useFahrenheit = false, precision 
     return `0${unit}`;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
   const unit = useFahrenheit ? '°F' : '°C';
   
   return `${temp.toFixed(precision)}${unit}`;
@@ -62,7 +62,7 @@ export function formatTemperatureValue(tempCelsius, useFahrenheit = false, preci
     return 0;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
   return Number(temp.toFixed(precision));
 }
 
@@ -112,5 +112,5 @@ export function convertCelsiusToDisplay(tempCelsius, displayInFahrenheit = false
     return 0;
   }
   
-  return displayInFahrenheit ? Math.round(celsiusToFahrenheit(tempCelsius)) : tempCelsius;
+  return displayInFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
 }

--- a/web/src/utils/temperatureConverter.js
+++ b/web/src/utils/temperatureConverter.js
@@ -33,6 +33,12 @@ export function formatTemperature(tempCelsius, useFahrenheit = false, precision 
     return useFahrenheit ? '0°F' : '0°C';
   }
   
+  // Special case: 0 means "default" regardless of temperature unit
+  if (tempCelsius === 0) {
+    const unit = useFahrenheit ? '°F' : '°C';
+    return `0${unit}`;
+  }
+  
   const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
   const unit = useFahrenheit ? '°F' : '°C';
   
@@ -48,6 +54,11 @@ export function formatTemperature(tempCelsius, useFahrenheit = false, precision 
  */
 export function formatTemperatureValue(tempCelsius, useFahrenheit = false, precision = 0) {
   if (tempCelsius === null || tempCelsius === undefined) {
+    return 0;
+  }
+  
+  // Special case: 0 means "default" regardless of temperature unit
+  if (tempCelsius === 0) {
     return 0;
   }
   
@@ -75,7 +86,14 @@ export function convertInputToCelsius(inputTemp, inputInFahrenheit = false) {
     return 0;
   }
   
-  return inputInFahrenheit ? fahrenheitToCelsius(Number(inputTemp)) : Number(inputTemp);
+  const numTemp = Number(inputTemp);
+  
+  // Special case: 0 means "default" regardless of temperature unit
+  if (numTemp === 0) {
+    return 0;
+  }
+  
+  return inputInFahrenheit ? fahrenheitToCelsius(numTemp) : numTemp;
 }
 
 /**
@@ -86,6 +104,11 @@ export function convertInputToCelsius(inputTemp, inputInFahrenheit = false) {
  */
 export function convertCelsiusToDisplay(tempCelsius, displayInFahrenheit = false) {
   if (tempCelsius === null || tempCelsius === undefined) {
+    return 0;
+  }
+  
+  // Special case: 0 means "default" regardless of temperature unit
+  if (tempCelsius === 0) {
     return 0;
   }
   

--- a/web/src/utils/temperatureConverter.js
+++ b/web/src/utils/temperatureConverter.js
@@ -57,7 +57,7 @@ export function formatTemperature(tempCelsius, useFahrenheit = false, precision 
     return `0${unit}`;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheitDisplay(tempCelsius) : Math.round(tempCelsius);
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
   const unit = useFahrenheit ? '°F' : '°C';
   
   return `${temp.toFixed(precision)}${unit}`;
@@ -80,7 +80,7 @@ export function formatTemperatureValue(tempCelsius, useFahrenheit = false, preci
     return 0;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheitDisplay(tempCelsius) : Math.round(tempCelsius);
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
   return Number(temp.toFixed(precision));
 }
 

--- a/web/src/utils/temperatureConverter.js
+++ b/web/src/utils/temperatureConverter.js
@@ -6,19 +6,37 @@
 /**
  * Convert Celsius to Fahrenheit
  * @param {number} celsius - Temperature in Celsius
- * @returns {number} Temperature in Fahrenheit (rounded to nearest integer)
+ * @returns {number} Temperature in Fahrenheit (full precision)
  */
 export function celsiusToFahrenheit(celsius) {
-  return Math.round((celsius * 9) / 5 + 32);
+  return (celsius * 9) / 5 + 32;
 }
 
 /**
  * Convert Fahrenheit to Celsius
  * @param {number} fahrenheit - Temperature in Fahrenheit
- * @returns {number} Temperature in Celsius (rounded to nearest integer)
+ * @returns {number} Temperature in Celsius (full precision)
  */
 export function fahrenheitToCelsius(fahrenheit) {
-  return Math.round(((fahrenheit - 32) * 5) / 9);
+  return ((fahrenheit - 32) * 5) / 9;
+}
+
+/**
+ * Convert Celsius to Fahrenheit for display (rounded)
+ * @param {number} celsius - Temperature in Celsius
+ * @returns {number} Temperature in Fahrenheit (rounded to nearest integer)
+ */
+export function celsiusToFahrenheitDisplay(celsius) {
+  return Math.round(celsiusToFahrenheit(celsius));
+}
+
+/**
+ * Convert Fahrenheit to Celsius for display (rounded)
+ * @param {number} fahrenheit - Temperature in Fahrenheit
+ * @returns {number} Temperature in Celsius (rounded to nearest integer)
+ */
+export function fahrenheitToCelsiusDisplay(fahrenheit) {
+  return Math.round(fahrenheitToCelsius(fahrenheit));
 }
 
 /**
@@ -39,7 +57,7 @@ export function formatTemperature(tempCelsius, useFahrenheit = false, precision 
     return `0${unit}`;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
+  const temp = useFahrenheit ? celsiusToFahrenheitDisplay(tempCelsius) : Math.round(tempCelsius);
   const unit = useFahrenheit ? '°F' : '°C';
   
   return `${temp.toFixed(precision)}${unit}`;
@@ -62,7 +80,7 @@ export function formatTemperatureValue(tempCelsius, useFahrenheit = false, preci
     return 0;
   }
   
-  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
+  const temp = useFahrenheit ? celsiusToFahrenheitDisplay(tempCelsius) : Math.round(tempCelsius);
   return Number(temp.toFixed(precision));
 }
 
@@ -112,5 +130,5 @@ export function convertCelsiusToDisplay(tempCelsius, displayInFahrenheit = false
     return 0;
   }
   
-  return displayInFahrenheit ? celsiusToFahrenheit(tempCelsius) : Math.round(tempCelsius);
+  return displayInFahrenheit ? celsiusToFahrenheitDisplay(tempCelsius) : Math.round(tempCelsius);
 }

--- a/web/src/utils/temperatureConverter.js
+++ b/web/src/utils/temperatureConverter.js
@@ -1,0 +1,93 @@
+/**
+ * Temperature conversion utilities
+ * All backend operations use Celsius, frontend can display in Fahrenheit
+ */
+
+/**
+ * Convert Celsius to Fahrenheit
+ * @param {number} celsius - Temperature in Celsius
+ * @returns {number} Temperature in Fahrenheit
+ */
+export function celsiusToFahrenheit(celsius) {
+  return (celsius * 9) / 5 + 32;
+}
+
+/**
+ * Convert Fahrenheit to Celsius
+ * @param {number} fahrenheit - Temperature in Fahrenheit
+ * @returns {number} Temperature in Celsius
+ */
+export function fahrenheitToCelsius(fahrenheit) {
+  return ((fahrenheit - 32) * 5) / 9;
+}
+
+/**
+ * Format temperature display with appropriate unit
+ * @param {number} tempCelsius - Temperature in Celsius (from backend)
+ * @param {boolean} useFahrenheit - Whether to display in Fahrenheit
+ * @param {number} precision - Number of decimal places (default: 0)
+ * @returns {string} Formatted temperature with unit
+ */
+export function formatTemperature(tempCelsius, useFahrenheit = false, precision = 0) {
+  if (tempCelsius === null || tempCelsius === undefined) {
+    return useFahrenheit ? '0°F' : '0°C';
+  }
+  
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
+  const unit = useFahrenheit ? '°F' : '°C';
+  
+  return `${temp.toFixed(precision)}${unit}`;
+}
+
+/**
+ * Format temperature value only (no unit)
+ * @param {number} tempCelsius - Temperature in Celsius (from backend)
+ * @param {boolean} useFahrenheit - Whether to display in Fahrenheit
+ * @param {number} precision - Number of decimal places (default: 0)
+ * @returns {number} Temperature value
+ */
+export function formatTemperatureValue(tempCelsius, useFahrenheit = false, precision = 0) {
+  if (tempCelsius === null || tempCelsius === undefined) {
+    return 0;
+  }
+  
+  const temp = useFahrenheit ? celsiusToFahrenheit(tempCelsius) : tempCelsius;
+  return Number(temp.toFixed(precision));
+}
+
+/**
+ * Get temperature unit symbol
+ * @param {boolean} useFahrenheit - Whether to use Fahrenheit
+ * @returns {string} Unit symbol
+ */
+export function getTemperatureUnit(useFahrenheit = false) {
+  return useFahrenheit ? '°F' : '°C';
+}
+
+/**
+ * Convert input temperature to Celsius for backend
+ * @param {number} inputTemp - Temperature from user input
+ * @param {boolean} inputInFahrenheit - Whether the input is in Fahrenheit
+ * @returns {number} Temperature in Celsius
+ */
+export function convertInputToCelsius(inputTemp, inputInFahrenheit = false) {
+  if (inputTemp === null || inputTemp === undefined || inputTemp === '') {
+    return 0;
+  }
+  
+  return inputInFahrenheit ? fahrenheitToCelsius(Number(inputTemp)) : Number(inputTemp);
+}
+
+/**
+ * Convert Celsius from backend to display units for input fields
+ * @param {number} tempCelsius - Temperature in Celsius (from backend)
+ * @param {boolean} displayInFahrenheit - Whether to display in Fahrenheit
+ * @returns {number} Temperature in display units
+ */
+export function convertCelsiusToDisplay(tempCelsius, displayInFahrenheit = false) {
+  if (tempCelsius === null || tempCelsius === undefined) {
+    return 0;
+  }
+  
+  return displayInFahrenheit ? Math.round(celsiusToFahrenheit(tempCelsius)) : tempCelsius;
+}


### PR DESCRIPTION
Front end
Added a toggle in the settings to select units (C / F). 
Modified Web UI and Touch UI. Conversions are done on the front-end

Back end
Changed steam/water/offset temp setpoints to floats
Modified raise/lower controller function to use a dynamic offset based on units

<img width="1867" height="741" alt="image" src="https://github.com/user-attachments/assets/6b6d4c9d-f0a5-4744-a2c7-aa905883a32c" />

<img width="901" height="373" alt="image" src="https://github.com/user-attachments/assets/46938337-28e2-4cfb-9220-53b9e8c29272" />

<img width="1018" height="1281" alt="image" src="https://github.com/user-attachments/assets/4099f6ac-9c7e-4a1c-9d07-74ab409f05bd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Add selectable Celsius/Fahrenheit unit across device UI and web app; displays and inputs show the chosen unit.
  - Temperature unit appears in web API/status and can be changed from Settings.

- Improvements
  - Target temperatures now support fractional values and smoother, unit-aware adjustments.
  - Gauges, charts, and labels dynamically scale and format for the active unit.
  - Automatic migration of existing temperature settings to the new format.

- Bug Fixes
  - Enhanced UI validation to reduce invalid status/update races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->