### PR TITLE
fix: Prevent WiFi from getting stuck offline after intermittent disconnects

### DIFF
--- a/src/display/core/WifiManager.cpp
+++ b/src/display/core/WifiManager.cpp
@@ -80,7 +80,7 @@ void WifiManager::wifiTask(void *parameter) {
 
         // Handle connection state
         if (WiFi.status() == WL_CONNECTED) {
-            if (!xEventGroupGetBits(manager->wifiEventGroup) & WIFI_CONNECTED_BIT) {
+            if (!(xEventGroupGetBits(manager->wifiEventGroup) & WIFI_CONNECTED_BIT)) {
                 // Just connected
                 xEventGroupSetBits(manager->wifiEventGroup, WIFI_CONNECTED_BIT);
                 xEventGroupClearBits(manager->wifiEventGroup, WIFI_FAIL_BIT);


### PR DESCRIPTION
Operator precedence bug caused the retry counter to never reset on successful reconnection, leading to premature AP mode activation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WiFi connection state detection to properly recognize when the device transitions to a connected state, ensuring reliable WiFi connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->