### PR TITLE
Add more shot notes

### DIFF
--- a/schema/shot_notes.json
+++ b/schema/shot_notes.json
@@ -44,7 +44,8 @@
     },
     "notes": {
       "description": "User notes",
-      "type": "string"
+      "type": "string",
+      "maxLength": 100
     },
     "timestamp": {
       "description": "Timestamp when notes were last updated",

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -346,12 +346,15 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded }) {
 
       {/* Notes Text Area - Full Width */}
       <div className='form-control mt-6'>
-        <label className='mb-2 block text-sm font-medium'>Notes</label>
+        <label className='mb-2 block text-sm font-medium'>
+          Notes {isEditing && <span className='text-xs text-gray-500'>({notes.notes.length}/100)</span>}
+        </label>
         {isEditing ? (
           <textarea
             className='textarea textarea-bordered w-full'
             rows='4'
             value={notes.notes}
+            maxLength={100}
             onChange={e => handleInputChange('notes', e.target.value)}
             placeholder='Tasting notes, brewing observations, etc...'
           />


### PR DESCRIPTION
- Add Bean Type to shot notes
- Limit 'notes' field to 100 characters and display character count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Bean Type field to Shot Notes, available in both view and edit modes.

* **UI Improvements**
  * Widened layout to accommodate the new field.
  * Notes label now shows a live character count.

* **Validation**
  * Notes are limited to 100 characters, enforced in the UI and data schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->