### PR TITLE
add pin config and test logic for the waveshare s3 1.43 inch display

### DIFF
--- a/src/display/drivers/AmoledDisplay/pin_config.h
+++ b/src/display/drivers/AmoledDisplay/pin_config.h
@@ -91,7 +91,7 @@ constexpr AmoledHwConfig WAVESHARE_S3_AMOLED_143_HW_CONFIG{
     .lcd_rst = 21,
     .lcd_width = 466,
     .lcd_height = 466,
-    .lcd_gram_offset_x = 0,
+    .lcd_gram_offset_x = 6,
     .lcd_gram_offset_y = 0,
     .lcd_en = 42,
     .i2c_sda = 47,

--- a/src/display/drivers/AmoledDisplay/pin_config.h
+++ b/src/display/drivers/AmoledDisplay/pin_config.h
@@ -81,6 +81,34 @@ constexpr AmoledHwConfig WAVESHARE_S3_AMOLED_HW_CONFIG{
     .mirror_touch = true,
 };
 
+constexpr AmoledHwConfig WAVESHARE_S3_AMOLED_143_HW_CONFIG{
+    .lcd_sdio0 = 11,
+    .lcd_sdio1 = 12,
+    .lcd_sdio2 = 13,
+    .lcd_sdio3 = 14,
+    .lcd_sclk = 10,
+    .lcd_cs = 9,
+    .lcd_rst = 21,
+    .lcd_width = 466,
+    .lcd_height = 466,
+    .lcd_gram_offset_x = 0,
+    .lcd_gram_offset_y = 0,
+    .lcd_en = 42,
+    .i2c_sda = 47,
+    .i2c_scl = 48,
+    .tp_int = -1,
+    .tp_rst = -1,
+    .battery_voltage_adc_data = 4, // BAT_ADC is IO4 in the table
+    .sd_cs = 38,
+    .sd_mosi = 39,
+    .sd_miso = 40,
+    .sd_sclk = 41,
+    .pcf8563_int = 15, // RTC INT is IO15 in the table
+    .rotation_175 = 0,
+    .mirror_touch = false,
+};
+
+
 #define CST92XX_DEVICE_ADDRESS 0x5A
 #define FT3168_DEVICE_ADDRESS 0x38
 #define PCF8563_DEVICE_ADDRESS 0x51

--- a/src/display/drivers/AmoledDisplayDriver.cpp
+++ b/src/display/drivers/AmoledDisplayDriver.cpp
@@ -27,9 +27,14 @@ bool AmoledDisplayDriver::isCompatible() {
         hwConfig = LILYGO_T_DISPLAY_S3_DS_HW_CONFIG;
         return true;
     }
-    ESP_LOGI("AmoledDisplayDriver", "Testing Waveshare AMOLED Display...");
+    ESP_LOGI("AmoledDisplayDriver", "Testing Waveshare AMOLED Display (1.75 inch)...");
     if (testHw(WAVESHARE_S3_AMOLED_HW_CONFIG)) {
         hwConfig = WAVESHARE_S3_AMOLED_HW_CONFIG;
+        return true;
+    }
+    ESP_LOGI("AmoledDisplayDriver", "Testing Waveshare AMOLED Display (1.43 inch)...");
+    if (testHw(WAVESHARE_S3_AMOLED_143_HW_CONFIG)) {
+        hwConfig = WAVESHARE_S3_AMOLED_143_HW_CONFIG;
         return true;
     }
     return false;


### PR DESCRIPTION
The 1.43 inch waveshare s3 Amoled display [(schema)](https://files.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.43/ESP32-S3-Touch-AMOLED-1.43-Schematic.pdf) has different pinout compared to the 1.75 inch version. 
This adds a hardware config and hardware checking to support the 1.43 inch version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Waveshare AMOLED 1.43-inch display variant. The system now attempts detection and will automatically configure the 1.43-inch display in addition to the existing 1.75-inch model, improving compatibility with smaller AMOLED panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->