### PR TITLE
Handle unicode when fetching shots from the machine

### DIFF
--- a/web/src/pages/ShotHistory/parseBinaryIndex.js
+++ b/web/src/pages/ShotHistory/parseBinaryIndex.js
@@ -13,12 +13,17 @@ const SHOT_FLAG_HAS_NOTES = 0x04;
 const WEIGHT_SCALE = 10;
 
 function decodeCString(bytes) {
-  let out = '';
+  // Find null terminator
+  let length = bytes.length;
   for (let i = 0; i < bytes.length; i++) {
-    if (bytes[i] === 0) break;
-    out += String.fromCharCode(bytes[i]);
+    if (bytes[i] === 0) {
+      length = i;
+      break;
+    }
   }
-  return out;
+  // Use TextDecoder to properly decode UTF-8
+  const decoder = new TextDecoder('utf-8');
+  return decoder.decode(bytes.subarray(0, length));
 }
 
 /**

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -14,12 +14,16 @@ const WEIGHT_SCALE = 10;
 const RESISTANCE_SCALE = 100;
 
 function decodeCString(bytes) {
-  let out = '';
+  // Find null terminator
+  let length = bytes.length;
   for (let i = 0; i < bytes.length; i++) {
-    if (bytes[i] === 0) break;
-    out += String.fromCharCode(bytes[i]);
+    if (bytes[i] === 0) {
+      length = i;
+      break;
+    }
   }
-  return out;
+  const decoder = new TextDecoder('utf-8');
+  return decoder.decode(bytes.subarray(0, length));
 }
 
 export function parseBinaryShot(arrayBuffer, id) {


### PR DESCRIPTION
I noticed when trying to add an Allongé profile that there's some unicode weirdness. I could add the profile just fine, but when viewing it in the shot history it looks like this:

<img width="334" height="210" alt="image" src="https://github.com/user-attachments/assets/1adee742-d3bd-46b4-b301-64c865c744c2" />

At first I thought it was primarily on the ESP32 side, because the é shows up as a `□` on the device. But on further inspection it seems that a simple Javascript fix at least makes unicode work on the web UI:

<img width="363" height="331" alt="image" src="https://github.com/user-attachments/assets/d7ef114a-50c9-46f3-bff4-bf9ba5777dce" />


If you're interested I could take a look at fixing this on the display side as well, but i'm not super familiar with LVGL so would have to figure it out. Seems like the font used just doesn't have unicode in its range of characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved UTF-8 string decoding in binary parsing operations for enhanced reliability and standards compliance in text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->