### PR TITLE
feat: Add dynamic label update for BrewScreen based on volumetric mode

### DIFF
--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -515,6 +515,12 @@ void DefaultUI::setupReactive() {
         },
         &volumetricMode);
     effect_mgr.use_effect(
+        [=] { return currentScreen == ui_BrewScreen; },
+        [=]() {
+            lv_label_set_text(ui_BrewScreen_Label1, volumetricMode ? "Brew by Weight" : "Brew by Time");
+        },
+        &volumetricMode);
+    effect_mgr.use_effect(
         [=] { return currentScreen == ui_GrindScreen; },
         [=]() {
             lv_img_set_src(ui_GrindScreen_targetSymbol, volumetricMode ? &ui_img_1424216268 : &ui_img_360122106);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Brew screen to display a dynamic label that shows either "Brew by Weight" or "Brew by Time" based on the current brewing mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->