### PR TITLE
Longer, Prettier Notes

### DIFF
--- a/schema/shot_notes.json
+++ b/schema/shot_notes.json
@@ -45,7 +45,7 @@
     "notes": {
       "description": "User notes",
       "type": "string",
-      "maxLength": 50000
+      "maxLength": 15000
     },
     "timestamp": {
       "description": "Timestamp when notes were last updated",

--- a/web/src/pages/ShotHistory/ShotNotesCard.jsx
+++ b/web/src/pages/ShotHistory/ShotNotesCard.jsx
@@ -348,14 +348,14 @@ export default function ShotNotesCard({ shot, onNotesUpdate, onNotesLoaded }) {
       <div className='form-control mt-6'>
         <label className='mb-2 block text-sm font-medium'>
           Notes{' '}
-          {isEditing && <span className='text-xs text-gray-500'>({notes.notes.length}/50000)</span>}
+          {isEditing && <span className='text-xs text-gray-500'>({notes.notes.length}/15000)</span>}
         </label>
         {isEditing ? (
           <textarea
             className='textarea textarea-bordered w-full'
             rows='4'
             value={notes.notes}
-            maxLength={50000}
+            maxLength={15000}
             onChange={e => handleInputChange('notes', e.target.value)}
             placeholder='Tasting notes, brewing observations, etc...'
           />


### PR DESCRIPTION
## The Change

I'm getting familiarized with this project with this tiny update to change a limitation that has been bugging me.

This update does two things:
1. Increases the note character limit to 15k
2. Improves display of notes by preserving white space and breaking words

## Character Limit Increase

Notes are currently limited to 200, which is far too short for me since I occasionally write novels when taking extra time to really taste a cup. The 200 character limit is actually a recent improvement thanks to https://github.com/jniebuhr/gaggimate/pull/496, which upped the limit from 100 introduced by https://github.com/jniebuhr/gaggimate/pull/453. I'm not sure where that original 100 limit came from, and I think the 200 limit was attempting to not rock the boat too much.

I landed on 15k as a good limit after I did some testing by removing the limit entirely and trying out different lengths of Lorem Ipsum. I found that it would start breaking between 65k and 66k characters. I assume the breakage is due to memory limits, and since one character could be anywhere from 1 to 4 bytes, I erred on the side of caution and assumed 4 bytes per character with 64kb of memory. 64k/4 = 16k characters, then I rounded down to 15k.

Originally, I thought I'd just use the entire 64kb memory and leave a little buffer for everything else, so I almost went with 50k as the character limit. I still think that's a fine option, so it could be increased in the future. However, since it's possible to blow through the memory with special characters and the loading/saving performance is noticeably degraded at 50k characters, 15k is just safer and should be plenty large enough even for the most verbose note takers out there.

## Prettier Notes Display

When not editing, the notes display currently removes excess whitespace and new lines. It also doesn't handle overflow well, so a loooooong word would visibly overflow outside of the textbox. I added some classes to the display to preserve whitespace and wrap text so now long notes will look nice!

## Screenshots

Here's an example of a preview of a long note:

<img width="1338" height="1272" alt="image" src="https://github.com/user-attachments/assets/1ed78f72-6a39-4764-bc69-fb56b82024c1" />

Here's what the same note looks like in edit mode:

<img width="1236" height="918" alt="image" src="https://github.com/user-attachments/assets/f82167d9-1ac1-4c4e-91e9-b897aeee73a4" />

Here's some fun things you can do with preserved white space and word breaks:

<img width="1275" height="756" alt="image" src="https://github.com/user-attachments/assets/633d92de-394c-4120-b32c-406a2d33430a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes field capacity increased to 15,000 characters, up from 200. Users can now write significantly longer and more detailed notes. The character counter has been updated to reflect the new maximum limit.

* **Bug Fixes**
  * Improved text wrapping and formatting in the notes display for better readability and visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->