### PR TITLE
fix: Update version comparison logic to allow updates from nightly to stable

### DIFF
--- a/lib/OTA/src/common.cpp
+++ b/lib/OTA/src/common.cpp
@@ -95,7 +95,9 @@ void print_update_result(Updater updater, HTTPUpdateResult result, const char *T
 bool update_required(semver_t _new_version, semver_t _current_version) {
     ESP_LOGI("update_required", "Comparing versions %s > %s", render_to_string(_new_version).c_str(),
              render_to_string(_current_version).c_str());
-    return _new_version > _current_version;
+    // Allow updates if new version is greater OR if versions are different and current is prerelease
+    return semver_gt(_new_version, _current_version) || 
+           (semver_neq(_new_version, _current_version) && _current_version.prerelease != nullptr);
 }
 
 void update_started() { ESP_LOGI("update_started", "HTTP update process started\n"); }


### PR DESCRIPTION
llow OTA updates from nightly builds to stable releases by permitting updates when the current version is a prerelease (nightly) and versions differ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTA update detection using semantic versioning for more accurate version comparisons.
  * Ensures devices on prerelease builds correctly update to stable or newer versions.
  * Reduces instances where valid updates were incorrectly skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->