### PR TITLE
Increase shot history stack depth - mitigate crashes

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -18,7 +18,7 @@ void ShotHistoryPlugin::setup(Controller *c, PluginManager *pm) {
            [this](Event const &event) { currentBluetoothWeight = event.getFloat("value"); });
     pm->on("boiler:currentTemperature:change", [this](Event const &event) { currentTemperature = event.getFloat("value"); });
     pm->on("pump:puck-resistance:change", [this](Event const &event) { currentPuckResistance = event.getFloat("value"); });
-    xTaskCreatePinnedToCore(loopTask, "ShotHistoryPlugin::loop", configMINIMAL_STACK_SIZE * 3, this, 1, &taskHandle, 0);
+    xTaskCreatePinnedToCore(loopTask, "ShotHistoryPlugin::loop", configMINIMAL_STACK_SIZE * 6, this, 1, &taskHandle, 0);
 }
 
 void ShotHistoryPlugin::record() {


### PR DESCRIPTION
Increase shot history stack depth to 6x minimal to prevent crashes during heavy file I/O and string operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Bug Fixes
  - Improved reliability of the Shot History feature, addressing rare crashes/freezes during prolonged or intensive use.
- Performance
  - Increased internal headroom for Shot History background processing, reducing the likelihood of interruptions on resource-constrained devices.
- Notes
  - No changes to UI or workflows; benefits are stability and smoother operation behind the scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->