### PR TITLE
Implement real-time log streaming and WebSocket health monitoring

### DIFF
--- a/lib/OTA/src/GitHubOTA.cpp
+++ b/lib/OTA/src/GitHubOTA.cpp
@@ -10,8 +10,8 @@
 GitHubOTA::GitHubOTA(const String &display_version, const String &controller_version, const String &release_url,
                      const phase_callback_t &phase_callback, const progress_callback_t &progress_callback,
                      const String &firmware_name, const String &filesystem_name, const String &controller_firmware_name) {
-    ESP_LOGV("GitHubOTA", "GitHubOTA(version: %s, firmware_name: %s, fetch_url_via_redirect: %d)\n", version.c_str(),
-             firmware_name.c_str(), fetch_url_via_redirect);
+    ESP_LOGV("GitHubOTA", "GitHubOTA(display_version: %s, controller_version: %s, firmware_name: %s)\n",
+             display_version.c_str(), controller_version.c_str(), firmware_name.c_str());
 
     _version = from_string(display_version.substring(1).c_str());
     _controller_version = from_string(controller_version.substring(1).c_str());

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -14,6 +14,7 @@
 #include <display/plugins/AutoWakeupPlugin.h>
 #include <display/plugins/BLEScalePlugin.h>
 #include <display/plugins/BoilerFillPlugin.h>
+#include <display/plugins/DebugLogPlugin.h>
 #include <display/plugins/HomekitPlugin.h>
 #include <display/plugins/LedControlPlugin.h>
 #include <display/plugins/MQTTPlugin.h>
@@ -63,6 +64,7 @@ void Controller::setup() {
     if (settings.isHomeAssistant()) {
         pluginManager->registerPlugin(new MQTTPlugin());
     }
+    pluginManager->registerPlugin(&DebugLog);
     pluginManager->registerPlugin(new WebUIPlugin());
     pluginManager->registerPlugin(&ShotHistory);
     pluginManager->registerPlugin(&BLEScales);
@@ -180,11 +182,11 @@ void Controller::setupBluetooth() {
 
 void Controller::setupInfos() {
     const std::string info = clientController.readInfo();
-    printf("System info: %s\n", info.c_str());
+    ESP_LOGI(LOG_TAG, "System info: %s", info.c_str());
     JsonDocument doc;
     DeserializationError err = deserializeJson(doc, info);
     if (err) {
-        printf("Error deserializing JSON: %s\n", err.c_str());
+        ESP_LOGE(LOG_TAG, "Error deserializing JSON: %s", err.c_str());
         systemInfo = SystemInfo{
             .hardware = "GaggiMate Standard 1.x", .version = "v1.0.0", .capabilities = {.dimming = false, .pressure = false}};
     } else {

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -55,6 +55,7 @@ Settings::Settings() {
     steamPumpCutoff = preferences.getFloat("spc", DEFAULT_STEAM_PUMP_CUTOFF);
     historyIndex = preferences.getInt("hi", 0);
     autowakeupEnabled = preferences.getBool("ab_en", false);
+    debugLoggingEnabled = preferences.getBool("log_en", true);
 
     // Load schedule format: "time1|days1;time2|days2" where days is 7-bit string (e.g., "1111100" for weekdays only)
     String schedulesStr = preferences.getString("ab_schedules", "");
@@ -460,6 +461,11 @@ void Settings::setAutoWakeupSchedules(const std::vector<AutoWakeupSchedule> &sch
     save();
 }
 
+void Settings::setDebugLoggingEnabled(bool enabled) {
+    debugLoggingEnabled = enabled;
+    save();
+}
+
 void Settings::doSave() {
     if (!dirty) {
         return;
@@ -517,6 +523,7 @@ void Settings::doSave() {
     preferences.putFloat("spc", steamPumpCutoff);
     preferences.putInt("hi", historyIndex);
     preferences.putBool("ab_en", autowakeupEnabled);
+    preferences.putBool("log_en", debugLoggingEnabled);
 
     // Save schedule format
     String schedulesForSave = "";

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -183,6 +183,9 @@ class Settings {
     void setAutoWakeupEnabled(bool enabled);
     void setAutoWakeupSchedules(const std::vector<AutoWakeupSchedule> &schedules);
 
+    void setDebugLoggingEnabled(bool enabled);
+    bool isDebugLoggingEnabled() const { return debugLoggingEnabled; }
+
   private:
     Preferences preferences;
     bool dirty = false;
@@ -200,6 +203,7 @@ class Settings {
     bool delayAdjust = true;
     int startupMode = MODE_STANDBY;
     bool autowakeupEnabled = false;
+    bool debugLoggingEnabled = false;
     std::vector<AutoWakeupSchedule> autowakeupSchedules;
     int standbyTimeout = DEFAULT_STANDBY_TIMEOUT_MS;
     String pid = DEFAULT_PID;

--- a/src/display/plugins/DebugLogPlugin.cpp
+++ b/src/display/plugins/DebugLogPlugin.cpp
@@ -1,0 +1,174 @@
+#include "DebugLogPlugin.h"
+#include "FS.h"
+
+#include <SD_MMC.h>
+#include <SPIFFS.h>
+#include <display/core/Controller.h>
+#include <esp_rom_sys.h>
+#include <esp_rom_uart.h>
+#include <time.h>
+#include <version.h>
+
+DebugLogPlugin DebugLog;
+
+void DebugLogPlugin::setup(Controller *c, PluginManager *pm) {
+    this->controller = c;
+    this->pluginManager = pm;
+    this->settings = &c->getSettings();
+
+    if (controller->isSDCard()) {
+        fs = &SD_MMC;
+    } else {
+        fs = &SPIFFS;
+    }
+
+    rotateLogIfNeeded();
+    checkAndEnableLogging();
+    pluginManager->on("settings:changed", [this](const Event &event) { checkAndEnableLogging(); });
+}
+
+void DebugLogPlugin::loop() {
+    unsigned long now = millis();
+
+    // Check if plugin is disabled and it's safe to free the buffer
+    bool shouldFreeBuffer = logBuffer && disabledAtMillis > 0;
+    // We're giving the 'unhook' some time to settle as there may still be in-flight ISRs or bytes left in the UART buffer.
+    bool isGracePeriodPassed = (now - disabledAtMillis) > 100;
+    bool allReadersUpToDate = logWritePos == fileReadPos && logWritePos == wsReadPos;
+    if (shouldFreeBuffer && isGracePeriodPassed && allReadersUpToDate) {
+        delete[] logBuffer;
+        logBuffer = nullptr;
+        logWritePos = 0;
+        wsReadPos = 0;
+        fileReadPos = 0;
+    }
+
+    // Buffer is empty (nothing to flush)
+    if (!logBuffer || logWritePos == fileReadPos) {
+        return;
+    }
+
+    // Check if buffer is getting full
+    size_t freeSpace;
+    if (logWritePos >= fileReadPos) {
+        freeSpace = DEBUG_LOG_BUFFER_SIZE - logWritePos + fileReadPos - 1;
+    } else {
+        freeSpace = (fileReadPos - logWritePos) - 1;
+    }
+
+    if (freeSpace <= 1024 || (now - lastFlush > DEBUG_LOG_FLUSH_INTERVAL)) {
+        flushToFile();
+        rotateLogIfNeeded();
+        lastFlush = now;
+    }
+}
+
+void DebugLogPlugin::rotateLogIfNeeded() {
+    if (!fs) {
+        return;
+    }
+
+    if (fs->exists(logFilePath)) {
+        File checkFile = fs->open(logFilePath, "r");
+        if (checkFile) {
+            size_t size = checkFile.size();
+            checkFile.close();
+
+            if (size > DEBUG_LOG_MAX_FILE_SIZE) {
+                if (fs->exists(oldLogFilePath)) {
+                    fs->remove(oldLogFilePath);
+                }
+                fs->rename(logFilePath, oldLogFilePath);
+                ESP_LOGI("DebugLogPlugin", "Rotated log file");
+            }
+        }
+    }
+}
+
+void debugLogPutcWrapper(char c) {
+    DebugLog.writeCharToBuffer(c);
+
+    // Also send to actual UART so we still see output on serial monitor
+    esp_rom_uart_tx_one_char(c);
+}
+
+void DebugLogPlugin::checkAndEnableLogging() {
+    if (settings->isDebugLoggingEnabled()) {
+        if (!logBuffer) {
+            logBuffer = new uint8_t[DEBUG_LOG_BUFFER_SIZE];
+            logWritePos = 0;
+            wsReadPos = 0;
+            fileReadPos = 0;
+            disabledAtMillis = 0;
+        }
+        // Channel 1 is the default console UART
+        esp_rom_install_channel_putc(1, &debugLogPutcWrapper);
+        ESP_LOGI("DebugLogPlugin", "Debug logging enabled");
+    } else {
+        // Restore normal UART output
+        esp_rom_install_uart_printf();
+        disabledAtMillis = millis();
+        ESP_LOGI("DebugLogPlugin", "Debug logging disabled");
+    }
+}
+
+String DebugLogPlugin::getNewWSLogs() {
+    String result;
+
+    wsReadPos = readFromCircularBuffer(
+        wsReadPos, logWritePos,
+        [](const uint8_t *data, size_t len, void *ctx) { ((String *)ctx)->concat((const char *)data, len); }, &result);
+
+    return result;
+}
+
+void DebugLogPlugin::writeCharToBuffer(char c) {
+    if (!logBuffer) {
+        return;
+    }
+
+    size_t nextWritePos = (logWritePos + 1) % DEBUG_LOG_BUFFER_SIZE;
+
+    // When buffer is full, just drop the latest bytes
+    if (nextWritePos == wsReadPos || nextWritePos == fileReadPos) {
+        return;
+    }
+
+    logBuffer[logWritePos] = c;
+    logWritePos = nextWritePos;
+}
+
+void DebugLogPlugin::flushToFile() {
+    if (!fs) {
+        return;
+    }
+
+    File logFile = fs->open(logFilePath, FILE_APPEND);
+    if (logFile) {
+        fileReadPos = readFromCircularBuffer(
+            fileReadPos, logWritePos, [](const uint8_t *data, size_t len, void *ctx) { ((File *)ctx)->write(data, len); },
+            &logFile);
+        logFile.close();
+    }
+}
+
+// Consume some bytes from the circular buffer via a callback.
+// The callback gets invoked once or twice depending on whether the read needs to wrap around the 'end' of the buffer.
+// Returns the new reader position.
+size_t DebugLogPlugin::readFromCircularBuffer(size_t readPos, size_t writePos,
+                                              void (*writeChunkCallback)(const uint8_t *data, size_t len, void *context),
+                                              void *context) {
+    if (!logBuffer) {
+        return readPos;
+    }
+
+    if (readPos < writePos) {
+        writeChunkCallback(&logBuffer[readPos], writePos - readPos, context);
+        return writePos;
+    } else if (readPos > writePos) {
+        writeChunkCallback(&logBuffer[readPos], DEBUG_LOG_BUFFER_SIZE - readPos, context);
+        writeChunkCallback(&logBuffer[0], writePos, context);
+        return writePos;
+    }
+    return readPos;
+}

--- a/src/display/plugins/DebugLogPlugin.h
+++ b/src/display/plugins/DebugLogPlugin.h
@@ -1,0 +1,53 @@
+#ifndef DEBUGLOGPLUGIN_H
+#define DEBUGLOGPLUGIN_H
+
+#include <FS.h>
+#include <WString.h>
+#include <display/core/Plugin.h>
+#include <display/core/Settings.h>
+#include <esp_log.h>
+
+constexpr size_t DEBUG_LOG_MAX_FILE_SIZE = 50 * 1024; // Max log file size
+constexpr size_t DEBUG_LOG_FLUSH_INTERVAL = 5000;     // Interval to flush logs to file
+constexpr size_t DEBUG_LOG_BUFFER_SIZE = 16384;       // Buffer to hold logs before flushing to file / WS
+constexpr size_t DEBUG_LOG_WS_INTERVAL = 2000;        // Interval to send logs over WebSocket
+constexpr size_t DEBUG_LOG_WS_FAST_INTERVAL = 250;    // Interval to send logs to WebSocket if there's more data to send
+
+class DebugLogPlugin : public Plugin {
+    friend void debugLogPutcWrapper(char c);
+
+  public:
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+    // Get new logs to send over WS. This advances wsReadPos.
+    String getNewWSLogs();
+
+  private:
+    void rotateLogIfNeeded();
+    void flushToFile();
+    void checkAndEnableLogging();
+    size_t readFromCircularBuffer(size_t readPos, size_t writePos,
+                                  void (*callback)(const uint8_t *data, size_t len, void *context), void *context);
+
+    void writeCharToBuffer(char c);
+
+    Controller *controller;
+    PluginManager *pluginManager;
+    Settings *settings;
+    FS *fs;
+
+    String logFilePath = "/logs.txt";
+    String oldLogFilePath = "/logs.old.txt";
+    unsigned long lastFlush = 0;
+
+    uint8_t *volatile logBuffer = nullptr;
+    volatile unsigned long disabledAtMillis = 0; // When >0, indicates when the plugin got disabled
+    volatile size_t logWritePos = 0;
+    volatile size_t wsReadPos = 0;   // For WebSocket consumers
+    volatile size_t fileReadPos = 0; // For file writes
+};
+
+extern DebugLogPlugin DebugLog;
+
+#endif // DEBUGLOGPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -49,9 +49,13 @@ class WebUIPlugin : public Plugin {
     void updateOTAStatus(const String &version);
     void updateOTAProgress(uint8_t phase, int progress);
     void sendAutotuneResult();
+    void sendDebugLogs();
 
     // Core dump download
     void handleCoreDumpDownload(AsyncWebServerRequest *request);
+
+    // Download the stored log files
+    void handleLogDownload(AsyncWebServerRequest *request);
 
     GitHubOTA *ota = nullptr;
     AsyncWebServer server;
@@ -65,6 +69,8 @@ class WebUIPlugin : public Plugin {
     long lastStatus = 0;
     long lastCleanup = 0;
     long lastDns = 0;
+    long lastDebugLog = 0;
+    bool lastDebugLogHadBytes = true;
     bool updating = false;
     bool apMode = false;
     bool serverRunning = false;

--- a/web/src/components/DebugLogs.jsx
+++ b/web/src/components/DebugLogs.jsx
@@ -38,10 +38,7 @@ export default function DebugLogs() {
 
       // Format date as YYYY-MM-DD-HH-MM-SS
       const now = new Date();
-      const timestamp = now.toISOString()
-        .replace(/T/, '-')
-        .replace(/:/g, '-')
-        .replace(/\..+/, '');
+      const timestamp = now.toISOString().replace(/T/, '-').replace(/:/g, '-').replace(/\..+/, '');
 
       a.href = url;
       a.download = `gaggimate-logs-${timestamp}.txt`;
@@ -57,9 +54,9 @@ export default function DebugLogs() {
 
   const filteredText = filter
     ? logs.value
-      .split('\n')
-      .filter(line => line.toLowerCase().includes(filter.toLowerCase()))
-      .join('\n')
+        .split('\n')
+        .filter(line => line.toLowerCase().includes(filter.toLowerCase()))
+        .join('\n')
     : logs.value;
 
   const colorizeLogLine = line => {
@@ -93,80 +90,80 @@ export default function DebugLogs() {
       )}
 
       {/* Controls */}
-      <div className='flex flex-wrap gap-2 items-center justify-between'>
-            <div className='flex gap-2 items-center flex-wrap'>
-              <div className='tooltip' data-tip='Clear logs'>
-                <button
-                  className='text-base-content/50 hover:text-error hover:bg-error/10 rounded-md p-2 transition-colors'
-                  onClick={handleClear}
-                  aria-label='Clear logs'
-                >
-                  <FontAwesomeIcon icon={faTrashCan} className='h-4 w-4' />
-                </button>
-              </div>
-              <div className='tooltip' data-tip='Download log file'>
-                <button
-                  className='text-base-content/50 hover:text-info hover:bg-info/10 rounded-md p-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-                  onClick={handleExport}
-                  disabled={isExporting}
-                  aria-label='Download log file'
-                >
-                  {isExporting ? (
-                    <span className='loading loading-spinner loading-xs' />
-                  ) : (
-                    <FontAwesomeIcon icon={faFileExport} className='h-4 w-4' />
-                  )}
-                </button>
-              </div>
-              <label className='label cursor-pointer gap-2'>
-                <span className='label-text'>Auto-scroll</span>
-                <input
-                  type='checkbox'
-                  className='toggle toggle-primary'
-                  checked={autoScroll}
-                  onChange={e => setAutoScroll(e.target.checked)}
-                />
-              </label>
-            </div>
-
-            <div className='flex gap-2 items-center flex-wrap'>
-              <input
-                type='text'
-                placeholder='Filter logs...'
-                className='input input-sm input-bordered w-48'
-                value={filter}
-                onChange={e => setFilter(e.target.value)}
-              />
-
-              <span className='text-sm opacity-70'>
-                {logLines.length} lines
-                {logs.value.length > 0 && ` (~${(logs.value.length / 1024).toFixed(1)}KB)`}
-              </span>
-            </div>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <div className='tooltip' data-tip='Clear logs'>
+            <button
+              className='text-base-content/50 hover:text-error hover:bg-error/10 rounded-md p-2 transition-colors'
+              onClick={handleClear}
+              aria-label='Clear logs'
+            >
+              <FontAwesomeIcon icon={faTrashCan} className='h-4 w-4' />
+            </button>
           </div>
+          <div className='tooltip' data-tip='Download log file'>
+            <button
+              className='text-base-content/50 hover:text-info hover:bg-info/10 rounded-md p-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50'
+              onClick={handleExport}
+              disabled={isExporting}
+              aria-label='Download log file'
+            >
+              {isExporting ? (
+                <span className='loading loading-spinner loading-xs' />
+              ) : (
+                <FontAwesomeIcon icon={faFileExport} className='h-4 w-4' />
+              )}
+            </button>
+          </div>
+          <label className='label cursor-pointer gap-2'>
+            <span className='label-text'>Auto-scroll</span>
+            <input
+              type='checkbox'
+              className='toggle toggle-primary'
+              checked={autoScroll}
+              onChange={e => setAutoScroll(e.target.checked)}
+            />
+          </label>
+        </div>
+
+        <div className='flex flex-wrap items-center gap-2'>
+          <input
+            type='text'
+            placeholder='Filter logs...'
+            className='input input-sm input-bordered w-48'
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+          />
+
+          <span className='text-sm opacity-70'>
+            {logLines.length} lines
+            {logs.value.length > 0 && ` (~${(logs.value.length / 1024).toFixed(1)}KB)`}
+          </span>
+        </div>
+      </div>
 
       {/* Console Output */}
       <div className='overflow-hidden'>
-          <div
-            ref={consoleRef}
-            className='font-mono text-xs overflow-auto h-full p-4 whitespace-pre'
-            style={{ maxHeight: '65vh' }}
-          >
-            {logLines.length === 0 ? (
-              <div className='text-center text-base-content opacity-50 py-8'>
-                {logs.value.length === 0
-                  ? 'No logs to show yet...'
-                  : 'No logs match the current filter.'}
+        <div
+          ref={consoleRef}
+          className='h-full overflow-auto p-4 font-mono text-xs whitespace-pre'
+          style={{ maxHeight: '65vh' }}
+        >
+          {logLines.length === 0 ? (
+            <div className='text-base-content py-8 text-center opacity-50'>
+              {logs.value.length === 0
+                ? 'No logs to show yet...'
+                : 'No logs match the current filter.'}
+            </div>
+          ) : (
+            logLines.map((line, index) => (
+              <div key={index} className={colorizeLogLine(line)}>
+                {line}
               </div>
-            ) : (
-              logLines.map((line, index) => (
-                <div key={index} className={colorizeLogLine(line)}>
-                  {line}
-                </div>
-              ))
-            )}
-            <div ref={bottomRef} />
-          </div>
+            ))
+          )}
+          <div ref={bottomRef} />
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/DebugLogs.jsx
+++ b/web/src/components/DebugLogs.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { logs } from '../services/ApiService.js';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+
+export default function DebugLogs() {
+  const [filter, setFilter] = useState('');
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState(null);
+  const consoleRef = useRef(null);
+  const bottomRef = useRef(null);
+
+  // Auto-scroll to bottom when new logs arrive
+  useEffect(() => {
+    if (autoScroll && consoleRef.current) {
+      consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
+    }
+  }, [logs.value, autoScroll]);
+
+  const handleClear = () => {
+    logs.value = '';
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const response = await fetch('/api/logs');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const logText = await response.text();
+      const blob = new Blob([logText], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+
+      // Format date as YYYY-MM-DD-HH-MM-SS
+      const now = new Date();
+      const timestamp = now.toISOString()
+        .replace(/T/, '-')
+        .replace(/:/g, '-')
+        .replace(/\..+/, '');
+
+      a.href = url;
+      a.download = `gaggimate-logs-${timestamp}.txt`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to export logs:', error);
+      setExportError(error.message);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const filteredText = filter
+    ? logs.value
+      .split('\n')
+      .filter(line => line.toLowerCase().includes(filter.toLowerCase()))
+      .join('\n')
+    : logs.value;
+
+  const colorizeLogLine = line => {
+    if (line.includes('[E]')) return 'text-error';
+    if (line.includes('[W]')) return 'text-warning';
+    if (line.includes('[I]')) return 'text-base-content';
+    if (line.includes('[D]')) return 'text-base-content opacity-70';
+    if (line.includes('[V]')) return 'text-base-content opacity-50';
+    return 'text-base-content';
+  };
+
+  const logLines = filteredText.split('\n').filter(line => line.trim());
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {/* Error Alert */}
+      {exportError && (
+        <div className='alert alert-error'>
+          <div>
+            <span className='font-semibold'>Failed to export logs:</span>
+            <span className='ml-2'>{exportError}</span>
+          </div>
+          <button
+            className='btn btn-sm btn-ghost'
+            onClick={() => setExportError(null)}
+            aria-label='Dismiss error'
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className='flex flex-wrap gap-2 items-center justify-between'>
+            <div className='flex gap-2 items-center flex-wrap'>
+              <div className='tooltip' data-tip='Clear logs'>
+                <button
+                  className='text-base-content/50 hover:text-error hover:bg-error/10 rounded-md p-2 transition-colors'
+                  onClick={handleClear}
+                  aria-label='Clear logs'
+                >
+                  <FontAwesomeIcon icon={faTrashCan} className='h-4 w-4' />
+                </button>
+              </div>
+              <div className='tooltip' data-tip='Download log file'>
+                <button
+                  className='text-base-content/50 hover:text-info hover:bg-info/10 rounded-md p-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+                  onClick={handleExport}
+                  disabled={isExporting}
+                  aria-label='Download log file'
+                >
+                  {isExporting ? (
+                    <span className='loading loading-spinner loading-xs' />
+                  ) : (
+                    <FontAwesomeIcon icon={faFileExport} className='h-4 w-4' />
+                  )}
+                </button>
+              </div>
+              <label className='label cursor-pointer gap-2'>
+                <span className='label-text'>Auto-scroll</span>
+                <input
+                  type='checkbox'
+                  className='toggle toggle-primary'
+                  checked={autoScroll}
+                  onChange={e => setAutoScroll(e.target.checked)}
+                />
+              </label>
+            </div>
+
+            <div className='flex gap-2 items-center flex-wrap'>
+              <input
+                type='text'
+                placeholder='Filter logs...'
+                className='input input-sm input-bordered w-48'
+                value={filter}
+                onChange={e => setFilter(e.target.value)}
+              />
+
+              <span className='text-sm opacity-70'>
+                {logLines.length} lines
+                {logs.value.length > 0 && ` (~${(logs.value.length / 1024).toFixed(1)}KB)`}
+              </span>
+            </div>
+          </div>
+
+      {/* Console Output */}
+      <div className='overflow-hidden'>
+          <div
+            ref={consoleRef}
+            className='font-mono text-xs overflow-auto h-full p-4 whitespace-pre'
+            style={{ maxHeight: '65vh' }}
+          >
+            {logLines.length === 0 ? (
+              <div className='text-center text-base-content opacity-50 py-8'>
+                {logs.value.length === 0
+                  ? 'No logs to show yet...'
+                  : 'No logs match the current filter.'}
+              </div>
+            ) : (
+              logLines.map((line, index) => (
+                <div key={index} className={colorizeLogLine(line)}>
+                  {line}
+                </div>
+              ))
+            )}
+            <div ref={bottomRef} />
+          </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -11,6 +11,7 @@ import { faRotate } from '@fortawesome/free-solid-svg-icons/faRotate';
 import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord';
+import { WSStatusIndicator } from './WSStatusIndicator.jsx';
 
 function HeaderItem(props) {
   const { path } = useLocation();
@@ -51,6 +52,10 @@ export function Header() {
           </div>
 
           <div className='flex items-center gap-1 lg:gap-5'>
+            <div className='relative inline-block'>
+              <WSStatusIndicator />
+            </div>
+
             <div className='relative inline-block'>
               <a
                 aria-label='github'

--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -8,6 +8,7 @@ import { faTemperatureHalf } from '@fortawesome/free-solid-svg-icons/faTemperatu
 import { faBluetoothB } from '@fortawesome/free-brands-svg-icons/faBluetoothB';
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog';
 import { faRotate } from '@fortawesome/free-solid-svg-icons/faRotate';
+import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord';
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -40,9 +40,7 @@ export function Navigation(props) {
         <MenuItem label='Settings' link='/settings' icon={faCog} />
       </div>
       <hr className='h-5 border-0' />
-      <div className='space-y-1.5'>
-        <MenuItem label='System & Updates' link='/ota' icon={faRotate} />
-      </div>
+      <MenuItem label='System & Updates' link='/ota' icon={faRotate} />
     </nav>
   );
 }

--- a/web/src/components/WSStatusIndicator.jsx
+++ b/web/src/components/WSStatusIndicator.jsx
@@ -1,0 +1,84 @@
+import { useContext, useEffect, useState } from 'preact/hooks';
+import { ApiServiceContext } from '../services/ApiService.js';
+
+export function WSStatusIndicator() {
+  const apiService = useContext(ApiServiceContext);
+  const [status, setStatus] = useState('disconnected');
+  const [secondsUntilReconnect, setSecondsUntilReconnect] = useState(null);
+
+  useEffect(() => {
+    if (!apiService) return;
+
+    const interval = setInterval(() => {
+      const timeSinceLastMessage = Date.now() - apiService.lastMessageTime;
+      const isConnected = apiService.socket?.readyState === WebSocket.OPEN;
+      const isConnecting = apiService.socket?.readyState === WebSocket.CONNECTING;
+
+      if (isConnecting) {
+        setStatus('connecting');
+        setSecondsUntilReconnect(null);
+      } else if (!isConnected) {
+        setStatus('disconnected');
+        if (apiService.reconnectScheduledAt) {
+          const seconds = Math.ceil((apiService.reconnectScheduledAt - Date.now()) / 1000);
+          setSecondsUntilReconnect(seconds > 0 ? seconds : null);
+        } else {
+          setSecondsUntilReconnect(null);
+        }
+      } else if (timeSinceLastMessage > 2000) {
+        setStatus('stale');
+        setSecondsUntilReconnect(null);
+      } else {
+        setStatus('connected');
+        setSecondsUntilReconnect(null);
+      }
+    }, 500);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [apiService]);
+
+  const getStatusColor = () => {
+    switch (status) {
+      case 'connected':
+        return 'bg-green-500';
+      case 'stale':
+        return 'bg-yellow-500';
+      case 'connecting':
+      case 'disconnected':
+      default:
+        return 'bg-red-500';
+    }
+  };
+
+  const getStatusTitle = () => {
+    switch (status) {
+      case 'connected':
+        return 'Connected to Gaggimate';
+      case 'stale':
+        return 'No recent messages from machine';
+      case 'connecting': {
+        return 'Connecting...';
+      }
+      case 'disconnected': {
+        if (secondsUntilReconnect != null && secondsUntilReconnect > 0) {
+          return `Gaggimate disconnected - reconnecting in ${secondsUntilReconnect}s`;
+        }
+        return 'Gaggimate disconnected';
+      }
+      default:
+        return 'Gaggimate disconnected';
+    }
+  };
+
+  return (
+    <div className='tooltip tooltip-left' data-tip={getStatusTitle()}>
+      <div className='relative inline-flex items-center justify-center'>
+        <div
+          className={`h-2 w-2 rounded-full ${getStatusColor()} transition-colors duration-100 ${status === 'connecting' ? 'animate-pulse' : ''}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/OTA/index.jsx
+++ b/web/src/pages/OTA/index.jsx
@@ -130,124 +130,126 @@ export function OTA() {
               </div>
             ) : (
               <>
-            <div className='flex flex-col space-y-4'>
-              <label htmlFor='channel' className='text-sm font-medium'>
-                Update Channel
-              </label>
-              <select id='channel' name='channel' className='select select-bordered w-full'>
-                <option value='latest' selected={formData.channel === 'latest'}>
-                  Stable
-                </option>
-                <option value='nightly' selected={formData.channel === 'nightly'}>
-                  Nightly
-                </option>
-              </select>
-            </div>
-
-            <div className='grid grid-cols-1 md:grid-cols-3 gap-4 mt-4'>
-              <div className='flex flex-col space-y-2 min-w-0'>
-                <label className='text-sm font-medium'>Hardware</label>
-                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
-                  {formData.hardware}
+                <div className='flex flex-col space-y-4'>
+                  <label htmlFor='channel' className='text-sm font-medium'>
+                    Update Channel
+                  </label>
+                  <select id='channel' name='channel' className='select select-bordered w-full'>
+                    <option value='latest' selected={formData.channel === 'latest'}>
+                      Stable
+                    </option>
+                    <option value='nightly' selected={formData.channel === 'nightly'}>
+                      Nightly
+                    </option>
+                  </select>
                 </div>
-              </div>
 
-              <div className='flex flex-col space-y-2 min-w-0'>
-                <label className='text-sm font-medium'>Controller version</label>
-                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
-                  <span className='break-all'>{formData.controllerVersion}</span>
-                  {formData.controllerUpdateAvailable && (
-                    <span className='text-primary font-bold break-all'>
-                      {' '}(Update available: {formData.latestVersion})
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              <div className='flex flex-col space-y-2 min-w-0'>
-                <label className='text-sm font-medium'>Display version</label>
-                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
-                  <span className='break-all'>{formData.displayVersion}</span>
-                  {formData.displayUpdateAvailable && (
-                    <span className='text-primary font-bold break-all'>
-                      {' '}(Update available: {formData.latestVersion})
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div className='grid grid-cols-1 md:grid-cols-2 gap-4 mt-4'>
-              {formData.spiffsTotal !== undefined && (
-                <div className='flex flex-col space-y-2 min-w-0'>
-                  <label className='text-sm font-medium'>Storage (SPIFFS)</label>
-                  <div className='flex flex-col gap-1'>
-                    <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
-                      <div
-                        className='bg-primary h-full transition-all'
-                        style={{ width: `${formData.spiffsUsedPct || 0}%` }}
-                      />
+                <div className='mt-4 grid grid-cols-1 gap-4 md:grid-cols-3'>
+                  <div className='flex min-w-0 flex-col space-y-2'>
+                    <label className='text-sm font-medium'>Hardware</label>
+                    <div className='input input-bordered bg-base-200 h-auto min-h-12 w-full cursor-default break-words whitespace-normal'>
+                      {formData.hardware}
                     </div>
-                    <div className='text-xs opacity-75'>
-                      {((formData.spiffsUsed || 0) / 1024).toFixed(1)} KB /{' '}
-                      {(formData.spiffsTotal / 1024).toFixed(1)} KB ({formData.spiffsUsedPct}%)
+                  </div>
+
+                  <div className='flex min-w-0 flex-col space-y-2'>
+                    <label className='text-sm font-medium'>Controller version</label>
+                    <div className='input input-bordered bg-base-200 h-auto min-h-12 w-full cursor-default break-words whitespace-normal'>
+                      <span className='break-all'>{formData.controllerVersion}</span>
+                      {formData.controllerUpdateAvailable && (
+                        <span className='text-primary font-bold break-all'>
+                          {' '}
+                          (Update available: {formData.latestVersion})
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className='flex min-w-0 flex-col space-y-2'>
+                    <label className='text-sm font-medium'>Display version</label>
+                    <div className='input input-bordered bg-base-200 h-auto min-h-12 w-full cursor-default break-words whitespace-normal'>
+                      <span className='break-all'>{formData.displayVersion}</span>
+                      {formData.displayUpdateAvailable && (
+                        <span className='text-primary font-bold break-all'>
+                          {' '}
+                          (Update available: {formData.latestVersion})
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>
-              )}
 
-              {formData.sdTotal !== undefined && (
-                <div className='flex flex-col space-y-2 min-w-0'>
-                  <label className='text-sm font-medium'>Storage (SD-Card)</label>
-                  <div className='flex flex-col gap-1'>
-                    <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
-                      <div
-                        className='bg-primary h-full transition-all'
-                        style={{ width: `${formData.sdUsedPct || 0}%` }}
-                      />
+                <div className='mt-4 grid grid-cols-1 gap-4 md:grid-cols-2'>
+                  {formData.spiffsTotal !== undefined && (
+                    <div className='flex min-w-0 flex-col space-y-2'>
+                      <label className='text-sm font-medium'>Storage (SPIFFS)</label>
+                      <div className='flex flex-col gap-1'>
+                        <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
+                          <div
+                            className='bg-primary h-full transition-all'
+                            style={{ width: `${formData.spiffsUsedPct || 0}%` }}
+                          />
+                        </div>
+                        <div className='text-xs opacity-75'>
+                          {((formData.spiffsUsed || 0) / 1024).toFixed(1)} KB /{' '}
+                          {(formData.spiffsTotal / 1024).toFixed(1)} KB ({formData.spiffsUsedPct}%)
+                        </div>
+                      </div>
                     </div>
-                    <div className='text-xs opacity-75'>
-                      {((formData.sdUsed || 0) / 1024 / 1024).toFixed(1)} MB /{' '}
-                      {(formData.sdTotal / 1024 / 1024).toFixed(1)} MB ({formData.sdUsedPct}%)
+                  )}
+
+                  {formData.sdTotal !== undefined && (
+                    <div className='flex min-w-0 flex-col space-y-2'>
+                      <label className='text-sm font-medium'>Storage (SD-Card)</label>
+                      <div className='flex flex-col gap-1'>
+                        <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
+                          <div
+                            className='bg-primary h-full transition-all'
+                            style={{ width: `${formData.sdUsedPct || 0}%` }}
+                          />
+                        </div>
+                        <div className='text-xs opacity-75'>
+                          {((formData.sdUsed || 0) / 1024 / 1024).toFixed(1)} MB /{' '}
+                          {(formData.sdTotal / 1024 / 1024).toFixed(1)} MB ({formData.sdUsedPct}%)
+                        </div>
+                      </div>
                     </div>
-                  </div>
+                  )}
                 </div>
-              )}
-            </div>
 
-            <div className='alert alert-warning mt-2'>
-              <span>
-                Make sure to backup your profiles from the profile screen before updating the
-                display.
-              </span>
-            </div>
+                <div className='alert alert-warning mt-2'>
+                  <span>
+                    Make sure to backup your profiles from the profile screen before updating the
+                    display.
+                  </span>
+                </div>
 
-            <div className='flex flex-col flex-wrap gap-2 sm:flex-row mt-2'>
-              <button type='submit' className='btn btn-primary' disabled={submitting}>
-                Save & Refresh
-              </button>
-              <button
-                type='submit'
-                name='update'
-                className='btn btn-secondary'
-                disabled={!formData.displayUpdateAvailable || submitting}
-                onClick={() => onUpdate('display')}
-              >
-                Update Display
-              </button>
-              <button
-                type='submit'
-                name='update'
-                className='btn btn-accent'
-                disabled={!formData.controllerUpdateAvailable || submitting}
-                onClick={() => onUpdate('controller')}
-              >
-                Update Controller
-              </button>
-              <button type='button' className='btn btn-outline' onClick={downloadSupportData}>
-                Download Support Data
-              </button>
-            </div>
+                <div className='mt-2 flex flex-col flex-wrap gap-2 sm:flex-row'>
+                  <button type='submit' className='btn btn-primary' disabled={submitting}>
+                    Save & Refresh
+                  </button>
+                  <button
+                    type='submit'
+                    name='update'
+                    className='btn btn-secondary'
+                    disabled={!formData.displayUpdateAvailable || submitting}
+                    onClick={() => onUpdate('display')}
+                  >
+                    Update Display
+                  </button>
+                  <button
+                    type='submit'
+                    name='update'
+                    className='btn btn-accent'
+                    disabled={!formData.controllerUpdateAvailable || submitting}
+                    onClick={() => onUpdate('controller')}
+                  >
+                    Update Controller
+                  </button>
+                  <button type='button' className='btn btn-outline' onClick={downloadSupportData}>
+                    Download Support Data
+                  </button>
+                </div>
               </>
             )}
           </Card>

--- a/web/src/pages/OTA/index.jsx
+++ b/web/src/pages/OTA/index.jsx
@@ -144,81 +144,85 @@ export function OTA() {
               </select>
             </div>
 
-            <div className='flex flex-col space-y-4'>
-              <label className='text-sm font-medium'>Hardware</label>
-              <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal'>
-                {formData.hardware}
-              </div>
-            </div>
-
-            <div className='flex flex-col space-y-4'>
-              <label className='text-sm font-medium'>Controller version</label>
-              <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal'>
-                <span className='break-all'>{formData.controllerVersion}</span>
-                {formData.controllerUpdateAvailable && (
-                  <span className='text-primary font-bold break-all'>
-                    (Update available: {formData.latestVersion})
-                  </span>
-                )}
-              </div>
-            </div>
-
-            <div className='flex flex-col space-y-4'>
-              <label className='text-sm font-medium'>Display version</label>
-              <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal'>
-                <span className='break-all'>{formData.displayVersion}</span>
-                {formData.displayUpdateAvailable && (
-                  <span className='text-primary font-bold break-all'>
-                    (Update available: {formData.latestVersion})
-                  </span>
-                )}
-              </div>
-            </div>
-
-            {formData.spiffsTotal !== undefined && (
-              <div className='flex flex-col space-y-2'>
-                <label className='text-sm font-medium'>Storage (SPIFFS)</label>
-                <div className='flex flex-col gap-1'>
-                  <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
-                    <div
-                      className='bg-primary h-full transition-all'
-                      style={{ width: `${formData.spiffsUsedPct || 0}%` }}
-                    />
-                  </div>
-                  <div className='text-xs opacity-75'>
-                    {((formData.spiffsUsed || 0) / 1024).toFixed(1)} KB /{' '}
-                    {(formData.spiffsTotal / 1024).toFixed(1)} KB ({formData.spiffsUsedPct}%)
-                  </div>
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-4 mt-4'>
+              <div className='flex flex-col space-y-2 min-w-0'>
+                <label className='text-sm font-medium'>Hardware</label>
+                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
+                  {formData.hardware}
                 </div>
               </div>
-            )}
 
-            {formData.sdTotal !== undefined && (
-              <div className='flex flex-col space-y-2'>
-                <label className='text-sm font-medium'>Storage (SD-Card)</label>
-                <div className='flex flex-col gap-1'>
-                  <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
-                    <div
-                      className='bg-primary h-full transition-all'
-                      style={{ width: `${formData.sdUsedPct || 0}%` }}
-                    />
-                  </div>
-                  <div className='text-xs opacity-75'>
-                    {((formData.sdUsed || 0) / 1024 / 1024).toFixed(1)} MB /{' '}
-                    {(formData.sdTotal / 1024 / 1024).toFixed(1)} MB ({formData.sdUsedPct}%)
-                  </div>
+              <div className='flex flex-col space-y-2 min-w-0'>
+                <label className='text-sm font-medium'>Controller version</label>
+                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
+                  <span className='break-all'>{formData.controllerVersion}</span>
+                  {formData.controllerUpdateAvailable && (
+                    <span className='text-primary font-bold break-all'>
+                      {' '}(Update available: {formData.latestVersion})
+                    </span>
+                  )}
                 </div>
               </div>
-            )}
 
-            <div className='alert alert-warning'>
+              <div className='flex flex-col space-y-2 min-w-0'>
+                <label className='text-sm font-medium'>Display version</label>
+                <div className='input input-bordered bg-base-200 cursor-default break-words whitespace-normal h-auto min-h-12 w-full'>
+                  <span className='break-all'>{formData.displayVersion}</span>
+                  {formData.displayUpdateAvailable && (
+                    <span className='text-primary font-bold break-all'>
+                      {' '}(Update available: {formData.latestVersion})
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className='grid grid-cols-1 md:grid-cols-2 gap-4 mt-4'>
+              {formData.spiffsTotal !== undefined && (
+                <div className='flex flex-col space-y-2 min-w-0'>
+                  <label className='text-sm font-medium'>Storage (SPIFFS)</label>
+                  <div className='flex flex-col gap-1'>
+                    <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
+                      <div
+                        className='bg-primary h-full transition-all'
+                        style={{ width: `${formData.spiffsUsedPct || 0}%` }}
+                      />
+                    </div>
+                    <div className='text-xs opacity-75'>
+                      {((formData.spiffsUsed || 0) / 1024).toFixed(1)} KB /{' '}
+                      {(formData.spiffsTotal / 1024).toFixed(1)} KB ({formData.spiffsUsedPct}%)
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {formData.sdTotal !== undefined && (
+                <div className='flex flex-col space-y-2 min-w-0'>
+                  <label className='text-sm font-medium'>Storage (SD-Card)</label>
+                  <div className='flex flex-col gap-1'>
+                    <div className='bg-base-300 h-3 w-full overflow-hidden rounded'>
+                      <div
+                        className='bg-primary h-full transition-all'
+                        style={{ width: `${formData.sdUsedPct || 0}%` }}
+                      />
+                    </div>
+                    <div className='text-xs opacity-75'>
+                      {((formData.sdUsed || 0) / 1024 / 1024).toFixed(1)} MB /{' '}
+                      {(formData.sdTotal / 1024 / 1024).toFixed(1)} MB ({formData.sdUsedPct}%)
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className='alert alert-warning mt-2'>
               <span>
                 Make sure to backup your profiles from the profile screen before updating the
                 display.
               </span>
             </div>
 
-            <div className='flex flex-col flex-wrap gap-2 sm:flex-row'>
+            <div className='flex flex-col flex-wrap gap-2 sm:flex-row mt-2'>
               <button type='submit' className='btn btn-primary' disabled={submitting}>
                 Save & Refresh
               </button>

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -348,6 +348,30 @@ export function PluginCard({
           </div>
         )}
       </div>
+
+      <div className='bg-base-200 rounded-lg p-4'>
+        <div className='flex items-center justify-between'>
+          <span className='text-xl font-medium'>Debug Logging</span>
+          <input
+            id='debugLoggingEnabled'
+            name='debugLoggingEnabled'
+            value='debugLoggingEnabled'
+            type='checkbox'
+            className='toggle toggle-primary'
+            checked={!!formData.debugLoggingEnabled}
+            onChange={onChange('debugLoggingEnabled')}
+            aria-label='Enable Debug Logging'
+          />
+        </div>
+        {formData.debugLoggingEnabled && (
+          <div className='border-base-300 mt-4 border-t pt-4'>
+            <p className='text-sm opacity-70'>
+              Captures all system logs to file and streams them to the System &amp; Updates page.
+              Log files are stored on the SD Card if present and on SPIFFS otherwise.
+            </p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -12,7 +12,6 @@ import { downloadJson } from '../../utils/download.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
-import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
 const pressureAvailable = computed(() => machine.value.capabilities.pressure);
@@ -102,6 +101,9 @@ export function Settings() {
       }
       if (key === 'homeAssistant') {
         value = !formData.homeAssistant;
+      }
+      if (key === 'debugLoggingEnabled') {
+        value = !formData.debugLoggingEnabled;
       }
       if (key === 'momentaryButtons') {
         value = !formData.momentaryButtons;

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -197,6 +197,16 @@ export default class ApiService {
     newValue.history = newValue.history.slice(-600);
     machine.value = newValue;
   }
+
+  _onLogs(message) {
+    if (!message.data || typeof message.data !== 'string') {
+      return;
+    }
+
+    // Append raw log text (keep last ~1MB of logs)
+    const currentText = logs.value;
+    logs.value = (currentText + message.data).slice(-1000000);
+  }
 }
 
 export const ApiServiceContext = createContext(null);
@@ -223,3 +233,5 @@ export const machine = signal({
   },
   history: [],
 });
+
+export const logs = signal('');

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -125,12 +125,14 @@ export default class ApiService {
       const isConnected = this.socket?.readyState === WebSocket.OPEN;
 
       if (isConnected && timeSinceLastMessage > this.heartbeatTimeout) {
-        console.log(`Connection stale (${timeSinceLastMessage}ms since last message), forcing reconnect`);
+        console.log(
+          `Connection stale (${timeSinceLastMessage}ms since last message), forcing reconnect`,
+        );
         if (this.socket) {
           this.socket.close();
         }
       }
-    }, 1000); 
+    }, 1000);
   }
 
   send(event) {


### PR DESCRIPTION
## Summary

This PR adds some logging QoL features to GaggiMate. There's a couple of parts to this:
- a plugin that hooks into ESP32 uart channel to capture logs
- these logs then go to a logfile and get sent over WS once per second
- a download endpoint
- bonus: websocket connectivity indicator (top right)

<img width="1591" height="940" alt="image" src="https://github.com/user-attachments/assets/4e90a737-25f4-490a-9b5e-7373ac843e1a" />

## Display/ESP32 Changes

### DebugLogPlugin
Implements a new plugin that intercepts most ESP32 console output (printf, ESP_LOG*, etc.) using the `esp_rom_install_channel_putc()` hook. This captures all logs from the moment the hook is installed, with the exception of panics/core dumps. The plugin has a 16KB internal circular buffer and tracks two readers: one for writing to file and one for streaming the logs over WS.

Because the hooked `putc` can get called from ISR, I avoided locks and file IO in the hook. This does mean the internal buffer might overflow if WS/file readers don't keep up with demand. When this happens it simply drops some bytes. 

The plugin writes to file once every 5 seconds or immediately if there's only 1KB of space left before the buffer would drop logs.

The log file is rotated (so there's actually two files) to ensure that we're never left with a completely empty log. Each file is kept under 50KB, so 100KB total. Writing prioritizes SD Card over SPIFFS.

### WebUIPlugin
- Streams new logs via `evt:logs` messages.
- REST API endpoint `/api/logs` serves combined log files (current + rotated).

## Frontend Changes

### System Logs Page
This page renders the received logs. It has a download button to hit the `/api/logs` endpoint (returns logs even if they were not caught through WS).
The logs are tracked in ApiService retaining a max of 1MB.

### WebSocket Status Indicator

Visual connection health indicator in the header with 4 states:
- **Connected** (green): Active connection with recent messages
- **Stale** (yellow): Connected but no messages for >2 seconds
- **Connecting** (red, pulsing): Attempting connection
- **Disconnected** (red, solid): No connection, shows countdown to next reconnection attempt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time debug logging: in-memory buffer with file persistence, WebSocket streaming, downloadable logs, and a web UI viewer with filtering, export and auto-scroll. Header now shows live WebSocket status. OTA page includes a Debug Logs card.

* **Bug Fixes**
  * Improved startup/runtime logging and safer brew phase timing/transition logs.

* **Settings**
  * New persisted toggle to enable/disable debug logging.

* **Breaking Changes**
  * Brew phase completion API now returns detailed completion reasons instead of a boolean.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->