### PR TITLE
fix(ShotNotesCard): icons were defined incorrectly

### DIFF
--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -16,16 +16,16 @@ export default function HistoryCard({ shot, onDelete }) {
   const onExport = useCallback(() => {
     const exportData = {
       ...shot,
-      notes: shotNotes
+      notes: shotNotes,
     };
     downloadJson(exportData, 'shot-' + shot.id + '.json');
   }, [shot, shotNotes]);
 
-  const handleNotesLoaded = useCallback((notes) => {
+  const handleNotesLoaded = useCallback(notes => {
     setShotNotes(notes);
   }, []);
 
-  const handleNotesUpdate = useCallback((notes) => {
+  const handleNotesUpdate = useCallback(notes => {
     setShotNotes(notes);
   }, []);
   return (
@@ -71,8 +71,8 @@ export default function HistoryCard({ shot, onDelete }) {
       <div>
         <HistoryChart shot={shot} />
       </div>
-      <ShotNotesCard 
-        shot={shot} 
+      <ShotNotesCard
+        shot={shot}
         onNotesLoaded={handleNotesLoaded}
         onNotesUpdate={handleNotesUpdate}
       />

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -5,9 +5,9 @@ import { Spinner } from '../../components/Spinner.jsx';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faSave } from '@fortawesome/free-solid-svg-icons/faSave';
 
-export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
+export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded }) {
   const apiService = useContext(ApiServiceContext);
-  
+
   const [notes, setNotes] = useState({
     id: shot.id,
     rating: 0,
@@ -18,7 +18,7 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
     balanceTaste: 'balanced',
     notes: '',
   });
-  
+
   const [loading, setLoading] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [initialLoaded, setInitialLoaded] = useState(false);
@@ -34,14 +34,14 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
   // Load notes ONLY on component mount
   useEffect(() => {
     if (initialLoaded) return; // Prevent reloading
-    
+
     const loadNotes = async () => {
       try {
-        const response = await apiService.request({ 
-          tp: 'req:history:notes:get', 
-          id: shot.id 
+        const response = await apiService.request({
+          tp: 'req:history:notes:get',
+          id: shot.id,
         });
-        
+
         let loadedNotes = {
           id: shot.id,
           rating: 0,
@@ -52,7 +52,7 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
           balanceTaste: 'balanced',
           notes: '',
         };
-        
+
         if (response.notes && Object.keys(response.notes).length > 0) {
           // Parse response.notes if it's a string
           let parsedNotes = response.notes;
@@ -64,21 +64,21 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
               parsedNotes = {};
             }
           }
-          
+
           // Merge loaded notes with defaults
           loadedNotes = { ...loadedNotes, ...parsedNotes };
         }
-        
+
         // Pre-populate doseOut with shot.volume if it's empty and shot.volume exists
         if (!loadedNotes.doseOut && shot.volume) {
           loadedNotes.doseOut = shot.volume.toFixed(1);
         }
-        
+
         // Calculate ratio from loaded data
         if (loadedNotes.doseIn && loadedNotes.doseOut) {
           loadedNotes.ratio = calculateRatio(loadedNotes.doseIn, loadedNotes.doseOut);
         }
-        
+
         setNotes(loadedNotes);
         setInitialLoaded(true);
         // Pass loaded notes to parent
@@ -87,7 +87,7 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
         }
       } catch (error) {
         console.error('Failed to load notes:', error);
-        
+
         // Even if loading fails, set up defaults
         const defaultNotes = {
           id: shot.id,
@@ -99,15 +99,15 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
           balanceTaste: 'balanced',
           notes: '',
         };
-        
+
         setNotes(defaultNotes);
         setInitialLoaded(true);
         if (onNotesLoaded) {
           onNotesLoaded(defaultNotes);
-        }        
+        }
       }
     };
-    
+
     loadNotes();
   }, []); // No dependencies - only run once
 
@@ -125,7 +125,7 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
       await apiService.request({
         tp: 'req:history:notes:save',
         id: shot.id,
-        notes: notes
+        notes: notes,
       });
       setIsEditing(false);
       if (onNotesUpdate) {
@@ -141,14 +141,14 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
   const handleInputChange = (field, value) => {
     setNotes(prev => {
       const newNotes = { ...prev, [field]: value };
-      
+
       // Only recalculate ratio if we're changing doseIn or doseOut
       if ((field === 'doseIn' || field === 'doseOut') && initialLoaded) {
         const doseIn = field === 'doseIn' ? value : prev.doseIn;
         const doseOut = field === 'doseOut' ? value : prev.doseOut;
         newNotes.ratio = calculateRatio(doseIn, doseOut);
       }
-      
+
       return newNotes;
     });
   };
@@ -159,49 +159,50 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
       stars.push(
         <button
           key={i}
-          type="button"
+          type='button'
           disabled={!editable}
           onClick={() => editable && handleInputChange('rating', i)}
           className={`text-lg ${i <= rating ? 'text-yellow-400' : 'text-gray-300'} ${
-            editable ? 'hover:text-yellow-300 cursor-pointer' : 'cursor-default'
+            editable ? 'cursor-pointer hover:text-yellow-300' : 'cursor-default'
           }`}
         >
           ★
-        </button>
+        </button>,
       );
     }
     return stars;
   };
 
-  const getTasteColor = (taste) => {
+  const getTasteColor = taste => {
     switch (taste) {
-      case 'bitter': return 'text-orange-600';
-      case 'sour': return 'text-yellow-600';
-      case 'balanced': return 'text-green-600';
-      default: return '';
+      case 'bitter':
+        return 'text-orange-600';
+      case 'sour':
+        return 'text-yellow-600';
+      case 'balanced':
+        return 'text-green-600';
+      default:
+        return '';
     }
   };
 
   // Don't render until initial load is complete
   if (!initialLoaded) {
     return (
-      <div className="mt-6 border-t pt-6">
-        <div className="flex justify-center items-center py-8">
-          <span className="loading loading-spinner loading-md"></span>
+      <div className='mt-6 border-t pt-6'>
+        <div className='flex items-center justify-center py-8'>
+          <span className='loading loading-spinner loading-md'></span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="mt-6 border-t-2 border-t-base-content/10 accent pt-6">
-      <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Shot Notes</h3>
+    <div className='border-t-base-content/10 accent mt-6 border-t-2 pt-6'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className='text-lg font-semibold'>Shot Notes</h3>
         {!isEditing ? (
-          <button
-            onClick={() => setIsEditing(true)}
-            className="btn btn-sm btn-outline"
-          >
+          <button onClick={() => setIsEditing(true)} className='btn btn-sm btn-outline'>
             <FontAwesomeIcon icon={faEdit} />
             Edit
           </button>
@@ -214,11 +215,7 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
             >
               Cancel
             </button>
-            <button
-              onClick={saveNotes}
-              className="btn btn-sm btn-primary"
-              disabled={loading}
-            >
+            <button onClick={saveNotes} className='btn btn-sm btn-primary' disabled={loading}>
               {loading ? (
                 <Spinner size={4} />
               ) : (
@@ -232,106 +229,94 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
         )}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
         {/* Rating */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Rating
-          </label>
-          <div className="flex gap-1">
-            {renderStars(notes.rating, isEditing)}
-          </div>
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Rating</label>
+          <div className='flex gap-1'>{renderStars(notes.rating, isEditing)}</div>
         </div>
 
         {/* Dose In */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Dose In (g)
-          </label>
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Dose In (g)</label>
           {isEditing ? (
             <input
-              type="number"
-              step="0.1"
-              className="input input-bordered w-full"
+              type='number'
+              step='0.1'
+              className='input input-bordered w-full'
               value={notes.doseIn}
-              onChange={(e) => handleInputChange('doseIn', e.target.value)}
-              placeholder="18.0"
+              onChange={e => handleInputChange('doseIn', e.target.value)}
+              placeholder='18.0'
             />
           ) : (
-            <div className="input input-bordered w-full bg-base-200 cursor-default">
+            <div className='input input-bordered bg-base-200 w-full cursor-default'>
               {notes.doseIn || '—'}
             </div>
           )}
         </div>
 
         {/* Dose Out */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Dose Out (g)
-          </label>
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Dose Out (g)</label>
           {isEditing ? (
             <input
-              type="number"
-              step="0.1"
-              className="input input-bordered w-full"
+              type='number'
+              step='0.1'
+              className='input input-bordered w-full'
               value={notes.doseOut}
-              onChange={(e) => handleInputChange('doseOut', e.target.value)}
-              placeholder="36.0"
+              onChange={e => handleInputChange('doseOut', e.target.value)}
+              placeholder='36.0'
             />
           ) : (
-            <div className="input input-bordered w-full bg-base-200 cursor-default">
+            <div className='input input-bordered bg-base-200 w-full cursor-default'>
               {notes.doseOut || '—'}
             </div>
           )}
         </div>
 
         {/* Ratio */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Ratio (1:{notes.ratio || '—'})
-          </label>
-          <div className="input input-bordered w-full bg-base-200 cursor-default">
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Ratio (1:{notes.ratio || '—'})</label>
+          <div className='input input-bordered bg-base-200 w-full cursor-default'>
             {notes.ratio ? `1:${notes.ratio}` : '—'}
           </div>
         </div>
 
         {/* Grind Setting */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Grind Setting
-          </label>
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Grind Setting</label>
           {isEditing ? (
             <input
-              type="text"
-              className="input input-bordered w-full"
+              type='text'
+              className='input input-bordered w-full'
               value={notes.grindSetting}
-              onChange={(e) => handleInputChange('grindSetting', e.target.value)}
-              placeholder="e.g., 2.5, Medium-Fine"
+              onChange={e => handleInputChange('grindSetting', e.target.value)}
+              placeholder='e.g., 2.5, Medium-Fine'
             />
           ) : (
-            <div className="input input-bordered w-full bg-base-200 cursor-default">
+            <div className='input input-bordered bg-base-200 w-full cursor-default'>
               {notes.grindSetting || '—'}
             </div>
           )}
         </div>
 
         {/* Balance/Taste */}
-        <div className="form-control">
-          <label className="mb-2 block text-sm font-medium">
-            Balance/Taste
-          </label>
+        <div className='form-control'>
+          <label className='mb-2 block text-sm font-medium'>Balance/Taste</label>
           {isEditing ? (
             <select
-              className="select select-bordered w-full"
+              className='select select-bordered w-full'
               value={notes.balanceTaste}
-              onChange={(e) => handleInputChange('balanceTaste', e.target.value)}
+              onChange={e => handleInputChange('balanceTaste', e.target.value)}
             >
-              <option value="bitter">Bitter</option>
-              <option value="balanced">Balanced</option>
-              <option value="sour">Sour</option>
+              <option value='bitter'>Bitter</option>
+              <option value='balanced'>Balanced</option>
+              <option value='sour'>Sour</option>
             </select>
           ) : (
-            <div className={`input input-bordered w-full bg-base-200 cursor-default capitalize ${getTasteColor(notes.balanceTaste)}`}>
+            <div
+              className={`input input-bordered bg-base-200 w-full cursor-default capitalize ${getTasteColor(notes.balanceTaste)}`}
+            >
               {notes.balanceTaste}
             </div>
           )}
@@ -339,20 +324,18 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded  }) {
       </div>
 
       {/* Notes Text Area - Full Width */}
-      <div className="form-control mt-6">
-        <label className="mb-2 block text-sm font-medium">
-          Notes
-        </label>
+      <div className='form-control mt-6'>
+        <label className='mb-2 block text-sm font-medium'>Notes</label>
         {isEditing ? (
           <textarea
-            className="textarea textarea-bordered w-full"
-            rows="4"
+            className='textarea textarea-bordered w-full'
+            rows='4'
             value={notes.notes}
-            onChange={(e) => handleInputChange('notes', e.target.value)}
-            placeholder="Tasting notes, brewing observations, etc..."
+            onChange={e => handleInputChange('notes', e.target.value)}
+            placeholder='Tasting notes, brewing observations, etc...'
           />
         ) : (
-          <div className="textarea textarea-bordered w-full bg-base-200 cursor-default min-h-[6rem]">
+          <div className='textarea textarea-bordered bg-base-200 min-h-[6rem] w-full cursor-default'>
             {notes.notes || 'No notes added'}
           </div>
         )}

--- a/web/src/pages/ShotHistory/utils.js
+++ b/web/src/pages/ShotHistory/utils.js
@@ -35,10 +35,10 @@ export function parseHistoryData(shot) {
     data.duration = lastSample.t;
     data.volume = lastSample.v;
   }
-  
+
   if (shot.notes) {
     data.notes = shot.notes;
   }
-  
+
   return data;
 }


### PR DESCRIPTION
I've made some small changes to `ShotNotesCard.jsx` so that the `edit` and `save` buttons render their icon correctly. Previously, they gave some unwanted whitespace as seen here:
<img width="120" height="64" alt="image" src="https://github.com/user-attachments/assets/3e19376d-a708-4c78-9920-213faffded62" />
<img width="177" height="87" alt="image" src="https://github.com/user-attachments/assets/0348663f-e17e-4974-80b0-10640d0f0500" />


I also adjusted the top border to use the theme color, and made it matching to the the style of the rest of the web ui. Finally, I changed the spinner to use the `Spinner.jsx` component for consistency. 

Make sure to look at the first commit, as the second commit does a bunch of formatter changes which makes it hard to read what actually changed with this PR.

Here's the final result:

<img width="1269" height="887" alt="image" src="https://github.com/user-attachments/assets/eb8e7cfe-cc82-4cba-8340-9dad5bb7e2d7" />

<img width="1300" height="794" alt="image" src="https://github.com/user-attachments/assets/d7ef4548-39da-4448-be20-8538808a63e1" />


<img width="1304" height="706" alt="image" src="https://github.com/user-attachments/assets/d60cd5b7-2dd8-4a45-855e-a568d176a26c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Icon-based Edit/Save buttons and a loading spinner for notes.
  - Expanded notes fields (dose in/out, ratio, grind, taste, notes) with auto-prefill and live ratio calculation.

- Bug Fixes
  - More resilient notes loading: safe parsing, sensible defaults, handles missing data, and recalculates ratio on input changes.

- Style
  - Minor formatting updates in ShotNotesCard and HistoryCard.
  - Whitespace cleanup in utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->