### PR TITLE
Nightly

### DIFF
--- a/lib/NayrodPID/src/PressureController/PressureController.h
+++ b/lib/NayrodPID/src/PressureController/PressureController.h
@@ -29,7 +29,7 @@ class PressureController {
     float getCoffeeOutputEstimate() { return std::fmax(0.0f, _coffeeOutput); };
     void setPumpFlowCoeff(float oneBarFlow, float nineBarFlow);
     void setPumpFlowPolyCoeffs(float a, float b, float c, float d);
-    float getPumpFlowRate() { return _pumpFlowRate; };
+    float getPumpFlowRate() { return exportPumpFlowRate; };
     float getCoffeeFlowRate() { return *_valveStatus == 1 ? _coffeeFlowRate : 0.0f; };
     float getPuckResistance() { return _puckResistance; }
 
@@ -100,7 +100,7 @@ class PressureController {
     float _puckConductanceDerivative = 0.0f; // Derivative of puck resistance
     bool _puckState[3] = {};
     int _puckCounter  = 0;
-    
+    float exportPumpFlowRate = 0.0f; // To disociate the exported value from the internal because of filtering (cosmetic) purpose
     SimpleKalmanFilter *_pressureKalmanFilter;
 };
 


### PR DESCRIPTION
Coffee flow estimation: 

- First drop detection on puck conductance estimation criteria 
- Reseted variable with tare 
- Tuned data filtering
<img width="1116" height="386" alt="image" src="https://github.com/user-attachments/assets/53e32ae3-1597-4a72-8eba-00e4a6ba2e04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Smarter puck conductance model that detects flow start and begins coffee-flow estimation.

- Improvements
  - New low-pass filtering helper used across estimators for smoother signals.
  - Configurable filter frequency for pump/flow for better responsiveness.
  - Pump duty outputs clamped to 0–100% for steadier control.
  - More comprehensive tare/reset that fully reinitializes puck-related state and metrics.
  - Safer edge-case handling to avoid divide-by-zero.

- Diagnostics
  - Expanded debug logging for puck and flow calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->