### PR TITLE
Verify taring before brew

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ lib_deps_default =
     https://github.com/ESP32Async/ESPAsyncWebServer.git#v3.9.1
     bblanchon/ArduinoJson@^7.2.1
     256dpi/MQTT@^2.5.2
-    https://github.com/gaggimate/esp-arduino-ble-scales
+    https://github.com/jaapp/esp-arduino-ble-scales
     homespan/HomeSpan@1.9.1
 
 [env:display]

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -554,9 +554,13 @@ void Controller::activate() {
 #endif
         if (mode == MODE_BREW) {
             pluginManager->trigger("controller:brew:prestart");
+            // Block until tare has actually zeroed, or timeout
+            bool tareOk = BLEScales.waitForZero(2000);
+            if (!tareOk) {
+                ESP_LOGW(LOG_TAG, "Brew starting without confirmed tare zero (timeout)");
+            }
         }
     }
-    delay(200);
     switch (mode) {
     case MODE_BREW:
         startProcess(new BrewProcess(profileManager->getSelectedProfile(),

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -40,6 +40,8 @@ class BLEScalePlugin : public Plugin {
 
     std::vector<DiscoveredDevice> getDiscoveredScales() const;
     void tare();
+    // Wait for tare to reach near-zero; returns true on success, false if timed out or disconnected.
+    bool waitForZero(uint32_t timeoutMs = 2000);
 
   private:
     void update();


### PR DESCRIPTION
Currently the code does a tare‑and‑forget approach and assumes the taring has worked. This is fragile; it tries to compensate by double taring, which still isn’t watertight. For some scales, particularly the myscale, this does not result in reliable taring results and can brewing to step premature or miss the target alltogether.

This PR amends this by adding a helper function tareWithVerification that performs a tare, waits for the scale to read near zero, and upon failure retries the tare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced BLE scale tare process with stability verification to ensure accurate zero-point measurements. Scale now automatically retries tare operations if measurement stability cannot be confirmed, providing improved reliability during device initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->