### PR TITLE
fix: Fix switching volumetric source while running a shot

### DIFF
--- a/.github/workflows/pr-flash.yml
+++ b/.github/workflows/pr-flash.yml
@@ -10,6 +10,7 @@ jobs:
       contents: write
       pages: write
       pull-requests: write
+    continue-on-error: true
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -41,22 +42,21 @@ jobs:
     - name: Build Web
       run: ./scripts/build_spiffs.sh
     - name: Build controller
-      run: pio run -e controller
-    - name: Build display
-      run: pio run -e display
-    - name: Rename firmware files
       run: |
+        pio run -e controller
         mv .pio/build/controller/firmware.bin out/board-firmware.bin
         mv .pio/build/controller/partitions.bin out/board-partitions.bin
         mv .pio/build/controller/bootloader.bin out/board-bootloader.bin
+    - name: Build display
+      run: |
+        pio run -e display
         mv .pio/build/display/firmware.bin out/display-firmware.bin
         mv .pio/build/display/partitions.bin out/display-partitions.bin
         mv .pio/build/display/bootloader.bin out/display-bootloader.bin
     - name: Build display FS
-      run: pio run -t buildfs -e display
-    - name: Rename FS files
       run: |
-        mv .pio/build/display/spiffs.bin out/display-filesystem.bin
+        pio run -t buildfs -e display
+        cp .pio/build/display/spiffs.bin out/display-filesystem.bin
     - name: Deploy to GitHub Pages subdirectory
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
       with:

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -632,7 +632,7 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     }
 
     if (currentVolumetricSource != source) {
-        ESP_LOGD(LOG_TAG, "Ignoring volumetric measurement, source does not match", timeSinceLastBluetooth);
+        ESP_LOGD(LOG_TAG, "Ignoring volumetric measurement, source does not match");
         return;
     }
     if (currentProcess != nullptr) {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -511,8 +511,14 @@ void Controller::activate() {
         return;
     clear();
     clientController.tare();
-    if (isVolumetricAvailable())
+    if (isVolumetricAvailable()) {
+#ifdef NIGHTLY_BUILD
+        currentVolumetricSource = isBluetoothScaleHealthy() ? VolumetricMeasurementSource::BLUETOOTH : VolumetricMeasurementSource::FLOW_ESTIMATION;
+#else
+        currentVolumetricSource = VolumetricMeasurementSource::FLOW_ESTIMATION;
+#endif
         pluginManager->trigger("controller:brew:prestart");
+    }
     delay(200);
     switch (mode) {
     case MODE_BREW:
@@ -557,6 +563,7 @@ void Controller::clear() {
     }
     delete lastProcess;
     lastProcess = nullptr;
+    currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
 }
 
 void Controller::activateGrind() {
@@ -624,16 +631,10 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
         lastBluetoothMeasurement = millis();
     }
 
-#ifdef NIGHTLY_BUILD
-    if (source == VolumetricMeasurementSource::FLOW_ESTIMATION && isBluetoothScaleHealthy()) {
-        ESP_LOGD(LOG_TAG, "Ignoring flow estimation, bluetooth scale available (%lums ago)", timeSinceLastBluetooth);
+    if (currentVolumetricSource != source) {
+        ESP_LOGD(LOG_TAG, "Ignoring volumetric measurement, source does not match", timeSinceLastBluetooth);
         return;
     }
-#else
-    if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
-        return;
-    }
-#endif
     if (currentProcess != nullptr) {
         currentProcess->updateVolume(measurement);
     }

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -515,7 +515,7 @@ void Controller::activate() {
 #ifdef NIGHTLY_BUILD
         currentVolumetricSource = isBluetoothScaleHealthy() ? VolumetricMeasurementSource::BLUETOOTH : VolumetricMeasurementSource::FLOW_ESTIMATION;
 #else
-        currentVolumetricSource = VolumetricMeasurementSource::FLOW_ESTIMATION;
+        currentVolumetricSource = VolumetricMeasurementSource::BLUETOOTH;
 #endif
         pluginManager->trigger("controller:brew:prestart");
     }

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -15,7 +15,7 @@
 const IPAddress WIFI_AP_IP(4, 4, 4, 1); // the IP address the web server, Samsung requires the IP to be in public space
 const IPAddress WIFI_SUBNET_MASK(255, 255, 255, 0); // no need to change: https://avinetworks.com/glossary/subnet-mask/
 
-enum class VolumetricMeasurementSource { FLOW_ESTIMATION, BLUETOOTH };
+enum class VolumetricMeasurementSource { INACTIVE, FLOW_ESTIMATION, BLUETOOTH };
 
 class Controller {
   public:
@@ -159,6 +159,7 @@ class Controller {
     int error = 0;
 
     // Bluetooth scale connection monitoring
+    VolumetricMeasurementSource currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
     unsigned long lastBluetoothMeasurement = 0;
     static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 1500; // 1.5 second grace period
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically selects and tracks the active volumetric measurement source at runtime; supports an explicit inactive state.
- Bug Fixes
  - Ignores measurements from inactive or mismatched sources to prevent incorrect readings.
  - Prevents false prestart triggers when volumetric data isn’t available.
- Improvements
  - Clearer diagnostic logs for source mismatches and state transitions; more consistent behavior across variants.
- Chores
  - CI workflow: more resilient deploy step and consolidated build/file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->