### PR TITLE
Flow UI/UX: Update validation min value for -1; Add label explaining the -1 magic…

### DIFF
--- a/web/src/pages/ProfileEdit/ExtendedPhase.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedPhase.jsx
@@ -271,6 +271,7 @@ export function ExtendedPhase({ phase, index, onChange, onRemove, pressureAvaila
           <div className='form-control'>
             <label htmlFor={`phase-${index}-flow`} className='mb-2 block text-sm font-medium'>
               {mode === 'flow' ? 'Target' : 'Maximum'} Flow {mode === 'pressure' && '(0 = Ignore)'}
+              {mode === 'flow' && '(-1 = Keep current flow)'}
             </label>
             <div className='input-group'>
               <label htmlFor={`phase-${index}-flow`} className='input w-full'>
@@ -284,7 +285,7 @@ export function ExtendedPhase({ phase, index, onChange, onRemove, pressureAvaila
                     onFieldChange('pump', { ...phase.pump, flow: parseFloat(e.target.value) })
                   }
                   aria-label='Flow rate in grams per second'
-                  min={mode === 'flow' ? '0.1' : '0'}
+                  min={mode === 'flow' ? '-1' : '0'}
                 />
                 <span aria-label='grams per second'>g/s</span>
               </label>

--- a/web/src/pages/ShotHistory/HistoryChart.jsx
+++ b/web/src/pages/ShotHistory/HistoryChart.jsx
@@ -32,7 +32,7 @@ function getChartData(data) {
   const minX = Math.min(...timeValues);
   const maxX = Math.max(...timeValues);
   const padding = maxTemp - minTemp > 10 ? 2 : 5;
-  
+
   // Check if weight data has any non-zero values
   const hasWeight = v.some(point => point.y > 0);
   const hasWeightFlow = vf.some(point => point.y > 0);
@@ -93,20 +93,28 @@ function getChartData(data) {
           data: tf,
         },
         // Only include weight datasets if they have non-zero values
-        ...(hasWeight ? [{
-          label: 'Weight',
-          borderColor: '#8B5CF6',
-          pointStyle: false,
-          yAxisID: 'y2',
-          data: v,
-        }] : []),
-        ...(hasWeightFlow ? [{
-          label: 'Weight Flow',
-          borderColor: '#4b2e8dff',
-          pointStyle: false,
-          yAxisID: 'y1',
-          data: vf,
-        }] : []),
+        ...(hasWeight
+          ? [
+              {
+                label: 'Weight',
+                borderColor: '#8B5CF6',
+                pointStyle: false,
+                yAxisID: 'y2',
+                data: v,
+              },
+            ]
+          : []),
+        ...(hasWeightFlow
+          ? [
+              {
+                label: 'Weight Flow',
+                borderColor: '#4b2e8dff',
+                pointStyle: false,
+                yAxisID: 'y1',
+                data: vf,
+              },
+            ]
+          : []),
       ],
     },
     options: {
@@ -179,21 +187,23 @@ function getChartData(data) {
           },
           grid: { drawOnChartArea: false },
         },
-        ...(hasWeight ? {
-          y2: {
-            type: 'linear',
-            min: 0,
-            position: 'right',
-            offset: true,
-            ticks: {
-              callback: value => `${value.toFixed()} g`,
-              font: {
-                size: window.innerWidth < 640 ? 10 : 12,
+        ...(hasWeight
+          ? {
+              y2: {
+                type: 'linear',
+                min: 0,
+                position: 'right',
+                offset: true,
+                ticks: {
+                  callback: value => `${value.toFixed()} g`,
+                  font: {
+                    size: window.innerWidth < 640 ? 10 : 12,
+                  },
+                },
+                grid: { drawOnChartArea: false },
               },
-            },
-            grid: { drawOnChartArea: false },
-          },
-        } : {}),
+            }
+          : {}),
       },
     },
   };


### PR DESCRIPTION
Previously browsers (tested on Chrome, Firefox) wouldn't allow saving profiles with -1 as the flow.

This was due to the `min` validation rule being set to `0.1`.

I've also added label text for this magic value.

Checks Passed.
Formatters and Linters ran (found one formatting fix).

Before:
<img width="1234" height="640" alt="image" src="https://github.com/user-attachments/assets/877a02fe-602f-4dae-9d99-1ef3e994f8ea" />


After:
<img width="1247" height="655" alt="image" src="https://github.com/user-attachments/assets/f85f648f-c6bc-43ab-b2bd-645bd4e36998" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hint to Flow/Pressure label indicating -1 preserves current flow settings.
  * Flow input now accepts negative values to enable enhanced flow control options.

* **Refactor**
  * Improved organization of weight-related dataset configurations in chart visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->