### PR TITLE
Add mDNS service advertisement for Home Assistant discovery

### DIFF
--- a/src/display/plugins/mDNSPlugin.cpp
+++ b/src/display/plugins/mDNSPlugin.cpp
@@ -3,7 +3,10 @@
 #include "../core/Event.h"
 #include <ESPmDNS.h>
 #include <WiFi.h>
+#include <esp_log.h>
 #include <version.h>
+
+static constexpr char LOG_TAG[] = "mDNSPlugin";
 
 void mDNSPlugin::setup(Controller *controller, PluginManager *pluginManager) {
     this->controller = controller;
@@ -14,7 +17,7 @@ void mDNSPlugin::start(Event const &event) const {
     if (apMode)
         return;
     if (!MDNS.begin(controller->getSettings().getMdnsName().c_str())) {
-        Serial.println(F("Error setting up MDNS responder!"));
+        ESP_LOGE(LOG_TAG, "Error setting up mDNS responder");
         return;
     }
 
@@ -28,5 +31,5 @@ void mDNSPlugin::start(Event const &event) const {
     MDNS.addServiceTxt("gaggimate", "tcp", "version", BUILD_GIT_VERSION);
     MDNS.addServiceTxt("gaggimate", "tcp", "type", "espresso_machine");
 
-    Serial.println(F("mDNS responder started with service advertisement"));
+    ESP_LOGI(LOG_TAG, "mDNS responder started with service advertisement");
 }


### PR DESCRIPTION
- Advertise _http._tcp service for web interface
- Advertise _gaggimate._tcp service for HA autodiscovery
- Add TXT records with version and device type metadata
- Enable automatic device discovery in Home Assistant

This allows Home Assistant to automatically discover GaggiMate devices on the network without manual configuration.

<img width="1733" height="882" alt="afbeelding" src="https://github.com/user-attachments/assets/982b4b72-cc61-495f-9ba7-0831ba5ad702" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device is discoverable on local networks with automatic service advertisement (HTTP and custom service).
  * Service metadata now includes firmware version and device type for improved identification.

* **Bug Fixes**
  * Improved error handling and clearer startup logging when network service initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->