### PR TITLE
high pressure pump shutdown in water mode

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -524,11 +524,7 @@ void Controller::updateControl() {
         }
         //shut off pump if pressure if higher than 5 bar in water mode, to avoid high pressure.
         if (currentProcess->getType() == MODE_WATER) {
-            if (currentProcess->getPumpPressure() < 5.0f) {
-                clientController.sendOutputControl(false, currentProcess->getPumpValue(), targetTemp)
-            } else {
-                clientController.sendOutputControl(false, 0, targetTemp)
-            }
+            clientController.sendAdvancedOutputControl(false, targetTemp, false, 5.0f, currentProcess->getPumpValue());
             return;
         }
         if (currentProcess->getType() == MODE_BREW) {


### PR DESCRIPTION
Hi everyone, 

First time contributor here.

This MR shut off pump if pressure exceeds 5 bar in water mode.

Please let me know what you think.

Cheers, Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pump now reliably shuts off during water-only mode to prevent unintended operation.
  * Output control sends a safe stop signal using a controlled pressure value to avoid progressing into other process flows.
  * Reduces risk of over-pressurization and unnecessary pump running during water-only operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->