### PR TITLE
Add profile chart under WebUI

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -73,6 +73,7 @@ void WebUIPlugin::loop() {
         doc["pt"] = controller->getTargetPressure();
         doc["m"] = controller->getMode();
         doc["p"] = controller->getProfileManager()->getSelectedProfile().label;
+        doc["puid"] = controller->getProfileManager()->getSelectedProfile().id;
         doc["cp"] = controller->getSystemInfo().capabilities.pressure;
         doc["cd"] = controller->getSystemInfo().capabilities.dimming;
         doc["bta"] = controller->isVolumetricAvailable() ? 1 : 0;

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -85,11 +85,11 @@ const ProcessControls = props => {
   const [profileData, setProfileData] = useState(null);
   const [profileLoading, setProfileLoading] = useState(false);
 
-  // Fetch profile data when selectedProfile changes
+  // Fetch profile data when selectedProfileId changes
   useEffect(() => {
-    const selectedProfile = status.value.selectedProfile;
+    const selectedProfileId = status.value.selectedProfileId;
     
-    if (!selectedProfile || !apiService) {
+    if (!selectedProfileId || !apiService) {
       setProfileData(null);
       return;
     }
@@ -97,16 +97,9 @@ const ProcessControls = props => {
     const fetchProfile = async () => {
       try {
         setProfileLoading(true);
-        // First get the list of profiles to find the ID for the selected profile
-        const profilesResponse = await apiService.request({ tp: 'req:profiles:list' });
-        const profile = profilesResponse.profiles.find(p => 
-          p.label === selectedProfile || 
-          (p.selected && p.label === selectedProfile)
-        );
-        
-        if (profile && profile.type === 'pro') {
-          // Load the full profile data with phases
-          const profileResponse = await apiService.request({ tp: 'req:profiles:load', id: profile.id });
+        // Load profile directly by ID
+        const profileResponse = await apiService.request({ tp: 'req:profiles:load', id: selectedProfileId });
+        if (profileResponse.profile && profileResponse.profile.type === 'pro') {
           setProfileData(profileResponse.profile);
         } else {
           setProfileData(null);
@@ -120,7 +113,7 @@ const ProcessControls = props => {
     };
 
     fetchProfile();
-  }, [status.value.selectedProfile, apiService]);
+  }, [status.value.selectedProfileId, apiService]);
 
   // Determine if we should show expanded view
   const shouldExpand = brew && (active || finished || (brew && !active && !finished));
@@ -242,7 +235,7 @@ const ProcessControls = props => {
             </span>
             <FontAwesomeIcon icon={faRectangleList} className='text-base-content/60 text-xl' />
           </a>
-          {status.value.selectedProfile && (
+          {status.value.selectedProfileId && (
             <div className='mb-2'>
               {profileLoading && (
                 <div className="flex items-center justify-center max-h-20 w-full">

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -85,9 +85,10 @@ const ProcessControls = props => {
   const [profileData, setProfileData] = useState(null);
   const [profileLoading, setProfileLoading] = useState(false);
 
-  // Fetch profile data when selectedProfileId changes
+  // Fetch profile data when selectedProfileId or selectedProfile changes
   useEffect(() => {
     const selectedProfileId = status.value.selectedProfileId;
+    const selectedProfileName = status.value.selectedProfile;
     
     if (!selectedProfileId || !apiService) {
       setProfileData(null);
@@ -113,7 +114,7 @@ const ProcessControls = props => {
     };
 
     fetchProfile();
-  }, [status.value.selectedProfileId, apiService]);
+  }, [status.value.selectedProfileId, status.value.selectedProfile, apiService]);
 
   // Determine if we should show expanded view
   const shouldExpand = brew && (active || finished || (brew && !active && !finished));

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -162,6 +162,7 @@ export default class ApiService {
       currentFlow: message.fl,
       mode: message.m,
       selectedProfile: message.p,
+      selectedProfileId: message.puid,
       brewTarget: message.bt || 0,
       volumetricAvailable: message.bta || false,
       process: message.process || null,
@@ -198,6 +199,7 @@ export const machine = signal({
     targetTemperature: 0,
     mode: 0,
     selectedProfile: '',
+    selectedProfileId: null,
     process: null,
   },
   capabilities: {


### PR DESCRIPTION
Add profile ID to websocket (to optimize loading of selected profile (no list) for this feature as well as others where loading profile data is necessary)
Add profile chart in the brew tab under the name

<img width="760" height="942" alt="image" src="https://github.com/user-attachments/assets/24b25d61-c657-4814-8396-8a9e4764f334" />
