### PR TITLE
Add tooltips to WebUI charts.

### DIFF
--- a/web/src/components/Chart.jsx
+++ b/web/src/components/Chart.jsx
@@ -89,8 +89,16 @@ export function ChartComponent({ data, className, chartClassName }) {
   }, [chart]);
 
   return (
-    <div className={className}>
-      <canvas className={chartClassName} ref={ref} />
+    <div className={className} style={{ position: 'relative' }}>
+      <canvas 
+        className={chartClassName} 
+        ref={ref}
+        style={{ 
+          width: '100%', 
+          height: '100%',
+          display: 'block'
+        }}
+      />
     </div>
   );
 }

--- a/web/src/components/Chart.jsx
+++ b/web/src/components/Chart.jsx
@@ -4,7 +4,7 @@ import annotationPlugin from 'chartjs-plugin-annotation';
 
 Chart.register(annotationPlugin);
 
-export function ChartComponent({ data, className, chartClassName }) {
+export function ChartComponent({ data, className, chartClassName, onMouseDown, onTouchStart }) {
   const [chart, setChart] = useState(null);
   const ref = useRef();
 
@@ -13,6 +13,10 @@ export function ChartComponent({ data, className, chartClassName }) {
     if (!ref.current) return;
 
     const newChart = new Chart(ref.current, data);
+    
+    // Store chart reference on canvas element for event handlers
+    ref.current.chart = newChart;
+    
     setChart(newChart);
 
     // Cleanup function to destroy chart on unmount
@@ -93,6 +97,8 @@ export function ChartComponent({ data, className, chartClassName }) {
       <canvas 
         className={chartClassName} 
         ref={ref}
+        onMouseDown={onMouseDown}
+        onTouchStart={onTouchStart}
         style={{ 
           width: '100%', 
           height: '100%',

--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -379,15 +379,16 @@ export function ExtendedProfileChart({
       // Find closest data point and update selected point
       const chart = chartRef.current.chart;
       if (chart && chart.scales && chart.scales.x && chart.chartArea) {
-        // Constrain x to chart area bounds
+        // Constrain x and y to chart area bounds
         const chartArea = chart.chartArea;
         const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+        const constrainedY = Math.max(chartArea.top, Math.min(chartArea.bottom, y));
         
         // Convert constrained position to data value
         const dataX = chart.scales.x.getValueForPixel(constrainedX);
         
         // Update tooltip position to the constrained mouse position
-        setTooltipPosition({ x: constrainedX, y });
+        setTooltipPosition({ x: constrainedX, y: constrainedY });
         
         // Find closest data point
         const datasets = chart.data.datasets;
@@ -529,9 +530,10 @@ export function ExtendedProfileChart({
               // Calculate constrained tooltip position relative to data point
               const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
               const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+              const constrainedY = Math.max(e.target.chart.chartArea.top, Math.min(y, e.target.chart.chartArea.bottom));
               
               setSelectedPoint(pointData);
-              setTooltipPosition({ x: constrainedX, y });
+              setTooltipPosition({ x: constrainedX, y: constrainedY });
               setIsDragging(true);
             }
           }
@@ -575,9 +577,10 @@ export function ExtendedProfileChart({
                 // Calculate constrained tooltip position relative to data point
                 const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
                 const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+                const constrainedY = Math.max(e.target.chart.chartArea.top, Math.min(y, e.target.chart.chartArea.bottom));
                 
                 setSelectedPoint(pointData);
-                setTooltipPosition({ x: constrainedX, y });
+                setTooltipPosition({ x: constrainedX, y: constrainedY });
                 setIsDragging(true);
               }
             }

--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { ChartComponent } from './Chart';
+import { Chart } from 'chart.js';
 
 const POINT_INTERVAL = 0.1; // s
 
@@ -111,7 +112,7 @@ function prepareData(phases, target) {
   return data;
 }
 
-function makeChartData(data, selectedPhase, isDarkMode = false, onPointClick = null, selectedPointIndex = null) {
+function makeChartData(data, selectedPhase, isDarkMode = false, _, selectedPointIndex = null) {
   let duration = 0;
   for (const phase of data.phases) {
     duration += parseFloat(phase.duration);
@@ -209,7 +210,6 @@ function makeChartData(data, selectedPhase, isDarkMode = false, onPointClick = n
       },
       animations: false,
       radius: 0,
-      onClick: onPointClick,
       scales: {
         x: {
           type: 'linear',
@@ -321,6 +321,9 @@ export function ExtendedProfileChart({
   selectedPhase = null,
 }) {
   const [selectedPoint, setSelectedPoint] = useState(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const chartRef = useRef(null);
   
   // Handle clicks outside the tooltip to dismiss it
   useEffect(() => {
@@ -340,29 +343,137 @@ export function ExtendedProfileChart({
       document.removeEventListener('click', handleClickOutside);
     };
   }, [selectedPoint]);
-  
-  const handlePointClick = (event, elements, chart) => {
-    if (elements.length > 0) {
-      const dataIndex = elements[0].index;
-      const datasets = chart.data.datasets;
+
+  // Handle mouse/touch move events for dragging
+  useEffect(() => {
+    if (!isDragging || !chartRef.current) return;
+
+    const handleMove = (event) => {
+      event.preventDefault();
       
-      // Get values from all datasets at this index
-      const pointData = {
-        time: datasets[0].data[dataIndex].x.toFixed(1),
-        pressure: datasets[0].data[dataIndex].y,
-        flow: datasets[1].data[dataIndex].y,
-        dataIndex // Store the index for visual indicator
-      };
+      const rect = chartRef.current.getBoundingClientRect();
+      let clientX, clientY;
       
-      setSelectedPoint(pointData);
-    } else {
-      setSelectedPoint(null);
-    }
-  };
+      if (event.type.includes('touch')) {
+        if (!event.touches || event.touches.length === 0) return;
+        clientX = event.touches[0].clientX;
+        clientY = event.touches[0].clientY;
+      } else {
+        clientX = event.clientX;
+        clientY = event.clientY;
+      }
+      
+      const x = clientX - rect.left;
+      const y = clientY - rect.top;
+      
+      // Find closest data point and update selected point
+      const chart = chartRef.current.chart;
+      if (chart && chart.scales && chart.scales.x && chart.chartArea) {
+        // Constrain x to chart area bounds
+        const chartArea = chart.chartArea;
+        const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+        
+        // Convert constrained position to data value
+        const dataX = chart.scales.x.getValueForPixel(constrainedX);
+        
+        // Update tooltip position to the constrained mouse position
+        setTooltipPosition({ x: constrainedX, y });
+        
+        // Find closest data point
+        const datasets = chart.data.datasets;
+        if (datasets.length > 0 && datasets[0].data) {
+          let closestIndex = 0;
+          let minDistance = Infinity;
+          
+          datasets[0].data.forEach((point, index) => {
+            const distance = Math.abs(point.x - dataX);
+            if (distance < minDistance) {
+              minDistance = distance;
+              closestIndex = index;
+            }
+          });
+          
+          // Update selected point
+          const pointData = {
+            time: datasets[0].data[closestIndex].x.toFixed(1),
+            pressure: datasets[0].data[closestIndex].y,
+            flow: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+            dataIndex: closestIndex
+          };
+          
+          setSelectedPoint(pointData);
+        }
+      }
+    };
+
+    const handleEnd = () => {
+      setIsDragging(false);
+    };
+
+    // Add event listeners
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleEnd);
+    document.addEventListener('touchmove', handleMove, { passive: false });
+    document.addEventListener('touchend', handleEnd);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleEnd);
+      document.removeEventListener('touchmove', handleMove);
+      document.removeEventListener('touchend', handleEnd);
+    };
+  }, [isDragging]);
   
   const isDarkMode = () =>
     window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const config = makeChartData(data, selectedPhase, isDarkMode(), handlePointClick, selectedPoint?.dataIndex);
+  const config = makeChartData(data, selectedPhase, isDarkMode(), null, selectedPoint?.dataIndex);
+
+  // Calculate tooltip position with left/right logic
+  const getTooltipStyle = () => {
+    if (!selectedPoint || !chartRef.current?.chart) return {};
+    
+    const chart = chartRef.current.chart;
+    const tooltipWidth = 120;
+    const padding = 15; // Position tooltip 15px away from the data line
+    
+    // Get the pixel position of the selected data point on the chart
+    const selectedTime = parseFloat(selectedPoint.time);
+    const dataPointX = chart.scales.x.getPixelForValue(selectedTime);
+    
+    // Fallback if dataPointX is invalid
+    if (!dataPointX || isNaN(dataPointX)) {
+      return {
+        fontSize: '11px',
+        lineHeight: '1.2',
+        left: '100px', // Fallback position
+        top: `${tooltipPosition.y - 50}px`, // Use mouse Y position even for fallback
+        minWidth: 'auto',
+        maxWidth: '120px'
+      };
+    }
+    
+    // Determine if tooltip should be to the left or right of the data point
+    // Show to the left if there's enough space, otherwise show to the right
+    const chartArea = chart.chartArea;
+    const distanceFromLeft = dataPointX - chartArea.left;
+    
+    const showLeft = distanceFromLeft > (tooltipWidth + padding);
+    
+    // Position tooltip just beside the vertical line (data point)
+    const containerWidth = chartRef.current.getBoundingClientRect().width;
+    const positioning = showLeft ? 
+      { right: `${containerWidth - dataPointX + padding}px` } :
+      { left: `${dataPointX + padding}px` };
+    
+    return {
+      fontSize: '11px',
+      lineHeight: '1.2',
+      ...positioning,
+      top: `${tooltipPosition.y - 50}px`, // Follow mouse Y position, offset upward to center tooltip
+      minWidth: 'auto',
+      maxWidth: '120px'
+    };
+  };
 
   return (
     <div className="relative w-full">
@@ -370,23 +481,108 @@ export function ExtendedProfileChart({
         className='w-full'
         chartClassName={className}
         data={config}
+        onMouseDown={(e) => {
+          const rect = e.target.getBoundingClientRect();
+          const x = e.clientX - rect.left;
+          const y = e.clientY - rect.top;
+          
+          // Store chart reference
+          chartRef.current = { chart: e.target.chart, getBoundingClientRect: () => rect };
+          
+          // Find data point at click position
+          if (e.target.chart && e.target.chart.scales && e.target.chart.scales.x) {
+            // Manual relative position calculation
+            const canvasX = x;
+            const dataX = e.target.chart.scales.x.getValueForPixel(canvasX);
+            
+            const datasets = e.target.chart.data.datasets;
+            if (datasets.length > 0 && datasets[0].data) {
+              let closestIndex = 0;
+              let minDistance = Infinity;
+              
+              datasets[0].data.forEach((point, index) => {
+                const distance = Math.abs(point.x - dataX);
+                if (distance < minDistance) {
+                  minDistance = distance;
+                  closestIndex = index;
+                }
+              });
+              
+              // Update selected point and start dragging
+              const pointData = {
+                time: datasets[0].data[closestIndex].x.toFixed(1),
+                pressure: datasets[0].data[closestIndex].y,
+                flow: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+                dataIndex: closestIndex
+              };
+              
+              // Calculate constrained tooltip position relative to data point
+              const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
+              const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+              
+              setSelectedPoint(pointData);
+              setTooltipPosition({ x: constrainedX, y });
+              setIsDragging(true);
+            }
+          }
+        }}
+        onTouchStart={(e) => {
+          if (e.touches.length === 1) {
+            const rect = e.target.getBoundingClientRect();
+            const x = e.touches[0].clientX - rect.left;
+            const y = e.touches[0].clientY - rect.top;
+            
+            // Store chart reference
+            chartRef.current = { chart: e.target.chart, getBoundingClientRect: () => rect };
+            
+            // Find data point at touch position
+            if (e.target.chart && e.target.chart.scales && e.target.chart.scales.x) {
+              // Manual relative position calculation
+              const canvasX = x;
+              const dataX = e.target.chart.scales.x.getValueForPixel(canvasX);
+              
+              const datasets = e.target.chart.data.datasets;
+              if (datasets.length > 0 && datasets[0].data) {
+                let closestIndex = 0;
+                let minDistance = Infinity;
+                
+                datasets[0].data.forEach((point, index) => {
+                  const distance = Math.abs(point.x - dataX);
+                  if (distance < minDistance) {
+                    minDistance = distance;
+                    closestIndex = index;
+                  }
+                });
+                
+                // Update selected point and start dragging
+                const pointData = {
+                  time: datasets[0].data[closestIndex].x.toFixed(1),
+                  pressure: datasets[0].data[closestIndex].y,
+                  flow: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+                  dataIndex: closestIndex
+                };
+                
+                // Calculate constrained tooltip position relative to data point
+                const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
+                const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+                
+                setSelectedPoint(pointData);
+                setTooltipPosition({ x: constrainedX, y });
+                setIsDragging(true);
+              }
+            }
+          }
+        }}
       />
       
       {selectedPoint && (
         <div 
-          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none"
-          style={{
-            fontSize: '11px',
-            lineHeight: '1.2',
-            left: '60px',
-            top: '60px',
-            minWidth: 'auto',
-            maxWidth: '120px'
-          }}
+          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none z-10"
+          style={getTooltipStyle()}
         >
           <div className="font-medium mb-0.5 text-white">{selectedPoint.time}s</div>
           <div style={{ color: '#81C784' }}>P: {selectedPoint.pressure.toFixed(1)} bar</div>
-          <div style={{ color: '#FFB74D' }}>F: {selectedPoint.flow.toFixed(1)} g/s</div>
+          <div style={{ color: '#FFB74D' }}>F: {selectedPoint.flow.toFixed(1)} ml/s</div>
         </div>
       )}
     </div>

--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -348,8 +348,18 @@ export function ExtendedProfileChart({
   useEffect(() => {
     if (!isDragging || !chartRef.current) return;
 
+    let lastUpdateTime = 0;
+    const throttleMs = 33; // ~30fps
+
     const handleMove = (event) => {
       event.preventDefault();
+      
+      // Throttle mouse events but allow touch events to run unthrottled
+      const now = Date.now();
+      if (!event.type.includes('touch') && now - lastUpdateTime < throttleMs) {
+        return;
+      }
+      lastUpdateTime = now;
       
       const rect = chartRef.current.getBoundingClientRect();
       let clientX, clientY;

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -3,7 +3,52 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { Chart } from 'chart.js';
 import { ChartComponent } from './Chart.jsx';
 
-function getChartData(data) {
+function getChartData(data, onPointClick, selectedPointIndex = null) {
+  // Create annotations object for visual indicators
+  const annotations = {};
+  
+  // Add selected point indicators
+  if (selectedPointIndex !== null && selectedPointIndex < data.length) {
+    const selectedTimestamp = data[selectedPointIndex].timestamp.toISOString();
+    
+    // Add vertical line at selected point
+    annotations['selected_line'] = {
+      type: 'line',
+      xMin: selectedTimestamp,
+      xMax: selectedTimestamp,
+      borderColor: '#6366F1', // Indigo color
+      borderWidth: 2,
+      borderDash: [5, 5],
+      label: {
+        enabled: false
+      }
+    };
+    
+    // Add point indicators for each dataset
+    const datasetColors = ['#F0561D', '#731F00', '#0066CC', '#003366', '#63993D'];
+    const yAxisIds = ['y', 'y', 'y1', 'y1', 'y1'];
+    const values = [
+      data[selectedPointIndex].currentTemperature,
+      data[selectedPointIndex].targetTemperature,
+      data[selectedPointIndex].currentPressure,
+      data[selectedPointIndex].targetPressure,
+      data[selectedPointIndex].currentFlow
+    ];
+    
+    values.forEach((value, index) => {
+      annotations[`selected_point_${index}`] = {
+        type: 'point',
+        xValue: selectedTimestamp,
+        yValue: value,
+        yScaleID: yAxisIds[index],
+        backgroundColor: datasetColors[index],
+        borderColor: '#FFFFFF',
+        borderWidth: 2,
+        radius: 4
+      };
+    });
+  }
+  
   let end = new Date();
   let start = new Date(end.getTime() - 300000);
   return {
@@ -71,8 +116,16 @@ function getChartData(data) {
             size: window.innerWidth < 640 ? 14 : 16,
           },
         },
+        annotation: {
+          annotations: annotations
+        }
       },
       animation: false,
+      interaction: {
+        intersect: false,
+        mode: 'index',
+      },
+      onClick: onPointClick,
       scales: {
         y: {
           type: 'linear',
@@ -130,13 +183,77 @@ function getChartData(data) {
 }
 
 export function OverviewChart() {
-  const chartData = getChartData(machine.value.history);
+  const [selectedPoint, setSelectedPoint] = useState(null);
+  
+  // Handle clicks outside the tooltip to dismiss it
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      // Check if the click is outside the tooltip
+      const tooltip = event.target.closest('.chart-tooltip');
+      const chart = event.target.closest('canvas');
+      
+      // If clicking outside tooltip but not on chart, dismiss
+      if (!tooltip && !chart && selectedPoint) {
+        setSelectedPoint(null);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [selectedPoint]);
+  
+  const handlePointClick = (event, elements, chart) => {
+    if (elements.length > 0) {
+      const dataIndex = elements[0].index;
+      const datasets = chart.data.datasets;
+      
+      // Get values from all datasets at this index
+      const pointData = {
+        timestamp: new Date(datasets[0].data[dataIndex].x),
+        currentTemperature: datasets[0].data[dataIndex].y,
+        targetTemperature: datasets[1].data[dataIndex].y,
+        currentPressure: datasets[2].data[dataIndex].y,
+        targetPressure: datasets[3].data[dataIndex].y,
+        currentFlow: datasets[4].data[dataIndex].y,
+        dataIndex // Store the index for visual indicator
+      };
+      
+      setSelectedPoint(pointData);
+    } else {
+      setSelectedPoint(null);
+    }
+  };
+
+  const chartData = getChartData(machine.value.history, handlePointClick, selectedPoint?.dataIndex);
 
   return (
-    <ChartComponent
-      className='h-full min-h-[200px] w-full flex-1 lg:min-h-[350px]'
-      chartClassName='h-full w-full'
-      data={chartData}
-    />
+    <div className="relative h-full w-full">
+      <ChartComponent
+        className='h-full min-h-[200px] w-full flex-1 lg:min-h-[350px]'
+        chartClassName='h-full w-full'
+        data={chartData}
+      />
+      
+      {selectedPoint && (
+        <div 
+          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none"
+          style={{
+            fontSize: '11px',
+            lineHeight: '1.2',
+            left: '60px',
+            top: '80px',
+            minWidth: 'auto',
+            maxWidth: '150px'
+          }}
+        >
+          <div className="font-medium mb-0.5 text-white">{selectedPoint.timestamp.toLocaleTimeString()}</div>
+          <div style={{ color: '#4FC3F7' }}>P: {selectedPoint.currentPressure.toFixed(1)}/{selectedPoint.targetPressure.toFixed(1)} bar</div>
+          <div style={{ color: '#FFB74D' }}>T: {selectedPoint.currentTemperature.toFixed(1)}/{selectedPoint.targetTemperature.toFixed(1)}°C</div>
+          <div style={{ color: '#81C784' }}>F: {selectedPoint.currentFlow.toFixed(1)} g/s</div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -210,8 +210,18 @@ export function OverviewChart() {
   useEffect(() => {
     if (!isDragging || !chartRef.current) return;
 
+    let lastUpdateTime = 0;
+    const throttleMs = 33; // ~30fps
+
     const handleMove = (event) => {
       event.preventDefault();
+      
+      // Throttle mouse events but allow touch events to run unthrottled
+      const now = Date.now();
+      if (!event.type.includes('touch') && now - lastUpdateTime < throttleMs) {
+        return;
+      }
+      lastUpdateTime = now;
       
       const rect = chartRef.current.getBoundingClientRect();
       let clientX, clientY;

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -241,15 +241,16 @@ export function OverviewChart() {
       // Find closest data point and update selected point
       const chart = chartRef.current.chart;
       if (chart && chart.scales && chart.scales.x && chart.chartArea) {
-        // Constrain x to chart area bounds
+        // Constrain x and y to chart area bounds
         const chartArea = chart.chartArea;
         const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+        const constrainedY = Math.max(chartArea.top, Math.min(chartArea.bottom, y));
         
         // Convert constrained position to data value
         const dataX = chart.scales.x.getValueForPixel(constrainedX);
         
         // Update tooltip position to the constrained mouse position
-        setTooltipPosition({ x: constrainedX, y });
+        setTooltipPosition({ x: constrainedX, y: constrainedY });
         
         // Find closest data point
         const datasets = chart.data.datasets;
@@ -391,9 +392,13 @@ export function OverviewChart() {
             // Constrain click to chart area bounds
             const chartArea = e.target.chart.chartArea;
             const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+            const constrainedY = Math.max(chartArea.top, Math.min(chartArea.bottom, y));
             
             // Convert constrained position to data value
             const dataX = e.target.chart.scales.x.getValueForPixel(constrainedX);
+            
+            // Update tooltip position immediately to constrained position
+            setTooltipPosition({ x: constrainedX, y: constrainedY });
             
             const datasets = e.target.chart.data.datasets;
             if (datasets.length > 0 && datasets[0].data) {
@@ -421,7 +426,7 @@ export function OverviewChart() {
               };
               
               setSelectedPoint(pointData);
-              setTooltipPosition({ x: constrainedX, y });
+              setTooltipPosition({ x: constrainedX, y: constrainedY });
               setIsDragging(true);
             }
           }
@@ -440,9 +445,13 @@ export function OverviewChart() {
               // Constrain touch to chart area bounds
               const chartArea = e.target.chart.chartArea;
               const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+              const constrainedY = Math.max(chartArea.top, Math.min(chartArea.bottom, y));
               
               // Convert constrained position to data value
               const dataX = e.target.chart.scales.x.getValueForPixel(constrainedX);
+              
+              // Update tooltip position immediately to constrained position
+              setTooltipPosition({ x: constrainedX, y: constrainedY });
               
               const datasets = e.target.chart.data.datasets;
               if (datasets.length > 0 && datasets[0].data) {
@@ -470,7 +479,7 @@ export function OverviewChart() {
                 };
                 
                 setSelectedPoint(pointData);
-                setTooltipPosition({ x: constrainedX, y });
+                setTooltipPosition({ x: constrainedX, y: constrainedY });
                 setIsDragging(true);
               }
             }

--- a/web/src/components/OverviewChart.jsx
+++ b/web/src/components/OverviewChart.jsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { Chart } from 'chart.js';
 import { ChartComponent } from './Chart.jsx';
 
-function getChartData(data, onPointClick, selectedPointIndex = null) {
+function getChartData(data, _, selectedPointIndex = null) {
   // Create annotations object for visual indicators
   const annotations = {};
   
@@ -125,7 +125,6 @@ function getChartData(data, onPointClick, selectedPointIndex = null) {
         intersect: false,
         mode: 'index',
       },
-      onClick: onPointClick,
       scales: {
         y: {
           type: 'linear',
@@ -184,6 +183,9 @@ function getChartData(data, onPointClick, selectedPointIndex = null) {
 
 export function OverviewChart() {
   const [selectedPoint, setSelectedPoint] = useState(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const chartRef = useRef(null);
   
   // Handle clicks outside the tooltip to dismiss it
   useEffect(() => {
@@ -203,6 +205,90 @@ export function OverviewChart() {
       document.removeEventListener('click', handleClickOutside);
     };
   }, [selectedPoint]);
+
+  // Handle mouse/touch move events for dragging
+  useEffect(() => {
+    if (!isDragging || !chartRef.current) return;
+
+    const handleMove = (event) => {
+      event.preventDefault();
+      
+      const rect = chartRef.current.getBoundingClientRect();
+      let clientX, clientY;
+      
+      if (event.type.includes('touch')) {
+        if (!event.touches || event.touches.length === 0) return;
+        clientX = event.touches[0].clientX;
+        clientY = event.touches[0].clientY;
+      } else {
+        clientX = event.clientX;
+        clientY = event.clientY;
+      }
+      
+      const x = clientX - rect.left;
+      const y = clientY - rect.top;
+      
+      // Find closest data point and update selected point
+      const chart = chartRef.current.chart;
+      if (chart && chart.scales && chart.scales.x && chart.chartArea) {
+        // Constrain x to chart area bounds
+        const chartArea = chart.chartArea;
+        const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+        
+        // Convert constrained position to data value
+        const dataX = chart.scales.x.getValueForPixel(constrainedX);
+        
+        // Update tooltip position to the constrained mouse position
+        setTooltipPosition({ x: constrainedX, y });
+        
+        // Find closest data point
+        const datasets = chart.data.datasets;
+        if (datasets.length > 0 && datasets[0].data) {
+          let closestIndex = 0;
+          let minDistance = Infinity;
+          
+          datasets[0].data.forEach((point, index) => {
+            const pointTime = new Date(point.x).getTime();
+            const distance = Math.abs(pointTime - dataX);
+            if (distance < minDistance) {
+              minDistance = distance;
+              closestIndex = index;
+            }
+          });
+          
+          // Update selected point
+          const pointData = {
+            timestamp: new Date(datasets[0].data[closestIndex].x),
+            currentTemperature: datasets[0].data[closestIndex].y,
+            targetTemperature: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+            currentPressure: datasets[2] && datasets[2].data[closestIndex] ? datasets[2].data[closestIndex].y : 0,
+            targetPressure: datasets[3] && datasets[3].data[closestIndex] ? datasets[3].data[closestIndex].y : 0,
+            currentFlow: datasets[4] && datasets[4].data[closestIndex] ? datasets[4].data[closestIndex].y : 0,
+            dataIndex: closestIndex
+          };
+          
+          setSelectedPoint(pointData);
+        }
+      }
+    };
+
+    const handleEnd = () => {
+      setIsDragging(false);
+    };
+
+    // Add event listeners
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleEnd);
+    document.addEventListener('touchmove', handleMove, { passive: false });
+    document.addEventListener('touchend', handleEnd);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleEnd);
+      document.removeEventListener('touchmove', handleMove);
+      document.removeEventListener('touchend', handleEnd);
+    };
+  }, [isDragging]);
   
   const handlePointClick = (event, elements, chart) => {
     if (elements.length > 0) {
@@ -226,7 +312,55 @@ export function OverviewChart() {
     }
   };
 
-  const chartData = getChartData(machine.value.history, handlePointClick, selectedPoint?.dataIndex);
+  const chartData = getChartData(machine.value.history, null, selectedPoint?.dataIndex);
+
+  // Calculate tooltip position with left/right logic
+  const getTooltipStyle = () => {
+    if (!selectedPoint || !chartRef.current?.chart) return {};
+    
+    const chart = chartRef.current.chart;
+    const tooltipWidth = 150;
+    const padding = 15; // Position tooltip 15px away from the data line
+    
+    // Get the pixel position of the selected data point on the chart
+    // Use timestamp in milliseconds instead of ISO string for Chart.js time scale
+    const selectedTimestamp = selectedPoint.timestamp.getTime();
+    const dataPointX = chart.scales.x.getPixelForValue(selectedTimestamp);
+    
+    // Fallback if dataPointX is invalid
+    if (!dataPointX || isNaN(dataPointX)) {
+      return {
+        fontSize: '11px',
+        lineHeight: '1.2',
+        left: '100px', // Fallback position
+        top: `${tooltipPosition.y - 50}px`, // Use mouse Y position even for fallback
+        minWidth: 'auto',
+        maxWidth: '150px'
+      };
+    }
+    
+    // Determine if tooltip should be to the left or right of the data point
+    // Show to the left if there's enough space, otherwise show to the right
+    const chartArea = chart.chartArea;
+    const distanceFromLeft = dataPointX - chartArea.left;
+    
+    const showLeft = distanceFromLeft > (tooltipWidth + padding);
+    
+    // Position tooltip just beside the vertical line (data point)
+    const containerWidth = chartRef.current.getBoundingClientRect().width;
+    const positioning = showLeft ? 
+      { right: `${containerWidth - dataPointX + padding}px` } :
+      { left: `${dataPointX + padding}px` };
+    
+    return {
+      fontSize: '11px',
+      lineHeight: '1.2',
+      ...positioning,
+      top: `${tooltipPosition.y - 50}px`, // Follow mouse Y position, offset upward to center tooltip
+      minWidth: 'auto',
+      maxWidth: '150px'
+    };
+  };
 
   return (
     <div className="relative h-full w-full">
@@ -234,23 +368,114 @@ export function OverviewChart() {
         className='h-full min-h-[200px] w-full flex-1 lg:min-h-[350px]'
         chartClassName='h-full w-full'
         data={chartData}
+        onMouseDown={(e) => {
+          const rect = e.target.getBoundingClientRect();
+          const x = e.clientX - rect.left;
+          const y = e.clientY - rect.top;
+          
+          // Store chart reference
+          chartRef.current = { chart: e.target.chart, getBoundingClientRect: () => rect };
+          
+          // Find data point at click position
+          if (e.target.chart && e.target.chart.scales && e.target.chart.scales.x && e.target.chart.chartArea) {
+            // Constrain click to chart area bounds
+            const chartArea = e.target.chart.chartArea;
+            const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+            
+            // Convert constrained position to data value
+            const dataX = e.target.chart.scales.x.getValueForPixel(constrainedX);
+            
+            const datasets = e.target.chart.data.datasets;
+            if (datasets.length > 0 && datasets[0].data) {
+              let closestIndex = 0;
+              let minDistance = Infinity;
+              
+              datasets[0].data.forEach((point, index) => {
+                const pointTime = new Date(point.x).getTime();
+                const distance = Math.abs(pointTime - dataX);
+                if (distance < minDistance) {
+                  minDistance = distance;
+                  closestIndex = index;
+                }
+              });
+              
+              // Update selected point and start dragging
+              const pointData = {
+                timestamp: new Date(datasets[0].data[closestIndex].x),
+                currentTemperature: datasets[0].data[closestIndex].y,
+                targetTemperature: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+                currentPressure: datasets[2] && datasets[2].data[closestIndex] ? datasets[2].data[closestIndex].y : 0,
+                targetPressure: datasets[3] && datasets[3].data[closestIndex] ? datasets[3].data[closestIndex].y : 0,
+                currentFlow: datasets[4] && datasets[4].data[closestIndex] ? datasets[4].data[closestIndex].y : 0,
+                dataIndex: closestIndex
+              };
+              
+              setSelectedPoint(pointData);
+              setTooltipPosition({ x: constrainedX, y });
+              setIsDragging(true);
+            }
+          }
+        }}
+        onTouchStart={(e) => {
+          if (e.touches.length === 1) {
+            const rect = e.target.getBoundingClientRect();
+            const x = e.touches[0].clientX - rect.left;
+            const y = e.touches[0].clientY - rect.top;
+            
+            // Store chart reference
+            chartRef.current = { chart: e.target.chart, getBoundingClientRect: () => rect };
+            
+            // Find data point at touch position
+            if (e.target.chart && e.target.chart.scales && e.target.chart.scales.x && e.target.chart.chartArea) {
+              // Constrain touch to chart area bounds
+              const chartArea = e.target.chart.chartArea;
+              const constrainedX = Math.max(chartArea.left, Math.min(chartArea.right, x));
+              
+              // Convert constrained position to data value
+              const dataX = e.target.chart.scales.x.getValueForPixel(constrainedX);
+              
+              const datasets = e.target.chart.data.datasets;
+              if (datasets.length > 0 && datasets[0].data) {
+                let closestIndex = 0;
+                let minDistance = Infinity;
+                
+                datasets[0].data.forEach((point, index) => {
+                  const pointTime = new Date(point.x).getTime();
+                  const distance = Math.abs(pointTime - dataX);
+                  if (distance < minDistance) {
+                    minDistance = distance;
+                    closestIndex = index;
+                  }
+                });
+                
+                // Update selected point and start dragging
+                const pointData = {
+                  timestamp: new Date(datasets[0].data[closestIndex].x),
+                  currentTemperature: datasets[0].data[closestIndex].y,
+                  targetTemperature: datasets[1] && datasets[1].data[closestIndex] ? datasets[1].data[closestIndex].y : 0,
+                  currentPressure: datasets[2] && datasets[2].data[closestIndex] ? datasets[2].data[closestIndex].y : 0,
+                  targetPressure: datasets[3] && datasets[3].data[closestIndex] ? datasets[3].data[closestIndex].y : 0,
+                  currentFlow: datasets[4] && datasets[4].data[closestIndex] ? datasets[4].data[closestIndex].y : 0,
+                  dataIndex: closestIndex
+                };
+                
+                setSelectedPoint(pointData);
+                setTooltipPosition({ x: constrainedX, y });
+                setIsDragging(true);
+              }
+            }
+          }
+        }}
       />
       
       {selectedPoint && (
         <div 
-          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none"
-          style={{
-            fontSize: '11px',
-            lineHeight: '1.2',
-            left: '60px',
-            top: '80px',
-            minWidth: 'auto',
-            maxWidth: '150px'
-          }}
+          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none z-10"
+          style={getTooltipStyle()}
         >
           <div className="font-medium mb-0.5 text-white">{selectedPoint.timestamp.toLocaleTimeString()}</div>
-          <div style={{ color: '#4FC3F7' }}>P: {selectedPoint.currentPressure.toFixed(1)}/{selectedPoint.targetPressure.toFixed(1)} bar</div>
           <div style={{ color: '#FFB74D' }}>T: {selectedPoint.currentTemperature.toFixed(1)}/{selectedPoint.targetTemperature.toFixed(1)}°C</div>
+          <div style={{ color: '#4FC3F7' }}>P: {selectedPoint.currentPressure.toFixed(1)}/{selectedPoint.targetPressure.toFixed(1)} bar</div>
           <div style={{ color: '#81C784' }}>F: {selectedPoint.currentFlow.toFixed(1)} g/s</div>
         </div>
       )}

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -286,9 +286,10 @@ export function HistoryChart({ shot }) {
             // Calculate constrained tooltip position relative to data point
             const dataPointX = chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
             const constrainedX = Math.max(chart.chartArea.left, Math.min(dataPointX, chart.chartArea.right));
+            const constrainedY = Math.max(chart.chartArea.top, Math.min(y, chart.chartArea.bottom));
             
             setSelectedPoint(pointData);
-            setTooltipPosition({ x: constrainedX, y });
+            setTooltipPosition({ x: constrainedX, y: constrainedY });
           }
         }
       }
@@ -435,9 +436,10 @@ export function HistoryChart({ shot }) {
                 // Calculate constrained tooltip position relative to data point
                 const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
                 const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+                const constrainedY = Math.max(e.target.chart.chartArea.top, Math.min(y, e.target.chart.chartArea.bottom));
                 
                 setSelectedPoint(pointData);
-                setTooltipPosition({ x: constrainedX, y });
+                setTooltipPosition({ x: constrainedX, y: constrainedY });
                 setIsDragging(true);
               }
             }
@@ -489,9 +491,10 @@ export function HistoryChart({ shot }) {
                   // Calculate constrained tooltip position relative to data point
                   const dataPointX = e.target.chart.scales.x.getPixelForValue(datasets[0].data[closestIndex].x);
                   const constrainedX = Math.max(e.target.chart.chartArea.left, Math.min(dataPointX, e.target.chart.chartArea.right));
+                  const constrainedY = Math.max(e.target.chart.chartArea.top, Math.min(y, e.target.chart.chartArea.bottom));
                   
                   setSelectedPoint(pointData);
-                  setTooltipPosition({ x: constrainedX, y });
+                  setTooltipPosition({ x: constrainedX, y: constrainedY });
                   setIsDragging(true);
                 }
               }

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -219,8 +219,18 @@ export function HistoryChart({ shot }) {
   useEffect(() => {
     if (!isDragging || !chartRef.current) return;
 
+    let lastUpdateTime = 0;
+    const throttleMs = 33; // ~30fps
+
     const handleMove = (event) => {
       event.preventDefault();
+      
+      // Throttle mouse events but allow touch events to run unthrottled
+      const now = Date.now();
+      if (!event.type.includes('touch') && now - lastUpdateTime < throttleMs) {
+        return;
+      }
+      lastUpdateTime = now;
       
       const rect = chartRef.current.getBoundingClientRect();
       let clientX, clientY;

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -1,7 +1,54 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { ChartComponent } from '../../components/Chart.jsx';
 
-function getChartData(data) {
+function getChartData(data, onPointClick, selectedPointIndex = null) {
+  // Create annotations object for visual indicators
+  const annotations = {};
+  
+  // Add selected point indicators
+  if (selectedPointIndex !== null && selectedPointIndex < data.length) {
+    const selectedTime = data[selectedPointIndex].t / 1000;
+    
+    // Add vertical line at selected point
+    annotations['selected_line'] = {
+      type: 'line',
+      xMin: selectedTime,
+      xMax: selectedTime,
+      borderColor: '#6366F1', // Indigo color
+      borderWidth: 2,
+      borderDash: [5, 5],
+      label: {
+        enabled: false
+      }
+    };
+    
+    // Add point indicators for each dataset
+    const datasetColors = ['#F0561D', '#731F00', '#0066CC', '#0066CC', '#63993D', '#204D00', '#63993D'];
+    const yAxisIds = ['y', 'y', 'y1', 'y1', 'y1', 'y1', 'y1'];
+    const values = [
+      data[selectedPointIndex].ct,
+      data[selectedPointIndex].tt,
+      data[selectedPointIndex].cp,
+      data[selectedPointIndex].tp,
+      data[selectedPointIndex].fl,
+      data[selectedPointIndex].pf,
+      data[selectedPointIndex].tf
+    ];
+    
+    values.forEach((value, index) => {
+      annotations[`selected_point_${index}`] = {
+        type: 'point',
+        xValue: selectedTime,
+        yValue: value,
+        yScaleID: yAxisIds[index],
+        backgroundColor: datasetColors[index],
+        borderColor: '#FFFFFF',
+        borderWidth: 2,
+        radius: 4
+      };
+    });
+  }
+  
   let start = 0;
   return {
     type: 'line',
@@ -11,7 +58,7 @@ function getChartData(data) {
           label: 'Current Temperature',
           borderColor: '#F0561D',
           pointStyle: false,
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.ct })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.ct })),
         },
         {
           label: 'Target Temperature',
@@ -19,14 +66,14 @@ function getChartData(data) {
           borderColor: '#731F00',
           borderDash: [6, 6],
           pointStyle: false,
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.tt })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.tt })),
         },
         {
           label: 'Current Pressure',
           borderColor: '#0066CC',
           pointStyle: false,
           yAxisID: 'y1',
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.cp })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.cp })),
         },
         {
           label: 'Target Pressure',
@@ -35,21 +82,21 @@ function getChartData(data) {
           borderDash: [6, 6],
           pointStyle: false,
           yAxisID: 'y1',
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.tp })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.tp })),
         },
         {
           label: 'Current Pump Flow',
           borderColor: '#63993D',
           pointStyle: false,
           yAxisID: 'y1',
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.fl })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.fl })),
         },
         {
           label: 'Current Puck Flow',
           borderColor: '#204D00',
           pointStyle: false,
           yAxisID: 'y1',
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.pf })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.pf })),
         },
         {
           label: 'Target Pump Flow',
@@ -57,12 +104,13 @@ function getChartData(data) {
           borderDash: [6, 6],
           pointStyle: false,
           yAxisID: 'y1',
-          data: data.map((i, idx) => ({ x: (i.t / 1000).toFixed(1), y: i.tf })),
+          data: data.map((i, idx) => ({ x: i.t / 1000, y: i.tf })),
         },
       ],
     },
     options: {
       responsive: true,
+      maintainAspectRatio: false,
       plugins: {
         legend: {
           position: 'top',
@@ -82,8 +130,16 @@ function getChartData(data) {
             size: window.innerWidth < 640 ? 14 : 16,
           },
         },
+        annotation: {
+          annotations: annotations
+        }
       },
       animation: false,
+      interaction: {
+        intersect: false,
+        mode: 'index',
+      },
+      onClick: onPointClick,
       scales: {
         y: {
           type: 'linear',
@@ -111,11 +167,22 @@ function getChartData(data) {
           },
         },
         x: {
+          type: 'linear',
+          display: true,
+          position: 'bottom',
+          title: {
+            display: true,
+            text: 'Time (s)'
+          },
           ticks: {
             source: 'auto',
+            callback: (value) => {
+              return `${value}s`;
+            },
             font: {
               size: window.innerWidth < 640 ? 10 : 12,
             },
+            maxTicksLimit: 10,
           },
         },
       },
@@ -124,7 +191,81 @@ function getChartData(data) {
 }
 
 export function HistoryChart({ shot }) {
-  const chartData = getChartData(shot.samples);
+  const [selectedPoint, setSelectedPoint] = useState(null);
+  
+  // Handle clicks outside the tooltip to dismiss it
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      // Check if the click is outside the tooltip
+      const tooltip = event.target.closest('.chart-tooltip');
+      const chart = event.target.closest('canvas');
+      
+      // If clicking outside tooltip but not on chart, dismiss
+      if (!tooltip && !chart && selectedPoint) {
+        setSelectedPoint(null);
+      }
+    };
 
-  return <ChartComponent className='' chartClassName='w-full' data={chartData} />;
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [selectedPoint]);
+  
+  const handlePointClick = (event, elements, chart) => {
+    if (elements.length > 0) {
+      const dataIndex = elements[0].index;
+      const datasets = chart.data.datasets;
+      const sampleData = shot.samples[dataIndex];
+      
+      // Get values from all datasets at this index
+      const pointData = {
+        time: (sampleData.t / 1000).toFixed(1),
+        currentTemperature: sampleData.ct,
+        targetTemperature: sampleData.tt,
+        currentPressure: sampleData.cp,
+        targetPressure: sampleData.tp,
+        currentPumpFlow: sampleData.fl,
+        currentPuckFlow: sampleData.pf,
+        targetPumpFlow: sampleData.tf,
+        dataIndex // Store the index for visual indicator
+      };
+      
+      setSelectedPoint(pointData);
+    } else {
+      setSelectedPoint(null);
+    }
+  };
+
+  const chartData = getChartData(shot.samples, handlePointClick, selectedPoint?.dataIndex);
+
+  return (
+    <div className="relative w-full">
+      <ChartComponent 
+        className='h-full min-h-[300px] w-full lg:min-h-[400px]' 
+        chartClassName='h-full w-full' 
+        data={chartData} 
+      />
+      
+      {selectedPoint && (
+        <div 
+          className="chart-tooltip absolute bg-black/90 p-1.5 rounded border border-gray-400/20 pointer-events-none"
+          style={{
+            fontSize: '11px',
+            lineHeight: '1.2',
+            left: '60px',
+            top: '60px',
+            minWidth: 'auto',
+            maxWidth: '160px'
+          }}
+        >
+          <div className="font-medium mb-0.5 text-white">{selectedPoint.time}s</div>
+          <div style={{ color: '#4FC3F7' }}>P: {selectedPoint.currentPressure.toFixed(1)}/{selectedPoint.targetPressure.toFixed(1)} bar</div>
+          <div style={{ color: '#FFB74D' }}>T: {selectedPoint.currentTemperature.toFixed(1)}/{selectedPoint.targetTemperature.toFixed(1)}°C</div>
+          <div style={{ color: '#81C784' }}>F: {selectedPoint.currentPumpFlow.toFixed(1)}/{selectedPoint.targetPumpFlow.toFixed(1)} g/s</div>
+          <div style={{ color: '#66BB6A' }}>PkF: {selectedPoint.currentPuckFlow.toFixed(1)} g/s</div>
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
Adds minimalist tool-tips to the WebUI charts and marks the chart with a vertical line and data points.

<img width="1255" height="808" alt="image" src="https://github.com/user-attachments/assets/1a9b85a4-068b-4312-a1dc-b1633432a9cf" />
<img width="733" height="612" alt="image" src="https://github.com/user-attachments/assets/4dd7f5ba-f78d-4954-a773-b7f8d5152d00" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive point selection across charts (click/tap, drag-to-scrub) with vertical selector and per-dataset markers.
  - Custom dismissible tooltips showing time, temperature, pressure, flow and point details; auto-positioning left/right.
  - Touch support for chart interactions.

- **Bug Fixes**
  - Chart canvas reliably fills its container and accepts pointer events.

- **Style**
  - Improved responsiveness and aspect-ratio handling for cleaner chart layout and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->