### PR TITLE
Ux/sticky save

### DIFF
--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -960,7 +960,6 @@ export function Settings() {
                 disabled={submitting}
                 onClick={e => onSubmit(e, true)}
               >
-                {/* Moved Saved and Restart before Save, as it's a more disruptive action. */}
                 Save and Restart
               </button>
 


### PR DESCRIPTION
* Improved save workflow.
* User no longer has to scroll all the way to the bottom to save changes. The save bar is sticky.
* Moved Save and Restart to be before Save, as it is a more disruptive action. Save is the most common action, and so it is now the right-most button.
* Move Back to the left side as it is a Navigation action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Redesigned Settings page with a sticky bottom action bar for improved layout and navigation
  * Reorganized buttons: Back button positioned on the left, Save and Restart buttons on the right
  * Enhanced responsive design with adaptive button stacking for smaller screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->