### PR TITLE
Updated if statement so that if standby timeout is 0 it will never autmatically return to standby mode

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -331,7 +331,7 @@ void Controller::loop() {
 
     if (grindActiveUntil != 0 && now > grindActiveUntil)
         deactivateGrind();
-    if (mode != MODE_STANDBY && now > lastAction + settings.getStandbyTimeout())
+    if (mode != MODE_STANDBY && settings.getStandbyTimeout() > 0 && now > lastAction + settings.getStandbyTimeout())
         activateStandby();
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where standby mode could activate incorrectly when the timeout setting was disabled. Standby now properly respects the timeout configuration and will not activate when the timeout is set to zero or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->