### PR TITLE
feat: warmup detection using heater power trend

### DIFF
--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -231,15 +231,17 @@ void GaggiMateController::thermalRunawayShutdown() {
 }
 
 void GaggiMateController::sendSensorData() {
+    // Convert heater output from 0-1000 to 0-100%
+    float heaterPower = this->heater->getOutput() / 10.0f;
     if (_config.capabilites.pressure) {
         auto dimmedPump = static_cast<DimmedPump *>(pump);
         _ble.sendSensorData(this->thermocouple->read(), this->pressureSensor->getPressure(), dimmedPump->getPuckFlow(),
-                            dimmedPump->getPumpFlow(), dimmedPump->getPuckResistance());
+                            dimmedPump->getPumpFlow(), dimmedPump->getPuckResistance(), heaterPower);
         if (this->valve->getState()) {
             _ble.sendVolumetricMeasurement(dimmedPump->getCoffeeVolume());
         }
     } else {
-        _ble.sendSensorData(this->thermocouple->read(), 0.0f, 0.0f, 0.0f, 0.0f);
+        _ble.sendSensorData(this->thermocouple->read(), 0.0f, 0.0f, 0.0f, 0.0f, heaterPower);
     }
 }
 

--- a/lib/GaggiMateController/src/peripherals/Heater.h
+++ b/lib/GaggiMateController/src/peripherals/Heater.h
@@ -26,6 +26,7 @@ class Heater {
     float getSetpoint() { return setpoint; };
     void setTunings(float Kp, float Ki, float Kd);
     void autotune(int goal, int windowSize);
+    float getOutput() const { return output; }
 
     // Thermal feedforward control
     void setThermalFeedforward(float *pumpFlowPtr = nullptr, float incomingWaterTemp = 23.0f, int *valveStatusPtr = nullptr);

--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -1,4 +1,5 @@
 #include "NimBLEClientController.h"
+#include <cmath>
 #include <cstdio>
 
 constexpr size_t MAX_CONNECT_RETRIES = 3;
@@ -313,18 +314,22 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
         float puckFlow = 0.0f;
         float pumpFlow = 0.0f;
         float puckResistance = 0.0f;
+        float heaterPower = NAN;
 
-        int parsed = sscanf(rawData, "%f,%f,%f,%f,%f", &temperature, &pressure, &puckFlow, &pumpFlow, &puckResistance);
+        int parsed = sscanf(rawData, "%f,%f,%f,%f,%f,%f", &temperature, &pressure, &puckFlow, &pumpFlow, &puckResistance, &heaterPower);
         if (parsed < 5) {
             ESP_LOGW(LOG_TAG, "Malformed sensor data payload: %s", rawData);
             return;
         }
+        if (parsed < 6) {
+            heaterPower = NAN;
+        }
 
         ESP_LOGV(LOG_TAG,
-                 "Received sensor data: temperature=%.1f, pressure=%.1f, puck_flow=%.1f, pump_flow=%.1f, puck_resistance=%.1f",
-                 temperature, pressure, puckFlow, pumpFlow, puckResistance);
+                 "Sensor data: temp=%.1f, pressure=%.1f, puck_flow=%.1f, pump_flow=%.1f, puck_resistance=%.1f, heater_power=%.1f",
+                 temperature, pressure, puckFlow, pumpFlow, puckResistance, heaterPower);
         if (sensorCallback != nullptr) {
-            sensorCallback(temperature, pressure, puckFlow, pumpFlow, puckResistance);
+            sensorCallback(temperature, pressure, puckFlow, pumpFlow, puckResistance, heaterPower);
         }
     }
     if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(AUTOTUNE_RESULT_UUID))) {

--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -49,6 +49,14 @@ void NimBLEClientController::registerSteamBtnCallback(const brew_callback_t &cal
 
 void NimBLEClientController::registerSensorCallback(const sensor_read_callback_t &callback) { sensorCallback = callback; }
 
+void NimBLEClientController::registerSensorCallback(const legacy_sensor_read_callback_t &callback) {
+    sensorCallback = [callback](float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance, float) {
+        if (callback) {
+            callback(temperature, pressure, puckFlow, pumpFlow, puckResistance);
+        }
+    };
+}
+
 void NimBLEClientController::registerAutotuneResultCallback(const pid_control_callback_t &callback) {
     autotuneResultCallback = callback;
 }

--- a/lib/NimBLEComm/src/NimBLEClientController.h
+++ b/lib/NimBLEComm/src/NimBLEClientController.h
@@ -29,6 +29,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void registerBrewBtnCallback(const brew_callback_t &callback);
     void registerSteamBtnCallback(const steam_callback_t &callback);
     void registerSensorCallback(const sensor_read_callback_t &callback);
+    void registerSensorCallback(const legacy_sensor_read_callback_t &callback);
     void registerAutotuneResultCallback(const pid_control_callback_t &callback);
     void registerVolumetricMeasurementCallback(const float_callback_t &callback);
     void registerTofMeasurementCallback(const int_callback_t &callback);

--- a/lib/NimBLEComm/src/NimBLEComm.h
+++ b/lib/NimBLEComm/src/NimBLEComm.h
@@ -49,7 +49,7 @@ using simple_output_callback_t = std::function<void(bool valve, float pumpSetpoi
 using advanced_output_callback_t =
     std::function<void(bool valve, float boilerSetpoint, bool pressureTarget, float pumpPressure, float pumpFlow)>;
 using sensor_read_callback_t =
-    std::function<void(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance)>;
+    std::function<void(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance, float heaterPower)>;
 using led_control_callback_t = std::function<void(uint8_t channel, uint8_t brightness)>;
 
 struct SystemCapabilities {

--- a/lib/NimBLEComm/src/NimBLEComm.h
+++ b/lib/NimBLEComm/src/NimBLEComm.h
@@ -50,6 +50,8 @@ using advanced_output_callback_t =
     std::function<void(bool valve, float boilerSetpoint, bool pressureTarget, float pumpPressure, float pumpFlow)>;
 using sensor_read_callback_t =
     std::function<void(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance, float heaterPower)>;
+using legacy_sensor_read_callback_t =
+    std::function<void(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance)>;
 using led_control_callback_t = std::function<void(uint8_t channel, uint8_t brightness)>;
 
 struct SystemCapabilities {

--- a/lib/NimBLEComm/src/NimBLEServerController.cpp
+++ b/lib/NimBLEComm/src/NimBLEServerController.cpp
@@ -89,10 +89,10 @@ void NimBLEServerController::loop() {
 }
 
 void NimBLEServerController::sendSensorData(float temperature, float pressure, float puckFlow, float pumpFlow,
-                                            float puckResistance) {
+                                            float puckResistance, float heaterPower) {
     if (deviceConnected && sensorChar != nullptr) {
-        snprintf(sensorDataBuffer, sizeof(sensorDataBuffer), "%.3f,%.3f,%.3f,%.3f,%.3f", temperature, pressure, puckFlow,
-                 pumpFlow, puckResistance);
+        snprintf(sensorDataBuffer, sizeof(sensorDataBuffer), "%.3f,%.3f,%.3f,%.3f,%.3f,%.1f", temperature, pressure, puckFlow,
+                 pumpFlow, puckResistance, heaterPower);
         sensorChar->setValue(sensorDataBuffer);
         sensorChar->notify();
     }

--- a/lib/NimBLEComm/src/NimBLEServerController.h
+++ b/lib/NimBLEComm/src/NimBLEServerController.h
@@ -11,7 +11,7 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     void initServer(String infoString);
     void loop();
 
-    void sendSensorData(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance);
+    void sendSensorData(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance, float heaterPower);
     void sendError(int errorCode);
     void sendBrewBtnState(bool brewButtonStatus);
     void sendSteamBtnState(bool steamButtonStatus);

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -143,15 +143,17 @@ void Controller::setupBluetooth() {
         }
     });
     clientController.registerSensorCallback(
-        [this](const float temp, const float pressure, const float puckFlow, const float pumpFlow, const float puckResistance) {
+        [this](const float temp, const float pressure, const float puckFlow, const float pumpFlow, const float puckResistance, const float heaterPower) {
             onTempRead(temp);
             this->pressure = pressure;
             this->currentPuckFlow = puckFlow;
             this->currentPumpFlow = pumpFlow;
+            this->heaterPower = heaterPower;
             pluginManager->trigger("boiler:pressure:change", "value", pressure);
             pluginManager->trigger("pump:puck-flow:change", "value", puckFlow);
             pluginManager->trigger("pump:flow:change", "value", pumpFlow);
             pluginManager->trigger("pump:puck-resistance:change", "value", puckResistance);
+            pluginManager->trigger("boiler:heaterPower:change", "value", heaterPower);
         });
     clientController.registerBrewBtnCallback([this](const int brewButtonStatus) { handleBrewButton(brewButtonStatus); });
     clientController.registerSteamBtnCallback([this](const int steamButtonStatus) { handleSteamButton(steamButtonStatus); });

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -51,6 +51,7 @@ class Controller {
     virtual float getCurrentPressure() const { return pressure; }
     virtual float getCurrentPuckFlow() const { return currentPuckFlow; }
     virtual float getCurrentPumpFlow() const { return currentPumpFlow; }
+    virtual float getHeaterPower() const { return heaterPower; }
 
     bool isTaskHealthy() const { return is_task_healthy(eTaskGetState(taskHandle)); }
 
@@ -146,6 +147,7 @@ class Controller {
     float currentPuckFlow = 0.0f;
     float currentPumpFlow = 0.0f;
     float targetFlow = 0.0f;
+    float heaterPower = 0.0f;
     int tofDistance = 0;
 
     SystemInfo systemInfo{};

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -85,6 +85,10 @@ void DefaultUI::updateTempStableFlag() {
         heaterPowerWindowStart = now;
     }
 
+    if (!isWarmedUp && heaterPowerTimeTotal == 0 && (now - heaterPowerWindowStart) >= STABLE_FALLBACK_MS) {
+        isWarmedUp = true;
+    }
+
     if (!isWarmedUp && heaterPowerTimeTotal > 0 && (now - heaterPowerWindowStart) >= HEATER_POWER_WINDOW_MS) {
         float avgPower = heaterPowerTimeSum / heaterPowerTimeTotal;
         if (lastHeaterPowerWindowAvg >= 0.0f) {

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -30,8 +30,8 @@ int16_t calculate_angle(int set_temp, int range, int offset) {
 }
 
 void DefaultUI::updateTempHistory() {
-    if (currentTemp > 0) {
-        tempHistory[tempHistoryIndex] = currentTemp;
+    if (currentTempSample > 0.0f) {
+        tempHistory[tempHistoryIndex] = currentTempSample;
         tempHistoryIndex += 1;
     }
 
@@ -66,9 +66,9 @@ void DefaultUI::updateTempStableFlag() {
     // Calculate temperature stability from history
     float totalError = 0.0f;
     float maxError = 0.0f;
-    const float targetTempF = static_cast<float>(targetTemp);
+    const float targetTempF = targetTempSample;
     for (int i = 0; i < TEMP_HISTORY_LENGTH; i++) {
-        float error = fabsf(static_cast<float>(tempHistory[i]) - targetTempF);
+        float error = fabsf(tempHistory[i] - targetTempF);
         totalError += error;
         maxError = max(maxError, error);
     }
@@ -82,12 +82,12 @@ void DefaultUI::updateTempStableFlag() {
     }
 
     // Reset stability if setpoint has changed
-    if (prevTargetTemp != targetTemp) {
+    if (prevTargetTemp != targetTempSample) {
         isTemperatureStable = false;
         resetWarmupState();
-        ESP_LOGD(TAG, "Target temp changed: %d -> %d, resetting stability", prevTargetTemp, targetTemp);
+        ESP_LOGD(TAG, "Target temp changed: %.1f -> %.1f, resetting stability", prevTargetTemp, targetTempSample);
     }
-    prevTargetTemp = targetTemp;
+    prevTargetTemp = targetTempSample;
 
     unsigned long now = millis();
 
@@ -101,15 +101,15 @@ void DefaultUI::updateTempStableFlag() {
         lastHeaterPowerSampleTime = 0;
         lastHeaterPowerWindowAvg = NAN;
         if (!wasStable) {
-            ESP_LOGI(TAG, "Stable: temp=%d target=%d", currentTemp, targetTemp);
+            ESP_LOGI(TAG, "Stable: temp=%.1f target=%.1f", currentTempSample, targetTempSample);
         }
     }
 
     // Handle loss of stability
     if (!isTemperatureStable) {
         if (wasStable) {
-            ESP_LOGD(TAG, "Unstable: temp=%d avgErr=%.2f maxErr=%.2f margin=%.2f",
-                     currentTemp, avgError, maxError, errorMargin);
+            ESP_LOGD(TAG, "Unstable: temp=%.1f avgErr=%.2f maxErr=%.2f margin=%.2f",
+                     currentTempSample, avgError, maxError, errorMargin);
         }
         resetWarmupState();
         return;
@@ -194,9 +194,11 @@ void DefaultUI::init() {
     profileManager = controller->getProfileManager();
     auto triggerRender = [this](Event const &) { rerender = true; };
     pluginManager->on("boiler:currentTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
-        if (newTemp != currentTemp) {
-            currentTemp = newTemp;
+        float newTemp = event.getFloat("value");
+        currentTempSample = newTemp;
+        int newTempInt = static_cast<int>(newTemp);
+        if (newTempInt != currentTemp) {
+            currentTemp = newTempInt;
             rerender = true;
         }
     });
@@ -208,9 +210,11 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("boiler:targetTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
-        if (newTemp != targetTemp) {
-            targetTemp = newTemp;
+        float newTemp = event.getFloat("value");
+        targetTempSample = newTemp;
+        int newTempInt = static_cast<int>(newTemp);
+        if (newTempInt != targetTemp) {
+            targetTemp = newTempInt;
             rerender = true;
         }
     });
@@ -482,9 +486,11 @@ void DefaultUI::setupState() {
     smartGrindActive = settings.isSmartGrindActive();
     grindAvailable = smartGrindActive || settings.getAltRelayFunction() == ALT_RELAY_GRIND;
     mode = controller->getMode();
-    currentTemp = static_cast<int>(controller->getCurrentTemp());
-    targetTemp = static_cast<int>(controller->getTargetTemp());
-    prevTargetTemp = targetTemp;
+    currentTempSample = controller->getCurrentTemp();
+    currentTemp = static_cast<int>(currentTempSample);
+    targetTempSample = controller->getTargetTemp();
+    targetTemp = static_cast<int>(targetTempSample);
+    prevTargetTemp = targetTempSample;
     targetDuration = profileManager->getSelectedProfile().getTotalDuration();
     targetVolume = profileManager->getSelectedProfile().getTotalVolume();
     grindDuration = settings.getTargetGrindDuration();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -154,7 +154,7 @@ void DefaultUI::init() {
     });
     pluginManager->on("boiler:heaterPower:change", [=](Event const &event) {
         currentHeaterPower = event.getFloat("value");
-        ESP_LOGI("DefaultUI", "heaterPower=%.1f stable=%d warmedUp=%d windowAvg=%.1f sum=%.0f total=%lu",
+        ESP_LOGV("DefaultUI", "heaterPower=%.1f stable=%d warmedUp=%d windowAvg=%.1f sum=%.0f total=%lu",
                  currentHeaterPower, isTemperatureStable, isWarmedUp, lastHeaterPowerWindowAvg,
                  heaterPowerTimeSum, heaterPowerTimeTotal);
         if (currentHeaterPower != currentHeaterPower || !isTemperatureStable || isWarmedUp) {

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -1,6 +1,10 @@
 #include "DefaultUI.h"
 
 #include <WiFi.h>
+#include <cmath>
+#include <esp_log.h>
+
+#include <display/config.h>
 #include <display/core/Controller.h>
 #include <display/core/process/BrewProcess.h>
 #include <display/core/process/Process.h>
@@ -17,6 +21,7 @@
 
 #include "esp_sntp.h"
 
+static const char *TAG = "DefaultUI";
 static EffectManager effect_mgr;
 
 int16_t calculate_angle(int set_temp, int range, int offset) {
@@ -30,7 +35,7 @@ void DefaultUI::updateTempHistory() {
         tempHistoryIndex += 1;
     }
 
-    if (tempHistoryIndex > TEMP_HISTORY_LENGTH) {
+    if (tempHistoryIndex >= TEMP_HISTORY_LENGTH) {
         tempHistoryIndex = 0;
         isTempHistoryInitialized = true;
     }
@@ -41,37 +46,140 @@ void DefaultUI::updateTempHistory() {
     }
 }
 
+void DefaultUI::resetWarmupState() {
+    isWarmedUp = false;
+    stableStartTime = 0;
+    heaterPowerWindowStart = 0;
+    heaterPowerTimeSum = 0.0f;
+    heaterPowerTimeTotal = 0;
+    lastHeaterPowerSampleTime = 0;
+    lastHeaterPowerWindowAvg = NAN;
+}
+
 void DefaultUI::updateTempStableFlag() {
-    if (isTempHistoryInitialized) {
-        float totalError = 0.0f;
-        float maxError = 0.0f;
-        for (uint16_t i = 0; i < TEMP_HISTORY_LENGTH; i++) {
-            float error = abs(tempHistory[i] - targetTemp);
-            totalError += error;
-            maxError = error > maxError ? error : maxError;
-        }
-
-        const float avgError = totalError / TEMP_HISTORY_LENGTH;
-        const float errorMargin = max(2.0f, static_cast<float>(targetTemp) * 0.02f);
-
-        isTemperatureStable = avgError < errorMargin && maxError <= errorMargin;
+    if (!isTempHistoryInitialized) {
+        return;
     }
 
-    // instantly reset stability if setpoint has changed
-    if (prevTargetTemp != targetTemp) {
+    bool wasStable = isTemperatureStable;
+
+    // Calculate temperature stability from history
+    float totalError = 0.0f;
+    float maxError = 0.0f;
+    for (int i = 0; i < TEMP_HISTORY_LENGTH; i++) {
+        float error = fabs(tempHistory[i] - targetTempFloat);
+        totalError += error;
+        maxError = max(maxError, error);
+    }
+    float avgError = totalError / TEMP_HISTORY_LENGTH;
+    float errorMargin = max(2.0f, targetTempFloat * 0.02f);
+    float unstableMargin = errorMargin + TEMP_STABILITY_HYSTERESIS;
+    if (isTemperatureStable) {
+        isTemperatureStable = (avgError < errorMargin) && (maxError <= unstableMargin);
+    } else {
+        isTemperatureStable = (avgError < errorMargin) && (maxError <= errorMargin);
+    }
+
+    // Reset stability if setpoint has changed
+    if (fabs(prevTargetTemp - targetTempFloat) > 0.1f) {
         isTemperatureStable = false;
+        resetWarmupState();
+        ESP_LOGD(TAG, "Target temp changed: %.1f -> %.1f, resetting stability", prevTargetTemp, targetTempFloat);
+    }
+    prevTargetTemp = targetTempFloat;
+
+    unsigned long now = millis();
+
+    // Initialize stable state tracking when entering or re-entering stable state
+    if (isTemperatureStable && stableStartTime == 0) {
+        isWarmedUp = false;
+        stableStartTime = now;
+        heaterPowerWindowStart = now;
+        heaterPowerTimeSum = 0.0f;
+        heaterPowerTimeTotal = 0;
+        lastHeaterPowerSampleTime = 0;
+        lastHeaterPowerWindowAvg = NAN;
+        if (!wasStable) {
+            ESP_LOGI(TAG, "Stable: temp=%.1f target=%.1f", currentTempFloat, targetTempFloat);
+        }
     }
 
-    prevTargetTemp = targetTemp;
+    // Handle loss of stability
+    if (!isTemperatureStable) {
+        if (wasStable) {
+            ESP_LOGD(TAG, "Unstable: temp=%.1f avgErr=%.2f maxErr=%.2f margin=%.2f",
+                     currentTempFloat, avgError, maxError, errorMargin);
+        }
+        resetWarmupState();
+        return;
+    }
+
+    // Check if warmed up state was lost due to heater power spike
+    if (isWarmedUp && currentHeaterPower >= HEATER_POWER_SPIKE_THRESHOLD) {
+        ESP_LOGI(TAG, "Warmup lost: heater power %.1f%% >= %.1f%%", currentHeaterPower, HEATER_POWER_SPIKE_THRESHOLD);
+        resetWarmupState();
+        return;
+    }
+
+    if (isWarmedUp) {
+        return;
+    }
+
+    unsigned long stableDuration = now - stableStartTime;
+    unsigned long windowDuration = heaterPowerWindowStart > 0 ? now - heaterPowerWindowStart : 0;
+
+    // Fallback: maximum stable time reached
+    if (stableDuration >= WARMUP_MAX_STABLE_MS) {
+        isWarmedUp = true;
+        ESP_LOGI(TAG, "Warmed up (fallback): stable for %lu seconds", stableDuration / 1000);
+        return;
+    }
+
+    // Heater power equilibrium detection: check at end of each window
+    if (windowDuration >= HEATER_POWER_WINDOW_MS && heaterPowerTimeTotal > 0) {
+        float avgPower = heaterPowerTimeSum / heaterPowerTimeTotal;
+        bool hasLastAvg = !std::isnan(lastHeaterPowerWindowAvg);
+        bool trendOk = hasLastAvg && fabsf(lastHeaterPowerWindowAvg - avgPower) <= HEATER_POWER_TREND_THRESHOLD;
+
+        if (trendOk) {
+            isWarmedUp = true;
+            ESP_LOGI(TAG, "Warmed up: power trend stable (avg=%.1f%%, prev=%.1f%%)",
+                     avgPower, lastHeaterPowerWindowAvg);
+        } else {
+            ESP_LOGD(TAG, "Warmup window: avg=%.1f%%, prev=%s",
+                     avgPower, hasLastAvg ? String(lastHeaterPowerWindowAvg, 1).c_str() : "n/a");
+            lastHeaterPowerWindowAvg = avgPower;
+            heaterPowerWindowStart = now;
+            heaterPowerTimeSum = 0.0f;
+            heaterPowerTimeTotal = 0;
+            lastHeaterPowerSampleTime = 0;
+        }
+    }
 }
 
 void DefaultUI::adjustHeatingIndicator(lv_obj_t *dials) {
     lv_obj_t *heatingIcon = ui_comp_get_child(dials, UI_COMP_DIALS_TEMPICON);
-    lv_obj_set_style_img_recolor(heatingIcon, lv_color_hex(isTemperatureStable ? 0x00D100 : 0xF62C2C),
-                                 LV_PART_MAIN | LV_STATE_DEFAULT);
-    if (!isTemperatureStable) {
-        lv_obj_set_style_opa(heatingIcon, heatingFlash ? LV_OPA_50 : LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    // Three-color indicator:
+    // - Red (flashing): heating, not at target
+    // - Yellow (solid): stable at target, but not yet warmed up
+    // - Green (solid): warmed up and ready
+    constexpr uint32_t COLOR_GREEN = 0x00D100;
+    constexpr uint32_t COLOR_YELLOW = 0xFFAA00;
+    constexpr uint32_t COLOR_RED = 0xF62C2C;
+
+    uint32_t color = COLOR_RED;
+    if (isWarmedUp) {
+        color = COLOR_GREEN;
+    } else if (isTemperatureStable) {
+        color = COLOR_YELLOW;
     }
+
+    lv_obj_set_style_img_recolor(heatingIcon, lv_color_hex(color), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    // Flash only when heating (red state, not stable)
+    bool shouldFlash = !isTemperatureStable && heatingFlash;
+    lv_obj_set_style_opa(heatingIcon, shouldFlash ? LV_OPA_50 : LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
 }
 
 void DefaultUI::reloadProfiles() { profileLoaded = 0; }
@@ -85,7 +193,8 @@ void DefaultUI::init() {
     profileManager = controller->getProfileManager();
     auto triggerRender = [this](Event const &) { rerender = true; };
     pluginManager->on("boiler:currentTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
+        currentTempFloat = event.getFloat("value");
+        int newTemp = static_cast<int>(currentTempFloat);
         if (newTemp != currentTemp) {
             currentTemp = newTemp;
             rerender = true;
@@ -99,11 +208,26 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("boiler:targetTemperature:change", [=](Event const &event) {
-        int newTemp = static_cast<int>(event.getFloat("value"));
+        targetTempFloat = event.getFloat("value");
+        int newTemp = static_cast<int>(targetTempFloat);
         if (newTemp != targetTemp) {
             targetTemp = newTemp;
             rerender = true;
         }
+    });
+    pluginManager->on("boiler:heaterPower:change", [=](Event const &event) {
+        currentHeaterPower = event.getFloat("value");
+        if (!std::isfinite(currentHeaterPower) || !isTemperatureStable || isWarmedUp) {
+            lastHeaterPowerSampleTime = 0;
+            return;
+        }
+        unsigned long now = millis();
+        if (lastHeaterPowerSampleTime > 0) {
+            unsigned long dt = now - lastHeaterPowerSampleTime;
+            heaterPowerTimeSum += currentHeaterPower * dt;
+            heaterPowerTimeTotal += dt;
+        }
+        lastHeaterPowerSampleTime = now;
     });
     pluginManager->on("controller:targetVolume:change", [=](Event const &event) {
         targetVolume = event.getFloat("value");
@@ -125,6 +249,7 @@ void DefaultUI::init() {
     pluginManager->on("controller:process:start", triggerRender);
     pluginManager->on("controller:mode:change", [this](Event const &event) {
         mode = event.getInt("value");
+        resetWarmupState();
         switch (mode) {
         case MODE_STANDBY:
             changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init);
@@ -360,6 +485,9 @@ void DefaultUI::setupState() {
     mode = controller->getMode();
     currentTemp = static_cast<int>(controller->getCurrentTemp());
     targetTemp = static_cast<int>(controller->getTargetTemp());
+    currentTempFloat = controller->getCurrentTemp();
+    targetTempFloat = controller->getTargetTemp();
+    prevTargetTemp = targetTempFloat;
     targetDuration = profileManager->getSelectedProfile().getTotalDuration();
     targetVolume = profileManager->getSelectedProfile().getTotalVolume();
     grindDuration = settings.getTargetGrindDuration();
@@ -385,17 +513,17 @@ void DefaultUI::setupReactive() {
     effect_mgr.use_effect([=] { return currentScreen == ui_ProfileScreen; }, [=]() { adjustDials(ui_ProfileScreen_dials); },
                           &pressureAvailable);
     effect_mgr.use_effect([=] { return currentScreen == ui_BrewScreen; }, [=]() { adjustHeatingIndicator(ui_BrewScreen_dials); },
-                          &isTemperatureStable, &heatingFlash);
+                          &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_SimpleProcessScreen; },
-                          [=]() { adjustHeatingIndicator(ui_SimpleProcessScreen_dials); }, &isTemperatureStable, &heatingFlash);
+                          [=]() { adjustHeatingIndicator(ui_SimpleProcessScreen_dials); }, &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_MenuScreen; }, [=]() { adjustHeatingIndicator(ui_MenuScreen_dials); },
-                          &isTemperatureStable, &heatingFlash);
+                          &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_ProfileScreen; },
-                          [=]() { adjustHeatingIndicator(ui_ProfileScreen_dials); }, &isTemperatureStable, &heatingFlash);
+                          [=]() { adjustHeatingIndicator(ui_ProfileScreen_dials); }, &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_GrindScreen; },
-                          [=]() { adjustHeatingIndicator(ui_GrindScreen_dials); }, &isTemperatureStable, &heatingFlash);
+                          [=]() { adjustHeatingIndicator(ui_GrindScreen_dials); }, &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_StatusScreen; },
-                          [=]() { adjustHeatingIndicator(ui_StatusScreen_dials); }, &isTemperatureStable, &heatingFlash);
+                          [=]() { adjustHeatingIndicator(ui_StatusScreen_dials); }, &isTemperatureStable, &heatingFlash, &isWarmedUp);
     effect_mgr.use_effect([=] { return currentScreen == ui_SimpleProcessScreen; },
                           [=]() { lv_label_set_text(ui_SimpleProcessScreen_mainLabel5, mode == MODE_STEAM ? "Steam" : "Water"); },
                           &mode);

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -97,13 +97,11 @@ void DefaultUI::updateTempStableFlag() {
             }
         }
 
-        if (!isWarmedUp) {
-            lastHeaterPowerWindowAvg = avgPower;
-            heaterPowerWindowStart = now;
-            heaterPowerTimeSum = 0.0f;
-            heaterPowerTimeTotal = 0;
-            lastHeaterPowerSampleTime = 0;
-        }
+        lastHeaterPowerWindowAvg = avgPower;
+        heaterPowerWindowStart = now;
+        heaterPowerTimeSum = 0.0f;
+        heaterPowerTimeTotal = 0;
+        lastHeaterPowerSampleTime = 0;
     }
 }
 
@@ -118,6 +116,8 @@ void DefaultUI::adjustHeatingIndicator(lv_obj_t *dials) {
     lv_obj_set_style_img_recolor(heatingIcon, lv_color_hex(color), LV_PART_MAIN | LV_STATE_DEFAULT);
     if (!isTemperatureStable) {
         lv_obj_set_style_opa(heatingIcon, heatingFlash ? LV_OPA_50 : LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
+    } else {
+        lv_obj_set_style_opa(heatingIcon, LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
     }
 }
 
@@ -154,6 +154,9 @@ void DefaultUI::init() {
     });
     pluginManager->on("boiler:heaterPower:change", [=](Event const &event) {
         currentHeaterPower = event.getFloat("value");
+        ESP_LOGI("DefaultUI", "heaterPower=%.1f stable=%d warmedUp=%d windowAvg=%.1f sum=%.0f total=%lu",
+                 currentHeaterPower, isTemperatureStable, isWarmedUp, lastHeaterPowerWindowAvg,
+                 heaterPowerTimeSum, heaterPowerTimeTotal);
         if (currentHeaterPower != currentHeaterPower || !isTemperatureStable || isWarmedUp) {
             lastHeaterPowerSampleTime = 0;
             return;

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -66,13 +66,14 @@ void DefaultUI::updateTempStableFlag() {
     // Calculate temperature stability from history
     float totalError = 0.0f;
     float maxError = 0.0f;
+    const float targetTempF = static_cast<float>(targetTemp);
     for (int i = 0; i < TEMP_HISTORY_LENGTH; i++) {
-        float error = fabs(tempHistory[i] - targetTempFloat);
+        float error = fabsf(static_cast<float>(tempHistory[i]) - targetTempF);
         totalError += error;
         maxError = max(maxError, error);
     }
     float avgError = totalError / TEMP_HISTORY_LENGTH;
-    float errorMargin = max(2.0f, targetTempFloat * 0.02f);
+    float errorMargin = max(2.0f, targetTempF * 0.02f);
     float unstableMargin = errorMargin + TEMP_STABILITY_HYSTERESIS;
     if (isTemperatureStable) {
         isTemperatureStable = (avgError < errorMargin) && (maxError <= unstableMargin);
@@ -81,12 +82,12 @@ void DefaultUI::updateTempStableFlag() {
     }
 
     // Reset stability if setpoint has changed
-    if (fabs(prevTargetTemp - targetTempFloat) > 0.1f) {
+    if (prevTargetTemp != targetTemp) {
         isTemperatureStable = false;
         resetWarmupState();
-        ESP_LOGD(TAG, "Target temp changed: %.1f -> %.1f, resetting stability", prevTargetTemp, targetTempFloat);
+        ESP_LOGD(TAG, "Target temp changed: %d -> %d, resetting stability", prevTargetTemp, targetTemp);
     }
-    prevTargetTemp = targetTempFloat;
+    prevTargetTemp = targetTemp;
 
     unsigned long now = millis();
 
@@ -100,15 +101,15 @@ void DefaultUI::updateTempStableFlag() {
         lastHeaterPowerSampleTime = 0;
         lastHeaterPowerWindowAvg = NAN;
         if (!wasStable) {
-            ESP_LOGI(TAG, "Stable: temp=%.1f target=%.1f", currentTempFloat, targetTempFloat);
+            ESP_LOGI(TAG, "Stable: temp=%d target=%d", currentTemp, targetTemp);
         }
     }
 
     // Handle loss of stability
     if (!isTemperatureStable) {
         if (wasStable) {
-            ESP_LOGD(TAG, "Unstable: temp=%.1f avgErr=%.2f maxErr=%.2f margin=%.2f",
-                     currentTempFloat, avgError, maxError, errorMargin);
+            ESP_LOGD(TAG, "Unstable: temp=%d avgErr=%.2f maxErr=%.2f margin=%.2f",
+                     currentTemp, avgError, maxError, errorMargin);
         }
         resetWarmupState();
         return;
@@ -193,8 +194,7 @@ void DefaultUI::init() {
     profileManager = controller->getProfileManager();
     auto triggerRender = [this](Event const &) { rerender = true; };
     pluginManager->on("boiler:currentTemperature:change", [=](Event const &event) {
-        currentTempFloat = event.getFloat("value");
-        int newTemp = static_cast<int>(currentTempFloat);
+        int newTemp = static_cast<int>(event.getFloat("value"));
         if (newTemp != currentTemp) {
             currentTemp = newTemp;
             rerender = true;
@@ -208,8 +208,7 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("boiler:targetTemperature:change", [=](Event const &event) {
-        targetTempFloat = event.getFloat("value");
-        int newTemp = static_cast<int>(targetTempFloat);
+        int newTemp = static_cast<int>(event.getFloat("value"));
         if (newTemp != targetTemp) {
             targetTemp = newTemp;
             rerender = true;
@@ -485,9 +484,7 @@ void DefaultUI::setupState() {
     mode = controller->getMode();
     currentTemp = static_cast<int>(controller->getCurrentTemp());
     targetTemp = static_cast<int>(controller->getTargetTemp());
-    currentTempFloat = controller->getCurrentTemp();
-    targetTempFloat = controller->getTargetTemp();
-    prevTargetTemp = targetTempFloat;
+    prevTargetTemp = targetTemp;
     targetDuration = profileManager->getSelectedProfile().getTotalDuration();
     targetVolume = profileManager->getSelectedProfile().getTotalVolume();
     grindDuration = settings.getTargetGrindDuration();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -1,8 +1,6 @@
 #include "DefaultUI.h"
 
 #include <WiFi.h>
-#include <cmath>
-#include <esp_log.h>
 
 #include <display/config.h>
 #include <display/core/Controller.h>
@@ -20,8 +18,6 @@
 #include <utility>
 
 #include "esp_sntp.h"
-
-static const char *TAG = "DefaultUI";
 static EffectManager effect_mgr;
 
 int16_t calculate_angle(int set_temp, int range, int offset) {
@@ -30,12 +26,12 @@ int16_t calculate_angle(int set_temp, int range, int offset) {
 }
 
 void DefaultUI::updateTempHistory() {
-    if (currentTempSample > 0.0f) {
-        tempHistory[tempHistoryIndex] = currentTempSample;
+    if (currentTemp > 0) {
+        tempHistory[tempHistoryIndex] = currentTemp;
         tempHistoryIndex += 1;
     }
 
-    if (tempHistoryIndex >= TEMP_HISTORY_LENGTH) {
+    if (tempHistoryIndex > TEMP_HISTORY_LENGTH) {
         tempHistoryIndex = 0;
         isTempHistoryInitialized = true;
     }
@@ -48,107 +44,60 @@ void DefaultUI::updateTempHistory() {
 
 void DefaultUI::resetWarmupState() {
     isWarmedUp = false;
-    stableStartTime = 0;
     heaterPowerWindowStart = 0;
     heaterPowerTimeSum = 0.0f;
     heaterPowerTimeTotal = 0;
     lastHeaterPowerSampleTime = 0;
-    lastHeaterPowerWindowAvg = NAN;
+    lastHeaterPowerWindowAvg = -1.0f;
 }
 
 void DefaultUI::updateTempStableFlag() {
-    if (!isTempHistoryInitialized) {
-        return;
+    if (isTempHistoryInitialized) {
+        float totalError = 0.0f;
+        float maxError = 0.0f;
+        for (uint16_t i = 0; i < TEMP_HISTORY_LENGTH; i++) {
+            float error = abs(tempHistory[i] - targetTemp);
+            totalError += error;
+            maxError = error > maxError ? error : maxError;
+        }
+
+        const float avgError = totalError / TEMP_HISTORY_LENGTH;
+        const float errorMargin = max(2.0f, static_cast<float>(targetTemp) * 0.02f);
+
+        isTemperatureStable = avgError < errorMargin && maxError <= errorMargin;
     }
 
-    bool wasStable = isTemperatureStable;
-
-    // Calculate temperature stability from history
-    float totalError = 0.0f;
-    float maxError = 0.0f;
-    const float targetTempF = targetTempSample;
-    for (int i = 0; i < TEMP_HISTORY_LENGTH; i++) {
-        float error = fabsf(tempHistory[i] - targetTempF);
-        totalError += error;
-        maxError = max(maxError, error);
-    }
-    float avgError = totalError / TEMP_HISTORY_LENGTH;
-    float errorMargin = max(2.0f, targetTempF * 0.02f);
-    float unstableMargin = errorMargin + TEMP_STABILITY_HYSTERESIS;
-    if (isTemperatureStable) {
-        isTemperatureStable = (avgError < errorMargin) && (maxError <= unstableMargin);
-    } else {
-        isTemperatureStable = (avgError < errorMargin) && (maxError <= errorMargin);
-    }
-
-    // Reset stability if setpoint has changed
-    if (prevTargetTemp != targetTempSample) {
+    // instantly reset stability if setpoint has changed
+    if (prevTargetTemp != targetTemp) {
         isTemperatureStable = false;
         resetWarmupState();
-        ESP_LOGD(TAG, "Target temp changed: %.1f -> %.1f, resetting stability", prevTargetTemp, targetTempSample);
     }
-    prevTargetTemp = targetTempSample;
+
+    prevTargetTemp = targetTemp;
+
+    if (!isTemperatureStable) {
+        resetWarmupState();
+        return;
+    }
 
     unsigned long now = millis();
-
-    // Initialize stable state tracking when entering or re-entering stable state
-    if (isTemperatureStable && stableStartTime == 0) {
-        isWarmedUp = false;
-        stableStartTime = now;
+    if (heaterPowerWindowStart == 0) {
         heaterPowerWindowStart = now;
-        heaterPowerTimeSum = 0.0f;
-        heaterPowerTimeTotal = 0;
-        lastHeaterPowerSampleTime = 0;
-        lastHeaterPowerWindowAvg = NAN;
-        if (!wasStable) {
-            ESP_LOGI(TAG, "Stable: temp=%.1f target=%.1f", currentTempSample, targetTempSample);
-        }
     }
 
-    // Handle loss of stability
-    if (!isTemperatureStable) {
-        if (wasStable) {
-            ESP_LOGD(TAG, "Unstable: temp=%.1f avgErr=%.2f maxErr=%.2f margin=%.2f",
-                     currentTempSample, avgError, maxError, errorMargin);
-        }
-        resetWarmupState();
-        return;
-    }
-
-    // Check if warmed up state was lost due to heater power spike
-    if (isWarmedUp && currentHeaterPower >= HEATER_POWER_SPIKE_THRESHOLD) {
-        ESP_LOGI(TAG, "Warmup lost: heater power %.1f%% >= %.1f%%", currentHeaterPower, HEATER_POWER_SPIKE_THRESHOLD);
-        resetWarmupState();
-        return;
-    }
-
-    if (isWarmedUp) {
-        return;
-    }
-
-    unsigned long stableDuration = now - stableStartTime;
-    unsigned long windowDuration = heaterPowerWindowStart > 0 ? now - heaterPowerWindowStart : 0;
-
-    // Fallback: maximum stable time reached
-    if (stableDuration >= WARMUP_MAX_STABLE_MS) {
-        isWarmedUp = true;
-        ESP_LOGI(TAG, "Warmed up (fallback): stable for %lu seconds", stableDuration / 1000);
-        return;
-    }
-
-    // Heater power equilibrium detection: check at end of each window
-    if (windowDuration >= HEATER_POWER_WINDOW_MS && heaterPowerTimeTotal > 0) {
+    if (!isWarmedUp && heaterPowerTimeTotal > 0 && (now - heaterPowerWindowStart) >= HEATER_POWER_WINDOW_MS) {
         float avgPower = heaterPowerTimeSum / heaterPowerTimeTotal;
-        bool hasLastAvg = !std::isnan(lastHeaterPowerWindowAvg);
-        bool trendOk = hasLastAvg && fabsf(lastHeaterPowerWindowAvg - avgPower) <= HEATER_POWER_TREND_THRESHOLD;
+        if (lastHeaterPowerWindowAvg >= 0.0f) {
+            float diff = lastHeaterPowerWindowAvg - avgPower;
+            if (diff < 0.0f) {
+                diff = -diff;
+            }
+            if (diff <= HEATER_POWER_TREND_THRESHOLD) {
+                isWarmedUp = true;
+            }
+        }
 
-        if (trendOk) {
-            isWarmedUp = true;
-            ESP_LOGI(TAG, "Warmed up: power trend stable (avg=%.1f%%, prev=%.1f%%)",
-                     avgPower, lastHeaterPowerWindowAvg);
-        } else {
-            ESP_LOGD(TAG, "Warmup window: avg=%.1f%%, prev=%s",
-                     avgPower, hasLastAvg ? String(lastHeaterPowerWindowAvg, 1).c_str() : "n/a");
+        if (!isWarmedUp) {
             lastHeaterPowerWindowAvg = avgPower;
             heaterPowerWindowStart = now;
             heaterPowerTimeSum = 0.0f;
@@ -160,27 +109,16 @@ void DefaultUI::updateTempStableFlag() {
 
 void DefaultUI::adjustHeatingIndicator(lv_obj_t *dials) {
     lv_obj_t *heatingIcon = ui_comp_get_child(dials, UI_COMP_DIALS_TEMPICON);
-
-    // Three-color indicator:
-    // - Red (flashing): heating, not at target
-    // - Yellow (solid): stable at target, but not yet warmed up
-    // - Green (solid): warmed up and ready
-    constexpr uint32_t COLOR_GREEN = 0x00D100;
-    constexpr uint32_t COLOR_YELLOW = 0xFFAA00;
-    constexpr uint32_t COLOR_RED = 0xF62C2C;
-
-    uint32_t color = COLOR_RED;
+    uint32_t color = 0xF62C2C; // Red: not stable
     if (isWarmedUp) {
-        color = COLOR_GREEN;
+        color = 0x00D100; // Green: power trend stable (warmed up)
     } else if (isTemperatureStable) {
-        color = COLOR_YELLOW;
+        color = 0xFFAA00; // Yellow: temp stable, waiting on power trend
     }
-
     lv_obj_set_style_img_recolor(heatingIcon, lv_color_hex(color), LV_PART_MAIN | LV_STATE_DEFAULT);
-
-    // Flash only when heating (red state, not stable)
-    bool shouldFlash = !isTemperatureStable && heatingFlash;
-    lv_obj_set_style_opa(heatingIcon, shouldFlash ? LV_OPA_50 : LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
+    if (!isTemperatureStable) {
+        lv_obj_set_style_opa(heatingIcon, heatingFlash ? LV_OPA_50 : LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
 }
 
 void DefaultUI::reloadProfiles() { profileLoaded = 0; }
@@ -194,11 +132,9 @@ void DefaultUI::init() {
     profileManager = controller->getProfileManager();
     auto triggerRender = [this](Event const &) { rerender = true; };
     pluginManager->on("boiler:currentTemperature:change", [=](Event const &event) {
-        float newTemp = event.getFloat("value");
-        currentTempSample = newTemp;
-        int newTempInt = static_cast<int>(newTemp);
-        if (newTempInt != currentTemp) {
-            currentTemp = newTempInt;
+        int newTemp = static_cast<int>(event.getFloat("value"));
+        if (newTemp != currentTemp) {
+            currentTemp = newTemp;
             rerender = true;
         }
     });
@@ -210,17 +146,15 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("boiler:targetTemperature:change", [=](Event const &event) {
-        float newTemp = event.getFloat("value");
-        targetTempSample = newTemp;
-        int newTempInt = static_cast<int>(newTemp);
-        if (newTempInt != targetTemp) {
-            targetTemp = newTempInt;
+        int newTemp = static_cast<int>(event.getFloat("value"));
+        if (newTemp != targetTemp) {
+            targetTemp = newTemp;
             rerender = true;
         }
     });
     pluginManager->on("boiler:heaterPower:change", [=](Event const &event) {
         currentHeaterPower = event.getFloat("value");
-        if (!std::isfinite(currentHeaterPower) || !isTemperatureStable || isWarmedUp) {
+        if (currentHeaterPower != currentHeaterPower || !isTemperatureStable || isWarmedUp) {
             lastHeaterPowerSampleTime = 0;
             return;
         }
@@ -252,7 +186,6 @@ void DefaultUI::init() {
     pluginManager->on("controller:process:start", triggerRender);
     pluginManager->on("controller:mode:change", [this](Event const &event) {
         mode = event.getInt("value");
-        resetWarmupState();
         switch (mode) {
         case MODE_STANDBY:
             changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init);
@@ -486,11 +419,8 @@ void DefaultUI::setupState() {
     smartGrindActive = settings.isSmartGrindActive();
     grindAvailable = smartGrindActive || settings.getAltRelayFunction() == ALT_RELAY_GRIND;
     mode = controller->getMode();
-    currentTempSample = controller->getCurrentTemp();
-    currentTemp = static_cast<int>(currentTempSample);
-    targetTempSample = controller->getTargetTemp();
-    targetTemp = static_cast<int>(targetTempSample);
-    prevTargetTemp = targetTempSample;
+    currentTemp = static_cast<int>(controller->getCurrentTemp());
+    targetTemp = static_cast<int>(controller->getTargetTemp());
     targetDuration = profileManager->getSelectedProfile().getTotalDuration();
     targetVolume = profileManager->getSelectedProfile().getTotalVolume();
     grindDuration = settings.getTargetGrindDuration();

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -18,8 +18,9 @@ constexpr int TEMP_HISTORY_INTERVAL = 250;
 constexpr int TEMP_HISTORY_LENGTH = 20 * 1000 / TEMP_HISTORY_INTERVAL;
 
 // Heater power equilibrium warmup detection
-constexpr unsigned long HEATER_POWER_WINDOW_MS = 60000; // Window size for sampling
-constexpr float HEATER_POWER_TREND_THRESHOLD = 1.0f;    // Max avg power diff (%) between windows
+constexpr unsigned long HEATER_POWER_WINDOW_MS = 60000;       // Window size for sampling
+constexpr float HEATER_POWER_TREND_THRESHOLD = 1.0f;          // Max avg power diff (%) between windows
+constexpr unsigned long STABLE_FALLBACK_MS = 10 * 60 * 1000;  // Fallback warmup if no heater power data
 
 int16_t calculate_angle(int set_temp, int range, int offset);
 

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -77,9 +77,9 @@ class DefaultUI {
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
 
-    int tempHistory[TEMP_HISTORY_LENGTH] = {0};
+    float tempHistory[TEMP_HISTORY_LENGTH] = {0.0f};
     int tempHistoryIndex = 0;
-    int prevTargetTemp = 0;
+    float prevTargetTemp = 0.0f;
     bool isTempHistoryInitialized = false;
     int isTemperatureStable = false;
     bool isWarmedUp = false;
@@ -131,6 +131,8 @@ class DefaultUI {
     unsigned long lastRender = 0;
 
     int mode = MODE_STANDBY;
+    float currentTempSample = 0.0f;
+    float targetTempSample = 0.0f;
     int currentTemp = 0;
     int targetTemp = 0;
     float targetDuration = 0;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -18,8 +18,8 @@ constexpr int TEMP_HISTORY_INTERVAL = 250;
 constexpr int TEMP_HISTORY_LENGTH = 20 * 1000 / TEMP_HISTORY_INTERVAL;
 
 // Heater power equilibrium warmup detection
-constexpr unsigned long HEATER_POWER_WINDOW_MS = 30000; // Window size for sampling
-constexpr float HEATER_POWER_TREND_THRESHOLD = 2.0f;    // Max avg power drop (%) between windows
+constexpr unsigned long HEATER_POWER_WINDOW_MS = 60000; // Window size for sampling
+constexpr float HEATER_POWER_TREND_THRESHOLD = 1.0f;    // Max avg power diff (%) between windows
 
 int16_t calculate_angle(int set_temp, int range, int offset);
 
@@ -78,7 +78,7 @@ class DefaultUI {
     int tempHistoryIndex = 0;
     int prevTargetTemp = 0;
     bool isTempHistoryInitialized = false;
-    int isTemperatureStable = false;
+    bool isTemperatureStable = false;
     bool isWarmedUp = false;
     unsigned long lastTempLog = 0;
     // Heater power equilibrium detection state

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -77,9 +77,9 @@ class DefaultUI {
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
 
-    float tempHistory[TEMP_HISTORY_LENGTH] = {0};
+    int tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;
-    float prevTargetTemp = 0.0f;
+    int prevTargetTemp = 0;
     bool isTempHistoryInitialized = false;
     int isTemperatureStable = false;
     bool isWarmedUp = false;
@@ -133,8 +133,6 @@ class DefaultUI {
     int mode = MODE_STANDBY;
     int currentTemp = 0;
     int targetTemp = 0;
-    float currentTempFloat = 0.0f;
-    float targetTempFloat = 0.0f;
     float targetDuration = 0;
     float targetVolume = 0;
     int grindDuration = 0;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -17,6 +17,13 @@ constexpr int RERENDER_INTERVAL_ACTIVE = 100;
 constexpr int TEMP_HISTORY_INTERVAL = 250;
 constexpr int TEMP_HISTORY_LENGTH = 20 * 1000 / TEMP_HISTORY_INTERVAL;
 
+// Heater power equilibrium warmup detection
+constexpr float HEATER_POWER_SPIKE_THRESHOLD = 60.0f;       // Power % above which resets warmup
+constexpr unsigned long HEATER_POWER_WINDOW_MS = 30000;     // Window size for sampling
+constexpr float TEMP_STABILITY_HYSTERESIS = 0.2f;           // Extra margin before declaring unstable
+constexpr float HEATER_POWER_TREND_THRESHOLD = 2.0f;        // Max avg power drop (%) between windows
+constexpr unsigned long WARMUP_MAX_STABLE_MS = 600000;       // Fallback: declare warmed up after 10min stable
+
 int16_t calculate_angle(int set_temp, int range, int offset);
 
 enum class BrewScreenState { Brew, Settings };
@@ -70,15 +77,25 @@ class DefaultUI {
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
 
-    int tempHistory[TEMP_HISTORY_LENGTH] = {0};
+    float tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;
-    int prevTargetTemp = 0;
+    float prevTargetTemp = 0.0f;
     bool isTempHistoryInitialized = false;
     int isTemperatureStable = false;
+    bool isWarmedUp = false;
+    unsigned long stableStartTime = 0;
     unsigned long lastTempLog = 0;
+    // Heater power equilibrium detection state
+    float currentHeaterPower = 0.0f;
+    float heaterPowerTimeSum = 0.0f;
+    unsigned long heaterPowerTimeTotal = 0;
+    unsigned long lastHeaterPowerSampleTime = 0;
+    unsigned long heaterPowerWindowStart = 0;
+    float lastHeaterPowerWindowAvg = NAN;
 
     void updateTempHistory();
     void updateTempStableFlag();
+    void resetWarmupState();
     void adjustHeatingIndicator(lv_obj_t *contentPanel);
     void reloadProfiles();
 
@@ -116,6 +133,8 @@ class DefaultUI {
     int mode = MODE_STANDBY;
     int currentTemp = 0;
     int targetTemp = 0;
+    float currentTempFloat = 0.0f;
+    float targetTempFloat = 0.0f;
     float targetDuration = 0;
     float targetVolume = 0;
     int grindDuration = 0;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -18,11 +18,8 @@ constexpr int TEMP_HISTORY_INTERVAL = 250;
 constexpr int TEMP_HISTORY_LENGTH = 20 * 1000 / TEMP_HISTORY_INTERVAL;
 
 // Heater power equilibrium warmup detection
-constexpr float HEATER_POWER_SPIKE_THRESHOLD = 60.0f;       // Power % above which resets warmup
-constexpr unsigned long HEATER_POWER_WINDOW_MS = 30000;     // Window size for sampling
-constexpr float TEMP_STABILITY_HYSTERESIS = 0.2f;           // Extra margin before declaring unstable
-constexpr float HEATER_POWER_TREND_THRESHOLD = 2.0f;        // Max avg power drop (%) between windows
-constexpr unsigned long WARMUP_MAX_STABLE_MS = 600000;       // Fallback: declare warmed up after 10min stable
+constexpr unsigned long HEATER_POWER_WINDOW_MS = 30000; // Window size for sampling
+constexpr float HEATER_POWER_TREND_THRESHOLD = 2.0f;    // Max avg power drop (%) between windows
 
 int16_t calculate_angle(int set_temp, int range, int offset);
 
@@ -77,13 +74,12 @@ class DefaultUI {
     void adjustTempTarget(lv_obj_t *dials);
     void adjustTarget(lv_obj_t *obj, double percentage, double start, double range) const;
 
-    float tempHistory[TEMP_HISTORY_LENGTH] = {0.0f};
+    int tempHistory[TEMP_HISTORY_LENGTH] = {0};
     int tempHistoryIndex = 0;
-    float prevTargetTemp = 0.0f;
+    int prevTargetTemp = 0;
     bool isTempHistoryInitialized = false;
     int isTemperatureStable = false;
     bool isWarmedUp = false;
-    unsigned long stableStartTime = 0;
     unsigned long lastTempLog = 0;
     // Heater power equilibrium detection state
     float currentHeaterPower = 0.0f;
@@ -91,7 +87,7 @@ class DefaultUI {
     unsigned long heaterPowerTimeTotal = 0;
     unsigned long lastHeaterPowerSampleTime = 0;
     unsigned long heaterPowerWindowStart = 0;
-    float lastHeaterPowerWindowAvg = NAN;
+    float lastHeaterPowerWindowAvg = -1.0f;
 
     void updateTempHistory();
     void updateTempStableFlag();
@@ -131,8 +127,6 @@ class DefaultUI {
     unsigned long lastRender = 0;
 
     int mode = MODE_STANDBY;
-    float currentTempSample = 0.0f;
-    float targetTempSample = 0.0f;
     int currentTemp = 0;
     int targetTemp = 0;
     float targetDuration = 0;


### PR DESCRIPTION
## Summary
Adds heater‑power reporting over BLE and a warm‑up readiness indicator based on heater‑power trend convergence. Indicator: red flashing = not temp‑stable, yellow = temp‑stable but power trend not yet stable, green = power trend stable (warmed up).

## Algorithm
1) Wait for temperature to be stable (existing check).
2) Compute time‑weighted average heater power over 60‑second windows.
3) If two consecutive window averages differ by ≤ 1%, latch as warmed up.
4) Reset if temperature becomes unstable or setpoint changes.

Once latched, warmup stays green until a real state change (temp instability or setpoint change). This avoids flickering from normal PID duty‑cycle noise.

## Changes

### Controller
- Expose `Heater::getOutput()` and convert 0–1000 to 0–100% in `sendSensorData()`.
- Add heater power as 6th field in BLE sensor data (backwards compatible — defaults to NaN if absent).

### Comms
- Append heater power to sensor CSV payload.
- Add legacy sensor callback overload for backwards compatibility.

### Display
- Parse heater power and publish `boiler:heaterPower:change` event.
- Track heater‑power windows and set `isWarmedUp` when the trend stabilizes.
- Heating icon uses red/yellow/green three‑state mapping.
- Fix opacity bug where icon could stay semi‑transparent after becoming stable.
- Fix `isTemperatureStable` type from `int` to `bool`.

## Testing
- [x] Manual testing from cold start — ~7 minutes to green, no flickering.
- [x] Window averages show clean convergence: 14.2 → 10.8 → 8.4 → 7.6% (latched at 0.8% diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heater power monitoring: system now tracks and reports heater power (0–100%) and exposes it to the UI.
  * Extended sensor data: Bluetooth sensor readings now include heater power; legacy callback support added for compatibility.

* **Enhancements**
  * Enhanced heating indicator & warmup detection: three-state visual indicator (red/yellow/green), power-trend analysis, timing windows, reset/warmup handling, and broader reactive UI updates.

* **Chores**
  * Emits heaterPower change events for reactive UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->