### PR TITLE
WebUI Chart Tweaks

### DIFF
--- a/web/src/components/Chart.jsx
+++ b/web/src/components/Chart.jsx
@@ -27,8 +27,21 @@ export function ChartComponent({ data, className, chartClassName }) {
   useEffect(() => {
     if (!chart) return;
 
+    // Preserve dataset visibility state when updating data
+    const hiddenDatasets = chart.data.datasets.map((dataset, index) => {
+      return chart.getDatasetMeta(index).hidden;
+    });
+
     chart.data = data.data;
     chart.options = data.options;
+
+    // Restore dataset visibility state
+    chart.data.datasets.forEach((dataset, index) => {
+      if (hiddenDatasets[index] !== undefined) {
+        chart.getDatasetMeta(index).hidden = hiddenDatasets[index];
+      }
+    });
+
     chart.update();
   }, [data, chart]);
 

--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
+import { Chart } from 'chart.js';
 import { ChartComponent } from './Chart';
 
 const POINT_INTERVAL = 0.1; // s
@@ -140,10 +141,26 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
           position: 'top',
           display: true,
           labels: {
-            boxWidth: 12,
+            usePointStyle: true,
+            pointStyle: 'line',
+            pointStyleWidth: 20,
             padding: 8,
             font: {
               size: window.innerWidth < 640 ? 10 : 12,
+            },
+            generateLabels: function(chart) {
+              const original = Chart.defaults.plugins.legend.labels.generateLabels;
+              const labels = original.call(this, chart);
+              
+              labels.forEach((label, index) => {
+                const dataset = chart.data.datasets[index];
+                label.lineWidth = 3; 
+                if (dataset.borderDash && dataset.borderDash.length > 0) {
+                  label.lineDash = dataset.borderDash;
+                }
+              });
+              
+              return labels;
             },
           },
         },

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -57,10 +57,26 @@ function getChartData(data) {
           position: 'top',
           display: true,
           labels: {
-            boxWidth: 12,
+            usePointStyle: true,
+            pointStyle: 'line',
+            pointStyleWidth: 20,
             padding: 8,
             font: {
               size: window.innerWidth < 640 ? 10 : 12,
+            },
+            generateLabels: function(chart) {
+              const original = Chart.defaults.plugins.legend.labels.generateLabels;
+              const labels = original.call(this, chart);
+              
+              labels.forEach((label, index) => {
+                const dataset = chart.data.datasets[index];
+                label.lineWidth = 3; 
+                if (dataset.borderDash && dataset.borderDash.length > 0) {
+                  label.lineDash = dataset.borderDash; 
+                }
+              });
+              
+              return labels;
             },
           },
         },


### PR DESCRIPTION
Fix Overview chart not maintaining line hidden status at each tick.
Change legend from bordered box to lines

<img width="721" height="174" alt="image" src="https://github.com/user-attachments/assets/d6445de5-31b3-4c23-9749-b8ca2a344c6c" />

<img width="477" height="207" alt="image" src="https://github.com/user-attachments/assets/3528a4b3-f56f-4ac8-b8b4-a3000cebc33d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved dataset visibility across data updates in charts, so hidden/visible selections no longer reset during refreshes.

* **Style**
  * Revamped chart legends to use line-based markers that mirror each dataset’s stroke width and dash pattern.
  * Improved legend clarity and visual consistency across profile and overview charts, making it easier to match legend entries to their lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->