### PR TITLE
Shot history index and front-end search tools

### DIFF
--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -66,4 +66,45 @@ struct ShotLogSample {
 static_assert(sizeof(ShotLogHeader) == SHOT_LOG_HEADER_SIZE, "ShotLogHeader size mismatch");
 static_assert(sizeof(ShotLogSample) == SHOT_LOG_SAMPLE_SIZE, "ShotLogSample size mismatch");
 
+// Binary shot index format
+// File: /h/index.bin
+// Layout: ShotIndexHeader followed by contiguous ShotIndexEntry records
+// All values little-endian
+
+static constexpr uint32_t SHOT_INDEX_MAGIC = 0x58444953; // 'S''I''D''X' little-endian
+static constexpr uint16_t SHOT_INDEX_VERSION = 1;
+static constexpr uint16_t SHOT_INDEX_HEADER_SIZE = 32;
+static constexpr uint16_t SHOT_INDEX_ENTRY_SIZE = 128;
+
+// Index entry flags
+static constexpr uint8_t SHOT_FLAG_COMPLETED = 0x01;
+static constexpr uint8_t SHOT_FLAG_DELETED = 0x02;
+static constexpr uint8_t SHOT_FLAG_HAS_NOTES = 0x04;
+
+#pragma pack(push,1)
+struct ShotIndexHeader {
+    uint32_t magic;          // SHOT_INDEX_MAGIC
+    uint16_t version;        // SHOT_INDEX_VERSION
+    uint16_t entrySize;      // SHOT_INDEX_ENTRY_SIZE
+    uint32_t entryCount;     // Number of entries in file
+    uint32_t nextId;         // Next shot ID to use
+    uint8_t  reserved[16];   // Future expansion
+};
+
+struct ShotIndexEntry {
+    uint32_t id;             // Shot ID
+    uint32_t timestamp;      // Unix timestamp
+    uint32_t duration;       // Duration in ms
+    uint16_t volume;         // Final weight (g * 10)
+    uint8_t  rating;         // 0-5 star rating from notes
+    uint8_t  flags;          // Bit flags (completed, deleted, etc.)
+    char     profileId[32];  // Profile ID, null-terminated
+    char     profileName[48];// Profile name, null-terminated
+    uint8_t  reserved[32];   // Future expansion
+};
+#pragma pack(pop)
+
+static_assert(sizeof(ShotIndexHeader) == SHOT_INDEX_HEADER_SIZE, "ShotIndexHeader size mismatch");
+static_assert(sizeof(ShotIndexEntry) == SHOT_INDEX_ENTRY_SIZE, "ShotIndexEntry size mismatch");
+
 #endif // SHOT_LOG_FORMAT_H

--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -36,7 +36,8 @@ struct ShotLogHeader {
     uint32_t startEpoch;     // epoch seconds
     char     profileId[32];  // null-terminated
     char     profileName[48];// null-terminated
-    uint8_t  reserved[128 - 4 -1 -1 -2 -2 -2 -4 -4 -4 -4 -32 -48]; // pad to 128
+    uint16_t finalWeight;    // final beverage weight (g * 10)
+    uint8_t  reserved[128 - 4 -1 -1 -2 -2 -2 -4 -4 -4 -4 -32 -48 -2]; // pad to 128
 };
 #pragma pack(pop)
 

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -106,20 +106,20 @@ void ShotHistoryPlugin::record() {
         currentBluetoothFlow = currentBluetoothFlow * 0.75f + btFlow * 0.25f;
         lastBluetoothWeight = currentBluetoothWeight;
 
-    ShotLogSample sample{};
-    uint32_t tick = sampleCount <= 0xFFFF ? sampleCount : 0xFFFF;
-    sample.t = static_cast<uint16_t>(tick);
-    sample.tt = encodeUnsigned(controller->getTargetTemp(), TEMP_SCALE, TEMP_MAX_VALUE);
-    sample.ct = encodeUnsigned(currentTemperature, TEMP_SCALE, TEMP_MAX_VALUE);
-    sample.tp = encodeUnsigned(controller->getTargetPressure(), PRESSURE_SCALE, PRESSURE_MAX_VALUE);
-    sample.cp = encodeUnsigned(controller->getCurrentPressure(), PRESSURE_SCALE, PRESSURE_MAX_VALUE);
-    sample.fl = encodeSigned(controller->getCurrentPumpFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-    sample.tf = encodeSigned(controller->getTargetFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-    sample.pf = encodeSigned(controller->getCurrentPuckFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-    sample.vf = encodeSigned(currentBluetoothFlow, FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-    sample.v = encodeUnsigned(currentBluetoothWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
-    sample.ev = encodeUnsigned(currentEstimatedWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
-    sample.pr = encodeUnsigned(currentPuckResistance, RESISTANCE_SCALE, RESISTANCE_MAX_VALUE);
+        ShotLogSample sample{};
+        uint32_t tick = sampleCount <= 0xFFFF ? sampleCount : 0xFFFF;
+        sample.t = static_cast<uint16_t>(tick);
+        sample.tt = encodeUnsigned(controller->getTargetTemp(), TEMP_SCALE, TEMP_MAX_VALUE);
+        sample.ct = encodeUnsigned(currentTemperature, TEMP_SCALE, TEMP_MAX_VALUE);
+        sample.tp = encodeUnsigned(controller->getTargetPressure(), PRESSURE_SCALE, PRESSURE_MAX_VALUE);
+        sample.cp = encodeUnsigned(controller->getCurrentPressure(), PRESSURE_SCALE, PRESSURE_MAX_VALUE);
+        sample.fl = encodeSigned(controller->getCurrentPumpFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
+        sample.tf = encodeSigned(controller->getTargetFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
+        sample.pf = encodeSigned(controller->getCurrentPuckFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
+        sample.vf = encodeSigned(currentBluetoothFlow, FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
+        sample.v = encodeUnsigned(currentBluetoothWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
+        sample.ev = encodeUnsigned(currentEstimatedWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
+        sample.pr = encodeUnsigned(currentPuckResistance, RESISTANCE_SCALE, RESISTANCE_MAX_VALUE);
 
         if (isFileOpen) {
             if (ioBufferPos + sizeof(sample) > sizeof(ioBuffer)) {
@@ -128,6 +128,12 @@ void ShotHistoryPlugin::record() {
             memcpy(ioBuffer + ioBufferPos, &sample, sizeof(sample));
             ioBufferPos += sizeof(sample);
             sampleCount++;
+        }
+        
+        // Check for early index insertion (once per shot after 7.5s)
+        if (!indexEntryCreated && (millis() - shotStart) > 7500) {
+            createEarlyIndexEntry();
+            indexEntryCreated = true;
         }
     }
     if (!recording && isFileOpen) {
@@ -145,9 +151,34 @@ void ShotHistoryPlugin::record() {
         if (duration <= 7500) { // Exclude failed shots and flushes
             SPIFFS.remove("/h/" + currentId + ".slog");
             SPIFFS.remove("/h/" + currentId + ".json");
+            
+            // If we created an early index entry, mark it as deleted
+            if (indexEntryCreated) {
+                markIndexDeleted(currentId.toInt());
+            }
         } else {
             controller->getSettings().setHistoryIndex(controller->getSettings().getHistoryIndex() + 1);
             cleanupHistory();
+            
+            if (indexEntryCreated) {
+                // Update existing entry with final completion data
+                updateIndexCompletion(currentId.toInt(), header);
+            } else {
+                // Create completed entry directly (edge case: shot ended right after 7.5s)
+                ShotIndexEntry indexEntry{};
+                indexEntry.id = currentId.toInt();
+                indexEntry.timestamp = header.startEpoch;
+                indexEntry.duration = header.durationMs;
+                indexEntry.volume = header.finalWeight;
+                indexEntry.rating = 0; // Will be updated if notes are added
+                indexEntry.flags = SHOT_FLAG_COMPLETED;
+                strncpy(indexEntry.profileId, header.profileId, sizeof(indexEntry.profileId) - 1);
+                indexEntry.profileId[sizeof(indexEntry.profileId) - 1] = '\0';
+                strncpy(indexEntry.profileName, header.profileName, sizeof(indexEntry.profileName) - 1);
+                indexEntry.profileName[sizeof(indexEntry.profileName) - 1] = '\0';
+                
+                appendToIndex(indexEntry);
+            }
         }
     }
 }
@@ -164,6 +195,7 @@ void ShotHistoryPlugin::startRecording() {
     currentBluetoothFlow = 0.0f;
     currentProfileName = controller->getProfileManager()->getSelectedProfile().label;
     recording = true;
+    indexEntryCreated = false;  // Reset flag for new shot
     sampleCount = 0;
     ioBufferPos = 0;
 }
@@ -242,6 +274,10 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         auto id = request["id"].as<String>();
         SPIFFS.remove("/h/" + id + ".slog");
         SPIFFS.remove("/h/" + id + ".json");
+        
+        // Mark as deleted in index
+        markIndexDeleted(id.toInt());
+        
         response["msg"] = "Ok";
     } else if (type == "req:history:notes:get") {
         auto id = request["id"].as<String>();
@@ -249,11 +285,31 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         loadNotes(id, notes);
         response["notes"] = notes;
     } else if (type == "req:history:notes:save") {
-        const String id = request["id"].as<String>();
-        const JsonDocument &notesDoc = request["notes"];
-
-        saveNotes(id, notesDoc);
+        auto id = request["id"].as<String>();
+        auto notes = request["notes"];
+        saveNotes(id, notes);
+        
+        // Update rating and volume in index
+        uint8_t rating = notes["rating"].as<uint8_t>();
+        
+        // Check if user provided a doseOut value to override volume
+        uint16_t volume = 0;
+        if (notes["doseOut"].is<String>() && !notes["doseOut"].as<String>().isEmpty()) {
+            float doseOut = notes["doseOut"].as<String>().toFloat();
+            if (doseOut > 0.0f) {
+                volume = encodeUnsigned(doseOut, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
+            }
+        }
+        
+        // Always use updateIndexMetadata - it handles both rating and optional volume
+        updateIndexMetadata(id.toInt(), rating, volume);
+        
+        response["msg"] = "Ok";
+    } else if (type == "req:history:rebuild") {
+        rebuildIndex();
+        response["msg"] = "Index rebuilt";
     }
+    
 }
 
 void ShotHistoryPlugin::saveNotes(const String &id, const JsonDocument &notes) {
@@ -289,4 +345,336 @@ void ShotHistoryPlugin::flushBuffer() {
         currentFile.write(ioBuffer, ioBufferPos);
         ioBufferPos = 0;
     }
+}
+
+// Index management methods
+bool ShotHistoryPlugin::ensureIndexExists() {
+    if (SPIFFS.exists("/h/index.bin")) {
+        return true;
+    }
+    
+    // Create new empty index
+    File indexFile = SPIFFS.open("/h/index.bin", FILE_WRITE);
+    if (!indexFile) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to create index file");
+        return false;
+    }
+    
+    ShotIndexHeader header{};
+    header.magic = SHOT_INDEX_MAGIC;
+    header.version = SHOT_INDEX_VERSION;
+    header.entrySize = SHOT_INDEX_ENTRY_SIZE;
+    header.entryCount = 0;
+    header.nextId = controller->getSettings().getHistoryIndex();
+    
+    indexFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
+    indexFile.close();
+    
+    ESP_LOGI("ShotHistoryPlugin", "Created new index file");
+    return true;
+}
+
+void ShotHistoryPlugin::appendToIndex(const ShotIndexEntry &entry) {
+    if (!ensureIndexExists()) {
+        return;
+    }
+    
+    File indexFile = SPIFFS.open("/h/index.bin", "r+");
+    if (!indexFile) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for append");
+        return;
+    }
+    
+    ShotIndexHeader header{};
+    if (!readIndexHeader(indexFile, header)) {
+        indexFile.close();
+        return;
+    }
+    
+    // Append entry
+    indexFile.seek(0, SeekEnd);
+    indexFile.write(reinterpret_cast<const uint8_t *>(&entry), sizeof(entry));
+    
+    // Update header
+    header.entryCount++;
+    header.nextId = entry.id + 1;
+    indexFile.seek(0, SeekSet);
+    indexFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
+    
+    indexFile.close();
+    ESP_LOGD("ShotHistoryPlugin", "Appended shot %u to index", entry.id);
+}
+
+void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume) {
+    File indexFile = SPIFFS.open("/h/index.bin", "r+");
+    if (!indexFile) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for metadata update");
+        return;
+    }
+    
+    ShotIndexHeader header{};
+    if (!readIndexHeader(indexFile, header)) {
+        indexFile.close();
+        return;
+    }
+    
+    int entryPos = findEntryPosition(indexFile, header, shotId);
+    if (entryPos >= 0) {
+        ShotIndexEntry entry{};
+        if (readEntryAtPosition(indexFile, entryPos, entry)) {
+            entry.rating = rating;
+            if (volume > 0) {
+                entry.volume = volume;
+            }
+            if (rating > 0) {
+                entry.flags |= SHOT_FLAG_HAS_NOTES;
+            }
+            
+            if (writeEntryAtPosition(indexFile, entryPos, entry)) {
+                ESP_LOGD("ShotHistoryPlugin", "Updated metadata for shot %u: rating=%u, volume=%u", shotId, rating, volume);
+            }
+        }
+    } else {
+        ESP_LOGW("ShotHistoryPlugin", "Shot %u not found in index for metadata update", shotId);
+    }
+    
+    indexFile.close();
+}
+
+void ShotHistoryPlugin::markIndexDeleted(uint32_t shotId) {
+    File indexFile = SPIFFS.open("/h/index.bin", "r+");
+    if (!indexFile) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for deletion marking");
+        return;
+    }
+    
+    ShotIndexHeader header{};
+    if (!readIndexHeader(indexFile, header)) {
+        indexFile.close();
+        return;
+    }
+    
+    int entryPos = findEntryPosition(indexFile, header, shotId);
+    if (entryPos >= 0) {
+        ShotIndexEntry entry{};
+        if (readEntryAtPosition(indexFile, entryPos, entry)) {
+            entry.flags |= SHOT_FLAG_DELETED;
+            
+            if (writeEntryAtPosition(indexFile, entryPos, entry)) {
+                ESP_LOGD("ShotHistoryPlugin", "Marked shot %u as deleted in index", shotId);
+            }
+        }
+    } else {
+        ESP_LOGW("ShotHistoryPlugin", "Shot %u not found in index for deletion marking", shotId);
+    }
+    
+    indexFile.close();
+}
+
+void ShotHistoryPlugin::rebuildIndex() {
+    ESP_LOGI("ShotHistoryPlugin", "Starting index rebuild...");
+    
+    // Delete existing index
+    SPIFFS.remove("/h/index.bin");
+    
+    // Create new empty index
+    if (!ensureIndexExists()) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to create index during rebuild");
+        return;
+    }
+    
+    File directory = SPIFFS.open("/h");
+    if (!directory || !directory.isDirectory()) {
+        ESP_LOGW("ShotHistoryPlugin", "No history directory found");
+        return;
+    }
+    
+    // Collect all .slog files
+    std::vector<String> slogFiles;
+    File file = directory.openNextFile();
+    while (file) {
+        String fname = String(file.name());
+        if (fname.endsWith(".slog")) {
+            slogFiles.push_back(fname);
+        }
+        file = directory.openNextFile();
+    }
+    directory.close();
+    
+    // Sort files to maintain order
+    std::sort(slogFiles.begin(), slogFiles.end());
+    
+    ESP_LOGI("ShotHistoryPlugin", "Rebuilding index from %d shot files", slogFiles.size());
+    
+    for (const String &fileName : slogFiles) {
+        File shotFile = SPIFFS.open(fileName, "r");
+        if (!shotFile) {
+            continue;
+        }
+        
+        // Read shot header
+        ShotLogHeader shotHeader{};
+        if (shotFile.read(reinterpret_cast<uint8_t *>(&shotHeader), sizeof(shotHeader)) != sizeof(shotHeader) ||
+            shotHeader.magic != SHOT_LOG_MAGIC) {
+            shotFile.close();
+            continue;
+        }
+        
+        // Extract shot ID from filename
+        int start = fileName.lastIndexOf('/') + 1;
+        int end = fileName.lastIndexOf('.');
+        uint32_t shotId = fileName.substring(start, end).toInt();
+        
+        // Create index entry
+        ShotIndexEntry entry{};
+        entry.id = shotId;
+        entry.timestamp = shotHeader.startEpoch;
+        entry.duration = shotHeader.durationMs;
+        entry.volume = shotHeader.finalWeight;
+        entry.rating = 0; // Will be updated if notes exist
+        entry.flags = SHOT_FLAG_COMPLETED;
+        strncpy(entry.profileId, shotHeader.profileId, sizeof(entry.profileId) - 1);
+        entry.profileId[sizeof(entry.profileId) - 1] = '\0';
+        strncpy(entry.profileName, shotHeader.profileName, sizeof(entry.profileName) - 1);
+        entry.profileName[sizeof(entry.profileName) - 1] = '\0';
+        
+        // Check for incomplete shots
+        if (shotHeader.sampleCount == 0) {
+            entry.flags &= ~SHOT_FLAG_COMPLETED;
+        }
+        
+        // Check for notes and extract rating and volume override
+        String notesPath = "/h/" + String(shotId, 10) + ".json";
+        if (SPIFFS.exists(notesPath)) {
+            entry.flags |= SHOT_FLAG_HAS_NOTES;
+            
+            File notesFile = SPIFFS.open(notesPath, "r");
+            if (notesFile) {
+                String notesStr = notesFile.readString();
+                notesFile.close();
+                
+                JsonDocument notesDoc;
+                if (deserializeJson(notesDoc, notesStr) == DeserializationError::Ok) {
+                    entry.rating = notesDoc["rating"].as<uint8_t>();
+                    
+                    // Check if user provided a doseOut value to override volume
+                    if (notesDoc["doseOut"].is<String>() && !notesDoc["doseOut"].as<String>().isEmpty()) {
+                        float doseOut = notesDoc["doseOut"].as<String>().toFloat();
+                        if (doseOut > 0.0f) {
+                            entry.volume = encodeUnsigned(doseOut, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
+                        }
+                    }
+                }
+            }
+        }
+        
+        shotFile.close();
+        
+        // Append to index
+        appendToIndex(entry);
+    }
+    
+    ESP_LOGI("ShotHistoryPlugin", "Index rebuild completed");
+}
+
+// Index helper functions
+bool ShotHistoryPlugin::readIndexHeader(File& indexFile, ShotIndexHeader& header) {
+    if (indexFile.read(reinterpret_cast<uint8_t *>(&header), sizeof(header)) != sizeof(header)) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to read index header");
+        return false;
+    }
+    if (header.magic != SHOT_INDEX_MAGIC) {
+        ESP_LOGE("ShotHistoryPlugin", "Invalid index magic: 0x%08X", header.magic);
+        return false;
+    }
+    return true;
+}
+
+int ShotHistoryPlugin::findEntryPosition(File& indexFile, const ShotIndexHeader& header, uint32_t shotId) {
+    for (uint32_t i = 0; i < header.entryCount; i++) {
+        size_t entryPos = sizeof(ShotIndexHeader) + i * sizeof(ShotIndexEntry);
+        indexFile.seek(entryPos, SeekSet);
+        
+        ShotIndexEntry entry{};
+        if (!readEntryAtPosition(indexFile, entryPos, entry)) {
+            ESP_LOGW("ShotHistoryPlugin", "Failed to read entry at position %u", i);
+            break;
+        }
+        
+        if (entry.id == shotId) {
+            return entryPos;
+        }
+    }
+    return -1;
+}
+
+bool ShotHistoryPlugin::readEntryAtPosition(File& indexFile, size_t position, ShotIndexEntry& entry) {
+    indexFile.seek(position, SeekSet);
+    if (indexFile.read(reinterpret_cast<uint8_t *>(&entry), sizeof(entry)) != sizeof(entry)) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to read entry at position %zu", position);
+        return false;
+    }
+    return true;
+}
+
+bool ShotHistoryPlugin::writeEntryAtPosition(File& indexFile, size_t position, const ShotIndexEntry& entry) {
+    indexFile.seek(position, SeekSet);
+    if (indexFile.write(reinterpret_cast<const uint8_t *>(&entry), sizeof(entry)) != sizeof(entry)) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to write entry at position %zu", position);
+        return false;
+    }
+    return true;
+}
+
+void ShotHistoryPlugin::createEarlyIndexEntry() {
+    Profile profile = controller->getProfileManager()->getSelectedProfile();
+    
+    ShotIndexEntry indexEntry{};
+    indexEntry.id = currentId.toInt();
+    indexEntry.timestamp = header.startEpoch;
+    indexEntry.duration = 0;  // Will be updated on completion
+    indexEntry.volume = 0;    // Will be updated on completion
+    indexEntry.rating = 0;
+    indexEntry.flags = 0;     // No SHOT_FLAG_COMPLETED - indicates incomplete shot
+    strncpy(indexEntry.profileId, profile.id.c_str(), sizeof(indexEntry.profileId) - 1);
+    indexEntry.profileId[sizeof(indexEntry.profileId) - 1] = '\0';
+    strncpy(indexEntry.profileName, profile.label.c_str(), sizeof(indexEntry.profileName) - 1);
+    indexEntry.profileName[sizeof(indexEntry.profileName) - 1] = '\0';
+    
+    appendToIndex(indexEntry);
+    ESP_LOGD("ShotHistoryPlugin", "Created early index entry for shot %u", indexEntry.id);
+}
+
+void ShotHistoryPlugin::updateIndexCompletion(uint32_t shotId, const ShotLogHeader& finalHeader) {
+    File indexFile = SPIFFS.open("/h/index.bin", "r+");
+    if (!indexFile) {
+        ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for completion update");
+        return;
+    }
+    
+    ShotIndexHeader header{};
+    if (!readIndexHeader(indexFile, header)) {
+        indexFile.close();
+        return;
+    }
+    
+    int entryPos = findEntryPosition(indexFile, header, shotId);
+    if (entryPos >= 0) {
+        ShotIndexEntry entry{};
+        if (readEntryAtPosition(indexFile, entryPos, entry)) {
+            // Update with final shot data
+            entry.duration = finalHeader.durationMs;
+            entry.volume = finalHeader.finalWeight;
+            entry.flags |= SHOT_FLAG_COMPLETED;  // Mark as completed
+            
+            if (writeEntryAtPosition(indexFile, entryPos, entry)) {
+                ESP_LOGD("ShotHistoryPlugin", "Updated shot %u completion: duration=%u, volume=%u", 
+                         shotId, entry.duration, entry.volume);
+            }
+        }
+    } else {
+        ESP_LOGW("ShotHistoryPlugin", "Shot %u not found in index for completion update", shotId);
+    }
+    
+    indexFile.close();
 }

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -7,7 +7,7 @@
 #include <display/core/utils.h>
 #include <display/models/shot_log_format.h>
 
-constexpr size_t MAX_HISTORY_ENTRIES = 10;
+constexpr size_t MAX_HISTORY_ENTRIES = 100;  // Increased from 10
 
 class ShotHistoryPlugin : public Plugin {
   public:
@@ -20,7 +20,21 @@ class ShotHistoryPlugin : public Plugin {
 
     void handleRequest(JsonDocument &request, JsonDocument &response);
 
+    // Index management methods
+    void appendToIndex(const ShotIndexEntry &entry);
+    void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume);
+    void markIndexDeleted(uint32_t shotId);
+    void rebuildIndex();
+    bool ensureIndexExists();
+
   private:
+    // Index helper functions
+    bool readIndexHeader(File& indexFile, ShotIndexHeader& header);
+    int findEntryPosition(File& indexFile, const ShotIndexHeader& header, uint32_t shotId);
+    bool readEntryAtPosition(File& indexFile, size_t position, ShotIndexEntry& entry);
+    bool writeEntryAtPosition(File& indexFile, size_t position, const ShotIndexEntry& entry);
+    void createEarlyIndexEntry();
+    void updateIndexCompletion(uint32_t shotId, const ShotLogHeader& finalHeader);
     void saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);
     void startRecording();
@@ -41,6 +55,7 @@ class ShotHistoryPlugin : public Plugin {
     size_t ioBufferPos = 0; // bytes used
 
     bool recording = false;
+    bool indexEntryCreated = false;  // Track if early index entry was created
     unsigned long shotStart = 0;
     float currentTemperature = 0.0f;
     float currentBluetoothWeight = 0.0f;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -156,6 +156,14 @@ void WebUIPlugin::setupServer() {
     server.on("/api/scales/scan", [this](AsyncWebServerRequest *request) { handleBLEScaleScan(request); });
     server.on("/api/scales/info", [this](AsyncWebServerRequest *request) { handleBLEScaleInfo(request); });
     server.serveStatic("/api/history/", SPIFFS, "/h/").setCacheControl("no-store");
+    server.on("/api/history/index.bin", HTTP_GET, [this](AsyncWebServerRequest *request) {
+        // Serve the binary index file directly
+        if (SPIFFS.exists("/h/index.bin")) {
+            request->send(SPIFFS, "/h/index.bin", "application/octet-stream");
+        } else {
+            request->send(404, "text/plain", "Index not found");
+        }
+    });
     server.on("/api/core-dump", HTTP_GET, [this](AsyncWebServerRequest *request) { handleCoreDumpDownload(request); });
     server.onNotFound([](AsyncWebServerRequest *request) { request->send(SPIFFS, "/w/index.html"); });
     server.serveStatic("/", SPIFFS, "/w").setDefaultFile("index.html").setCacheControl("max-age=0");

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -155,7 +155,7 @@ void WebUIPlugin::setupServer() {
     server.on("/api/scales/connect", [this](AsyncWebServerRequest *request) { handleBLEScaleConnect(request); });
     server.on("/api/scales/scan", [this](AsyncWebServerRequest *request) { handleBLEScaleScan(request); });
     server.on("/api/scales/info", [this](AsyncWebServerRequest *request) { handleBLEScaleInfo(request); });
-    server.serveStatic("/history/", SPIFFS, "/h/").setCacheControl("no-store");
+    server.serveStatic("/api/history/", SPIFFS, "/h/").setCacheControl("no-store");
     server.on("/api/core-dump", HTTP_GET, [this](AsyncWebServerRequest *request) { handleCoreDumpDownload(request); });
     server.onNotFound([](AsyncWebServerRequest *request) { request->send(SPIFFS, "/w/index.html"); });
     server.serveStatic("/", SPIFFS, "/w").setDefaultFile("index.html").setCacheControl("max-age=0");

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -8,6 +8,8 @@ import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import ShotNotesCard from './ShotNotesCard.jsx';
 
 
@@ -66,14 +68,18 @@ export default function HistoryCard({ shot, onDelete, onLoad, onNotesChanged }) 
       <div className='flex flex-col gap-2'>
         <div className='flex flex-row items-start gap-2'>
           <button
-            className='shrink-0 rounded-md border px-2 py-1 text-xs font-medium text-base-content hover:bg-base-content/10 transition-colors'
+            className='p-2 border border-base-content/20 text-base-content/60 hover:text-base-content hover:bg-base-content/10 hover:border-base-content/40 rounded-md transition-all duration-200'
             onClick={() => {
               const next = !expanded;
               setExpanded(next);
               if (next && !shot.loaded && onLoad) onLoad(shot.id);
             }}
+            aria-label={expanded ? 'Collapse shot details' : 'Expand shot details'}
           >
-            {expanded ? '−' : '+'}
+            <FontAwesomeIcon 
+              icon={expanded ? faMinus : faPlus} 
+              className='w-3 h-3'
+            />
           </button>
 
           <div className='flex-grow min-w-0'>

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -50,6 +50,8 @@ export default function HistoryCard({ shot, onDelete, onLoad }) {
   const handleNotesUpdate = useCallback(notes => {
     setShotNotes(notes);
   }, []);
+  const profileTitle = shot.profile || 'Unknown Profile';
+  const displayTitle = shot.incomplete ? `${profileTitle} (Interrupted)` : profileTitle;
   return (
     <Card sm={12}>
       <div className='flex flex-col'>
@@ -66,11 +68,11 @@ export default function HistoryCard({ shot, onDelete, onLoad }) {
           </button>
           <div className='flex-grow'>
             <div className='flex flex-row'>
-              <span className='flex-grow text-xl leading-tight font-bold'>
-                {shot.profile} - {date.toLocaleString()}
+              <span className='flex-grow text-lg leading-tight font-bold'>
+                {displayTitle} - {date.toLocaleString()}
               </span>
               {shot.incomplete && (
-                <span className='bg-warning/20 text-warning border-warning/40 ml-2 shrink-0 rounded border px-2 py-1 text-xs font-semibold'>
+                <span className='ml-2 shrink-0 inline-flex items-center justify-center rounded border border-warning/40 bg-warning/20 px-2 py-1 text-xs font-semibold text-warning leading-none'>
                   INCOMPLETE
                 </span>
               )}

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -7,6 +7,7 @@ import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import ShotNotesCard from './ShotNotesCard.jsx';
 
 const DECIMALS = 2;
@@ -15,7 +16,7 @@ function round2(v) {
   return Math.round((v + Number.EPSILON) * 100) / 100;
 }
 
-export default function HistoryCard({ shot, onDelete, onLoad }) {
+export default function HistoryCard({ shot, onDelete, onLoad, onNotesChanged }) {
   const [shotNotes, setShotNotes] = useState(shot.notes || null);
   const [expanded, setExpanded] = useState(false);
   const date = new Date(shot.timestamp * 1000);
@@ -49,7 +50,11 @@ export default function HistoryCard({ shot, onDelete, onLoad }) {
 
   const handleNotesUpdate = useCallback(notes => {
     setShotNotes(notes);
-  }, []);
+    // Notify parent that notes changed (so it can reload the index)
+    if (onNotesChanged) {
+      onNotesChanged();
+    }
+  }, [onNotesChanged]);
   const profileTitle = shot.profile || 'Unknown Profile';
   const displayTitle = shot.incomplete ? `${profileTitle} (Interrupted)` : profileTitle;
   return (
@@ -114,6 +119,12 @@ export default function HistoryCard({ shot, onDelete, onLoad }) {
               )}
             </div>
           </div>
+            {shot.rating && shot.rating > 0 && (
+              <div className='flex flex-row items-center gap-2'>
+                <FontAwesomeIcon icon={faStar} className="text-yellow-500" />
+                {shot.rating}/5
+              </div>
+            )}
         </div>
         {expanded && (
           <div className='mt-2'>

--- a/web/src/pages/ShotHistory/HistoryCard.jsx
+++ b/web/src/pages/ShotHistory/HistoryCard.jsx
@@ -10,16 +10,18 @@ import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import ShotNotesCard from './ShotNotesCard.jsx';
 
-const DECIMALS = 2;
+
 function round2(v) {
-  if (v == null || isNaN(v)) return v;
+  if (v == null || Number.isNaN(v)) return v;
   return Math.round((v + Number.EPSILON) * 100) / 100;
 }
 
 export default function HistoryCard({ shot, onDelete, onLoad, onNotesChanged }) {
   const [shotNotes, setShotNotes] = useState(shot.notes || null);
   const [expanded, setExpanded] = useState(false);
+
   const date = new Date(shot.timestamp * 1000);
+
   const onExport = useCallback(() => {
     if (!shot.loaded) return; // Only export loaded data
     const exportData = { ...shot, notes: shotNotes };
@@ -44,101 +46,128 @@ export default function HistoryCard({ shot, onDelete, onLoad, onNotesChanged }) 
     downloadJson(exportData, 'shot-' + shot.id + '.json');
   }, [shot, shotNotes]);
 
-  const handleNotesLoaded = useCallback(notes => {
+  const handleNotesLoaded = useCallback((notes) => {
     setShotNotes(notes);
   }, []);
 
-  const handleNotesUpdate = useCallback(notes => {
+  const handleNotesUpdate = useCallback((notes) => {
     setShotNotes(notes);
     // Notify parent that notes changed (so it can reload the index)
-    if (onNotesChanged) {
-      onNotesChanged();
-    }
+    if (onNotesChanged) onNotesChanged();
   }, [onNotesChanged]);
   const profileTitle = shot.profile || 'Unknown Profile';
-  const displayTitle = shot.incomplete ? `${profileTitle} (Interrupted)` : profileTitle;
+  const formattedDate =
+    date.toLocaleDateString() +
+    ' ' +
+    date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
   return (
-    <Card sm={12}>
-      <div className='flex flex-col'>
-        <div className='flex flex-row items-start gap-3'>
+    <Card sm={12} className='[&>.card-body]:p-2'>
+      <div className='flex flex-col gap-2'>
+        <div className='flex flex-row items-start gap-2'>
           <button
-            className='shrink-0 rounded-md border px-2 py-1 text-sm'
+            className='shrink-0 rounded-md border px-2 py-1 text-xs font-medium text-base-content hover:bg-base-content/10 transition-colors'
             onClick={() => {
               const next = !expanded;
               setExpanded(next);
               if (next && !shot.loaded && onLoad) onLoad(shot.id);
             }}
           >
-            {expanded ? '-' : '+'}
+            {expanded ? '−' : '+'}
           </button>
-          <div className='flex-grow'>
-            <div className='flex flex-row'>
-              <span className='flex-grow text-lg leading-tight font-bold'>
-                {displayTitle} - {date.toLocaleString()}
-              </span>
-              {shot.incomplete && (
-                <span className='ml-2 shrink-0 inline-flex items-center justify-center rounded border border-warning/40 bg-warning/20 px-2 py-1 text-xs font-semibold text-warning leading-none'>
-                  INCOMPLETE
-                </span>
-              )}
-              <div className='flex flex-row justify-end gap-2'>
-                <div
-                  className='tooltip tooltip-left'
-                  data-tip={shot.loaded ? 'Export' : 'Load first'}
-                >
-                  <button
-                    disabled={!shot.loaded}
-                    onClick={() => onExport()}
-                    className='group text-info hover:bg-info/10 active:border-info/20 inline-block items-center justify-between gap-2 rounded-md border border-transparent px-2.5 py-2 text-sm font-semibold disabled:opacity-40'
-                    aria-label='Export shot data'
+
+          <div className='flex-grow min-w-0'>
+            {/* Header Row */}
+            <div className='flex flex-row items-start justify-between gap-3 mb-1'>
+              <div className='flex-grow min-w-0'>
+                <h3 className='text-base font-semibold text-base-content truncate'>
+                  {profileTitle}
+                </h3>
+                <p className='text-sm text-base-content/70'>
+                  #{shot.id} • {formattedDate}
+                </p>
+              </div>
+
+              <div className='flex flex-row items-center gap-2 shrink-0'>
+                {shot.incomplete && (
+                  <span className='inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800'>
+                    INCOMPLETE
+                  </span>
+                )}
+
+                <div className='flex flex-row gap-1'>
+                  <div
+                    className='tooltip tooltip-left'
+                    data-tip={shot.loaded ? 'Export' : 'Load first'}
                   >
-                    <FontAwesomeIcon icon={faFileExport} />
-                  </button>
-                </div>
-                <div className='tooltip tooltip-left' data-tip='Delete'>
-                  <button
-                    onClick={() => onDelete(shot.id)}
-                    className='group text-error hover:bg-error/10 active:border-error/20 inline-block items-center justify-between gap-2 rounded-md border border-transparent px-2.5 py-2 text-sm font-semibold'
-                    aria-label='Delete shot'
-                  >
-                    <FontAwesomeIcon icon={faTrashCan} />
-                  </button>
+                    <button
+                      disabled={!shot.loaded}
+                      onClick={onExport} // no wrapper needed
+                      className='p-2 text-base-content/50 hover:text-info hover:bg-info/10 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+                      aria-label='Export shot data'
+                    >
+                      <FontAwesomeIcon icon={faFileExport} className='w-4 h-4' />
+                    </button>
+                  </div>
+                  <div className='tooltip tooltip-left' data-tip='Delete'>
+                    <button
+                      onClick={() => onDelete(shot.id)}
+                      className='p-2 text-base-content/50 hover:text-error hover:bg-error/10 rounded-md transition-colors'
+                      aria-label='Delete shot'
+                    >
+                      <FontAwesomeIcon icon={faTrashCan} className='w-4 h-4' />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-            <div className='flex flex-row items-center gap-4'>
-              <div className='flex flex-row items-center gap-2'>
-                <FontAwesomeIcon icon={faClock} />
-                {(shot.duration / 1000).toFixed(1)}s
+
+            {/* Stats Row */}
+            <div className='flex flex-row items-center gap-4 text-sm text-base-content/80 mb-1'>
+              <div className='flex items-center gap-1'>
+                <FontAwesomeIcon icon={faClock} className='w-4 h-4' />
+                <span>{(shot.duration / 1000).toFixed(1)}s</span>
               </div>
+
               {shot.volume && shot.volume > 0 && (
-                <div className='flex flex-row items-center gap-2'>
-                  <FontAwesomeIcon icon={faWeightScale} />
-                  {round2(shot.volume)}g
+                <div className='flex items-center gap-1'>
+                  <FontAwesomeIcon icon={faWeightScale} className='w-4 h-4' />
+                  <span>{round2(shot.volume)}g</span>
+                </div>
+              )}
+
+              {shot.rating && shot.rating > 0 ? (
+                <div className='flex items-center gap-1'>
+                  <FontAwesomeIcon icon={faStar} className='w-4 h-4 text-yellow-500' />
+                  <span className='font-medium'>{shot.rating}/5</span>
+                </div>
+              ) : (
+                <div className='flex items-center gap-1 text-base-content/50'>
+                  <FontAwesomeIcon icon={faStar} className='w-4 h-4' />
+                  <span>Not rated</span>
                 </div>
               )}
             </div>
-          </div>
-            {shot.rating && shot.rating > 0 && (
-              <div className='flex flex-row items-center gap-2'>
-                <FontAwesomeIcon icon={faStar} className="text-yellow-500" />
-                {shot.rating}/5
+
+            {expanded && (
+              <div className='mt-4 pt-4 border-t border-base-content/20'>
+                {!shot.loaded && (
+                  <div className='flex items-center justify-center py-8'>
+                    <span className='text-sm text-base-content/70'>Loading shot data...</span>
+                  </div>
+                )}
+                {shot.loaded && <HistoryChart shot={shot} />}
+                {shot.loaded && (
+                  <ShotNotesCard
+                    shot={shot}
+                    onNotesLoaded={handleNotesLoaded}
+                    onNotesUpdate={handleNotesUpdate}
+                  />
+                )}
               </div>
             )}
-        </div>
-        {expanded && (
-          <div className='mt-2'>
-            {!shot.loaded && <div className='py-6 text-sm opacity-70'>Loading…</div>}
-            {shot.loaded && <HistoryChart shot={shot} />}
-            {shot.loaded && (
-              <ShotNotesCard
-                shot={shot}
-                onNotesLoaded={handleNotesLoaded}
-                onNotesUpdate={handleNotesUpdate}
-              />
-            )}
           </div>
-        )}
+        </div>
       </div>
     </Card>
   );

--- a/web/src/pages/ShotHistory/index.jsx
+++ b/web/src/pages/ShotHistory/index.jsx
@@ -43,7 +43,9 @@ export function ShotHistory() {
         timestamp: item.timestamp,
         duration: item.duration,
         samples: item.samples, // count only
-        notes: item.notes || null,
+        volume: item.volume ?? null,
+        incomplete: !!item.incomplete,
+        notes: null,
         loaded: false,
         data: null,
       }))
@@ -91,7 +93,7 @@ export function ShotHistory() {
               const target = history.find(h => h.id === id);
               if (!target || target.loaded) return;
               try {
-                const resp = await fetch(`/history/${id}.slog`);
+                const resp = await fetch(`/api/history/${id}.slog`);
                 if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
                 const buf = await resp.arrayBuffer();
                 const parsed = parseBinaryShot(buf, id);

--- a/web/src/pages/ShotHistory/parseBinaryIndex.js
+++ b/web/src/pages/ShotHistory/parseBinaryIndex.js
@@ -1,0 +1,129 @@
+// Parser for index.bin binary shot index files
+// Mirrors shot_log_format.h ShotIndexHeader and ShotIndexEntry (keep in sync)
+
+const INDEX_HEADER_SIZE = 32;
+const INDEX_ENTRY_SIZE = 128;
+const INDEX_MAGIC = 0x58444953; // 'SIDX'
+
+// Index entry flags
+const SHOT_FLAG_COMPLETED = 0x01;
+const SHOT_FLAG_DELETED = 0x02;
+const SHOT_FLAG_HAS_NOTES = 0x04;
+
+const WEIGHT_SCALE = 10;
+
+function decodeCString(bytes) {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) break;
+    out += String.fromCharCode(bytes[i]);
+  }
+  return out;
+}
+
+/**
+ * Parse binary shot index file
+ * @param {ArrayBuffer} arrayBuffer - The binary index file data
+ * @returns {Object} Parsed index with header and entries
+ */
+export function parseBinaryIndex(arrayBuffer) {
+  const view = new DataView(arrayBuffer);
+  
+  if (view.byteLength < INDEX_HEADER_SIZE) {
+    throw new Error('Index file too small');
+  }
+  
+  // Parse header
+  const magic = view.getUint32(0, true);
+  if (magic !== INDEX_MAGIC) {
+    throw new Error(`Invalid index magic: 0x${magic.toString(16)} (expected 0x${INDEX_MAGIC.toString(16)})`);
+  }
+  
+  const version = view.getUint16(4, true);
+  const entrySize = view.getUint16(6, true);
+  const entryCount = view.getUint32(8, true);
+  const nextId = view.getUint32(12, true);
+  
+  if (entrySize !== INDEX_ENTRY_SIZE) {
+    throw new Error(`Unsupported entry size ${entrySize} (expected ${INDEX_ENTRY_SIZE})`);
+  }
+  
+  const expectedSize = INDEX_HEADER_SIZE + entryCount * INDEX_ENTRY_SIZE;
+  if (view.byteLength < expectedSize) {
+    throw new Error(`Index file truncated: ${view.byteLength} bytes (expected ${expectedSize})`);
+  }
+  
+  // Parse entries
+  const entries = [];
+  for (let i = 0; i < entryCount; i++) {
+    const base = INDEX_HEADER_SIZE + i * INDEX_ENTRY_SIZE;
+    
+    const id = view.getUint32(base + 0, true);
+    const timestamp = view.getUint32(base + 4, true);
+    const duration = view.getUint32(base + 8, true);
+    const volume = view.getUint16(base + 12, true);
+    const rating = view.getUint8(base + 14);
+    const flags = view.getUint8(base + 15);
+    
+    const profileIdBytes = new Uint8Array(arrayBuffer, base + 16, 32);
+    const profileNameBytes = new Uint8Array(arrayBuffer, base + 48, 48);
+    
+    const profileId = decodeCString(profileIdBytes);
+    const profileName = decodeCString(profileNameBytes);
+    
+    // Convert volume from scaled integer to float
+    const volumeFloat = volume > 0 ? volume / WEIGHT_SCALE : null;
+    
+    entries.push({
+      id,
+      timestamp,
+      duration,
+      volume: volumeFloat,
+      rating,
+      flags,
+      profileId,
+      profileName,
+      // Computed flags
+      completed: !!(flags & SHOT_FLAG_COMPLETED),
+      deleted: !!(flags & SHOT_FLAG_DELETED),
+      hasNotes: !!(flags & SHOT_FLAG_HAS_NOTES),
+      incomplete: !(flags & SHOT_FLAG_COMPLETED),
+    });
+  }
+  
+  return {
+    header: {
+      magic,
+      version,
+      entrySize,
+      entryCount,
+      nextId,
+    },
+    entries,
+  };
+}
+
+/**
+ * Filter out deleted entries and convert to frontend format
+ * @param {Object} indexData - Parsed index data from parseBinaryIndex
+ * @returns {Array} Array of shot objects for frontend use
+ */
+export function indexToShotList(indexData) {
+  return indexData.entries
+    .filter(entry => !entry.deleted)
+    .map(entry => ({
+      id: entry.id.toString(),
+      profile: entry.profileName,
+      profileId: entry.profileId,
+      timestamp: entry.timestamp,
+      duration: entry.duration,
+      samples: 0, // Not available in index, filled when loading full shot
+      volume: entry.volume,
+      rating: entry.rating > 0 ? entry.rating : null, // Only include rating if > 0
+      incomplete: entry.incomplete,
+      notes: null,
+      loaded: false,
+      data: null,
+    }))
+    .sort((a, b) => b.timestamp - a.timestamp); // Most recent first
+}

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -5,7 +5,7 @@
 
 const HEADER_SIZE = 128;
 const SAMPLE_SIZE = 24; // 12 packed 16-bit values
-const MAGIC = 0x544f4853; // 'SHOT'
+const MAGIC = 0x544F4853; // 'SHOT' - matches backend SHOT_LOG_MAGIC
 
 const TEMP_SCALE = 10;
 const PRESSURE_SCALE = 10;
@@ -26,7 +26,7 @@ export function parseBinaryShot(arrayBuffer, id) {
   const view = new DataView(arrayBuffer);
   if (view.byteLength < HEADER_SIZE) throw new Error('File too small');
   const magic = view.getUint32(0, true);
-  if (magic !== MAGIC) throw new Error('Bad magic');
+  if (magic !== MAGIC) throw new Error(`Bad magic: expected 0x${MAGIC.toString(16)}, got 0x${magic.toString(16)}`);
   const version = view.getUint8(4);
   const deviceSampleSize = view.getUint8(5); // reserved0 holds sample size
   const headerSize = view.getUint16(6, true);

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -37,6 +37,7 @@ export function parseBinaryShot(arrayBuffer, id) {
   const startEpoch = view.getUint32(24, true);
   const profileIdBytes = new Uint8Array(arrayBuffer, 28, 32);
   const profileNameBytes = new Uint8Array(arrayBuffer, 60, 48);
+  const finalWeightHeader = view.getUint16(108, true);
   const profileId = decodeCString(profileIdBytes);
   const profileName = decodeCString(profileNameBytes);
 
@@ -81,6 +82,10 @@ export function parseBinaryShot(arrayBuffer, id) {
   const incomplete = headerIncomplete || inferredIncomplete;
   const effectiveDuration = !incomplete && durationHeader ? durationHeader : lastT;
 
+  const headerVolume = finalWeightHeader ? finalWeightHeader / WEIGHT_SCALE : 0;
+  const sampleVolume = samples.length ? samples[samples.length - 1].v : 0;
+  const volume = headerVolume > 0 ? headerVolume : sampleVolume > 0 ? sampleVolume : null;
+
   return {
     id,
     version,
@@ -89,7 +94,7 @@ export function parseBinaryShot(arrayBuffer, id) {
     timestamp: startEpoch,
     duration: effectiveDuration,
     samples,
-    volume: samples.length ? samples[samples.length - 1].v : 0,
+    volume,
     incomplete,
     sampleInterval,
     fieldsMask,


### PR DESCRIPTION
- Expand shot history to 100 shots (can support much more)
- Add shot history index and serve the full file to the front-end for processing
- Merge note data (weight, rating) into the index entry - use entered weight instead of shot weight (if provided)
- Index entries are created above the 7.5s threshold to avoid polluting the index
- Fix history endpoint
- Don't process incomplete shots on the back-end, process on the front end and show incomplete badge
- Delay loading shot notes until expanded
- Add weight to shot log header / list

- Add sorting, filtering, searching and pagination to the front end

TODO:
- Integrate rebuild index into settings (potentially check on startup?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Faster shot history powered by a binary index with direct download at /api/history/index.bin.
  - Web UI: search, sort, filter, and pagination for history; improved cards with icons and accessible controls.
  - Early listing of in-progress shots; completed status updates automatically.
  - New /api/history/ endpoint for history data.

- Enhancements
  - History capacity increased from 10 to 100 entries.
  - More accurate volume using final weight when available.
  - Improved export/delete actions, notes handling, and empty-state messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->