### PR TITLE
Track maximum observed Bluetooth weight during shot

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -78,6 +78,7 @@ class ShotHistoryPlugin : public Plugin {
     float currentBluetoothFlow = 0.0f;
     float currentEstimatedWeight = 0.0f;
     float currentPuckResistance = 0.0f;
+    float maxRecordedWeight = 0.0f; // Track maximum observed weight during shot
     String currentProfileName;
 
     // Phase transition tracking (v5+)


### PR DESCRIPTION
Store maximum observed bluetooth weight in header (instead of instantaneous scale reading at end of shot). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified weight tracking during espresso shots to record and utilize the maximum observed weight for final calculations, replacing the previous current weight method.
  * Ensured per-shot state is properly reset when starting new recording sessions, including all weight tracking counters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->