### PR TITLE
Shot history async rebuild and progress bar

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -8,7 +8,7 @@
 #include <display/models/shot_log_format.h>
 
 constexpr size_t SHOT_HISTORY_INTERVAL = 100;
-constexpr size_t MAX_HISTORY_ENTRIES = 100;                 // Increased from 10
+constexpr size_t MAX_HISTORY_ENTRIES = 500;                 // Increased from 10
 constexpr unsigned long EXTENDED_RECORDING_DURATION = 3000; // 3 seconds
 constexpr unsigned long WEIGHT_STABILIZATION_TIME = 1000;   // 1 second
 constexpr float WEIGHT_STABILIZATION_THRESHOLD = 0.1f;      // 0.1g threshold
@@ -29,6 +29,7 @@ class ShotHistoryPlugin : public Plugin {
     void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume);
     void markIndexDeleted(uint32_t shotId);
     void rebuildIndex();
+    void startAsyncRebuild();
     bool ensureIndexExists();
 
   private:
@@ -82,6 +83,9 @@ class ShotHistoryPlugin : public Plugin {
 
     // Phase transition tracking (v5+)
     uint8_t lastRecordedPhase = 0xFF; // Invalid initial value to detect first phase
+
+    // Async rebuild state  
+    bool rebuildInProgress = false;
 
     xTaskHandle taskHandle;
     void flushBuffer();


### PR DESCRIPTION
- Add progress bar to WebUI rebuild function
- Increase max shot history to 500 (new PR will check free space)
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History rebuild now runs asynchronously in the background and returns an immediate, non-blocking acknowledgment.
  * Real-time rebuild progress exposed to the UI with status and progress bar updates.

* **Bug Fixes**
  * Concurrent rebuild requests are ignored while a rebuild is in progress to prevent duplicate work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->