### PR TITLE
Fix shot history legend to match latest update on other webui charts.

### DIFF
--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -68,10 +68,26 @@ function getChartData(data) {
           position: 'top',
           display: true,
           labels: {
-            boxWidth: 12,
+            usePointStyle: true,
+            pointStyle: 'line',
+            pointStyleWidth: 20,
             padding: 8,
             font: {
               size: window.innerWidth < 640 ? 10 : 12,
+            },
+            generateLabels: function(chart) {
+              const original = Chart.defaults.plugins.legend.labels.generateLabels;
+              const labels = original.call(this, chart);
+              
+              labels.forEach((label, index) => {
+                const dataset = chart.data.datasets[index];
+                label.lineWidth = 3;
+                if (dataset.borderDash && dataset.borderDash.length > 0) {
+                  label.lineDash = dataset.borderDash;
+                }
+              });
+              
+              return labels;
             },
           },
         },


### PR DESCRIPTION
Fix shot history legend style to follow previous WebUI chart tweaks.

<img width="1288" height="400" alt="image" src="https://github.com/user-attachments/assets/a1d9ec1e-d262-44ea-a6ee-e7d5603b7930" />
