### PR TITLE
fix: Rewrite scripts to analyze support file

### DIFF
--- a/scripts/analyze_coredump.py
+++ b/scripts/analyze_coredump.py
@@ -10,12 +10,12 @@ Usage:
     python3 scripts/analyze_coredump.py <coredump_file> [environment_or_elf_file] [elf_file]
     
 Examples:
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin display
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin controller
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin display-headless
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin /path/to/firmware.elf
-    python3 scripts/analyze_coredump.py /path/to/coredump.bin display /path/to/firmware.elf
+    python3 scripts/analyze_coredump.py /path/to/support.bin
+    python3 scripts/analyze_coredump.py /path/to/support.bin display
+    python3 scripts/analyze_coredump.py /path/to/support.bin controller
+    python3 scripts/analyze_coredump.py /path/to/support.bin display-headless
+    python3 scripts/analyze_coredump.py /path/to/support.bin /path/to/firmware.elf
+    python3 scripts/analyze_coredump.py /path/to/support.bin display /path/to/firmware.elf
 
 Environments:
     display           - Main display controller (default)
@@ -30,6 +30,8 @@ import sys
 import subprocess
 import tempfile
 import shutil
+import json
+import base64
 from pathlib import Path
 
 def find_pio_build_dir(environment="display"):
@@ -214,8 +216,23 @@ def main():
         print("  python3 scripts/analyze_coredump.py ~/Downloads/coredump.bin display /path/to/firmware.elf")
         sys.exit(1)
     
-    coredump_file = sys.argv[1]
-    
+    support_file = sys.argv[1]
+    support_data = {
+        'versions': {
+            'displayVersion': 'unknown'
+        }
+    }
+
+    coredump_file = "coredump.bin"
+    with open(support_file, 'r') as f:
+        support_data = json.load(f)
+        coredump = support_data['coredump']
+        coredump_binary = base64.b64decode(coredump)
+        with open(coredump_file, 'wb') as f2:
+            f2.write(coredump_binary)
+
+
+
     # Parse arguments - support both environment and direct ELF file specification
     environment = "display"  # default
     custom_elf_file = None
@@ -233,6 +250,8 @@ def main():
     
     print("🚀 ESP32 Core Dump Analyzer")
     print("="*50)
+    print(f"Version: {support_data['versions']['displayVersion']}")
+    print(f"Support file: {support_file}")
     print(f"Core dump: {coredump_file}")
     if custom_elf_file:
         print(f"ELF file: {custom_elf_file}")

--- a/scripts/analyze_coredump.sh
+++ b/scripts/analyze_coredump.sh
@@ -8,15 +8,15 @@
 #   ./scripts/analyze_coredump.sh <coredump_file> [environment]
 #
 # Examples:
-#   ./scripts/analyze_coredump.sh ~/Downloads/coredump.bin
-#   ./scripts/analyze_coredump.sh ~/Downloads/coredump.bin display
-#   ./scripts/analyze_coredump.sh ~/Downloads/coredump.bin controller
-#   ./scripts/analyze_coredump.sh ~/Downloads/coredump.bin display-headless
+#   ./scripts/analyze_coredump.sh ~/Downloads/support.bin
+#   ./scripts/analyze_coredump.sh ~/Downloads/support.bin display
+#   ./scripts/analyze_coredump.sh ~/Downloads/support.bin controller
+#   ./scripts/analyze_coredump.sh ~/Downloads/support.bin display-headless
 #
 
 # Check if at least one argument is provided
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <coredump_file> [environment]"
+    echo "Usage: $0 <support_file> [environment]"
     echo ""
     echo "Available environments:"
     echo "  display           - Main display controller (default)"
@@ -24,9 +24,9 @@ if [ $# -lt 1 ]; then
     echo "  display-headless  - Headless display mode"
     echo ""
     echo "Examples:"
-    echo "  $0 ~/Downloads/coredump.bin"
-    echo "  $0 ~/Downloads/coredump.bin display"
-    echo "  $0 ~/Downloads/coredump.bin controller"
+    echo "  $0 ~/Downloads/support.bin"
+    echo "  $0 ~/Downloads/support.bin display"
+    echo "  $0 ~/Downloads/support.bin controller"
     exit 1
 fi
 

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -4,20 +4,20 @@
 #include <esp_system.h>
 #include <esp_core_dump.h>
 #include <esp_err.h>
-#include <esp_log.h>
 #include <esp_partition.h>
 #include <display/core/Controller.h>
 #include <display/core/ProfileManager.h>
 #include <display/core/process/BrewProcess.h>
 #include <display/models/profile.h>
 
-#include "BLEScalePlugin.h"
-#include "ShotHistoryPlugin.h"
+#include <display/plugins/BLEScalePlugin.h>
+#include <display/plugins/ShotHistoryPlugin.h>
 #include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <version.h>
+
 static std::unordered_map<uint32_t, std::string> rxBuffers;
 static WebUIPlugin* g_webUIPlugin = nullptr;
 
@@ -639,7 +639,7 @@ void WebUIPlugin::handleCoreDumpDownload(AsyncWebServerRequest *request) {
                 ESP_LOGE("WebUIPlugin", "Failed to read core dump: %s", esp_err_to_name(err));
                 return 0;
             }
-            
+
             return toRead;
         }
     );

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -4,16 +4,11 @@
 #define ELEGANTOTA_USE_ASYNC_WEBSERVER 1
 
 #include <DNSServer.h>
-#include <esp_system.h>
-#include <esp_log.h>
 
-#include "../core/Plugin.h"
+#include <display/core/Plugin.h>
 #include "GitHubOTA.h"
-#include "ShotHistoryPlugin.h"
 #include <ArduinoJson.h>
-#include <AsyncJson.h>
 #include <ESPAsyncWebServer.h>
-#include <vector>
 
 constexpr size_t UPDATE_CHECK_INTERVAL = 5 * 60 * 1000;
 constexpr size_t CLEANUP_PERIOD = 5 * 1000;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Download Support Data” in the Web UI to export a single support file (.dat) containing sanitized settings, version info, and the device core dump.
  - Automatically timestamps the exported file name.

- Refactor
  - Command-line analysis now accepts a support file instead of a raw core dump, with improved validation and diagnostics.
  - Temporary analysis artifacts are cleaned up after processing.

- Documentation
  - Updated usage/help text to reference the new support file workflow and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->