### PR TITLE
fix: return false if led init fails

### DIFF
--- a/lib/GaggiMateController/src/peripherals/LedController.cpp
+++ b/lib/GaggiMateController/src/peripherals/LedController.cpp
@@ -30,6 +30,7 @@ bool LedController::initialize() {
     bool retval = this->pca9634->begin();
     if (!retval) {
         ESP_LOGE("LedController", "Failed to initialize PCA9634");
+        return false;
     }
     ESP_LOGI("LedController", "Initialized PCA9634");
     this->initialized = retval;


### PR DESCRIPTION
I haven't tested this, but people on discord with a standard PCB are reporting their controller fails to start up with logs printing `Failed to initialize PCA9634` followed by `Initialized PCA9634`. This seems like it may be enough to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved LED initialization robustness with better error handling that immediately halts initialization when hardware detection fails, preventing potential cascading failures downstream.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->