### PR TITLE
feat: build timestamp added at link-time to further avoid rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ node_modules/
 __pycache__
 data/
 .codebuddy
-src/version.h
+src/version.cpp

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,7 @@ lib_deps_default =
 [env:display]
 board = LilyGo-T-RGB
 upload_speed = 921600
-build_src_filter = -<*> +<display/> +<version.h>
+build_src_filter = -<*> +<display/> +<version.*>
 extra_scripts =
 	pre:scripts/auto_firmware_version.py
 lib_deps =
@@ -80,7 +80,7 @@ lib_deps =
 build_flags =
     ${display_common.build_flags}
     -DGAGGIMATE_HEADLESS
-build_src_filter = -<*> +<display/> +<version.h> -<display/drivers/> -<display/ui/> -<display/lv_conf.h>
+build_src_filter = -<*> +<display/> +<version.*> -<display/drivers/> -<display/ui/> -<display/lv_conf.h>
 
 [env:display-headless-8m]
 extends = env:display-headless
@@ -92,7 +92,7 @@ board = esp32-s3-supermini
 
 [env:controller]
 board = Gaggimate-Controller
-build_src_filter = -<*> +<controller/> +<version.h>
+build_src_filter = -<*> +<controller/> +<version.*>
 extra_scripts =
     pre:scripts/auto_firmware_version.py
 lib_deps =

--- a/scripts/auto_firmware_version.py
+++ b/scripts/auto_firmware_version.py
@@ -3,25 +3,20 @@ import datetime
 
 Import("env")
 
-def get_firmware_specifier_build_flag():
+def get_firmware_specifier():
     ret = subprocess.run(["git", "describe", "--tags", "--dirty", "--exclude", "nightly"], stdout=subprocess.PIPE, text=True) #Uses any tags
     build_version = ret.stdout.strip()
-    build_flag = "#define BUILD_GIT_VERSION \"" + build_version + "\""
     print ("Build version: " + build_version)
-    return build_flag
+    return build_version
 
-def get_time_specifier_build_flag():
+def get_time_specifier():
     build_timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    build_flag = "#define BUILD_TIMESTAMP \"" + build_timestamp + "\""
     print ("Build date: " + build_timestamp)
-    return build_flag
+    return build_timestamp
 
-with open('src/version.h', 'w') as f:
+with open('src/version.cpp', 'w') as f:
     f.write(
-        '#pragma once\n' +
-        '#ifndef GIT_VERSION_H\n' +
-        '#define GIT_VERSION_H\n' +
-        get_firmware_specifier_build_flag() + '\n' +
-        get_time_specifier_build_flag() + '\n'
-        '#endif\n'
-    )
+        f"""#include <Arduino.h>
+extern const String BUILD_GIT_VERSION = "{get_firmware_specifier()}";
+extern const String BUILD_TIMESTAMP = "{get_time_specifier()}";
+""")

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,7 @@
+#pragma once
+#ifndef GIT_VERSION_H
+#define GIT_VERSION_H
+#include <Arduino.h>
+extern const String BUILD_GIT_VERSION;
+extern const String BUILD_TIMESTAMP;
+#endif


### PR DESCRIPTION
Minor adjustment to the work done in [this commit](https://github.com/jniebuhr/gaggimate/commit/ed51f5d1f66b20ca07e4ec7045cdeb0429952f6b) so that changes to `version.h` don't flow through anywhere they are included and trigger a rebuild. Totally understandable if you're happy with the current approach using `#define` though!