### PR TITLE
Shot history index fixes and capacity-based history limit

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -8,7 +8,7 @@
 #include <display/models/shot_log_format.h>
 
 constexpr size_t SHOT_HISTORY_INTERVAL = 100;
-constexpr size_t MAX_HISTORY_ENTRIES = 100;                 // Increased from 10
+constexpr size_t MIN_FREE_SPACE_BYTES = 500 * 1024;        // 500 KB reserved free space
 constexpr unsigned long EXTENDED_RECORDING_DURATION = 3000; // 3 seconds
 constexpr unsigned long WEIGHT_STABILIZATION_TIME = 1000;   // 1 second
 constexpr float WEIGHT_STABILIZATION_THRESHOLD = 0.1f;      // 0.1g threshold
@@ -49,6 +49,7 @@ class ShotHistoryPlugin : public Plugin {
     void endRecording();
     void endExtendedRecording();
     void cleanupHistory();
+    size_t getFreeSpace();
 
     void recordPhaseTransition(uint8_t phaseNumber, uint16_t sampleIndex); // Helper for phase transitions
 

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -25,7 +25,7 @@ class ShotHistoryPlugin : public Plugin {
     void handleRequest(JsonDocument &request, JsonDocument &response);
 
     // Index management methods
-    void appendToIndex(const ShotIndexEntry &entry);
+    bool appendToIndex(const ShotIndexEntry &entry);
     void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume);
     void markIndexDeleted(uint32_t shotId);
     void rebuildIndex();
@@ -37,7 +37,7 @@ class ShotHistoryPlugin : public Plugin {
     int findEntryPosition(File &indexFile, const ShotIndexHeader &header, uint32_t shotId);
     bool readEntryAtPosition(File &indexFile, size_t position, ShotIndexEntry &entry);
     bool writeEntryAtPosition(File &indexFile, size_t position, const ShotIndexEntry &entry);
-    void createEarlyIndexEntry();
+    bool createEarlyIndexEntry();
     void updateIndexCompletion(uint32_t shotId, const ShotLogHeader &finalHeader);
     void saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -38,7 +38,6 @@ class ShotHistoryPlugin : public Plugin {
     bool readEntryAtPosition(File &indexFile, size_t position, ShotIndexEntry &entry);
     bool writeEntryAtPosition(File &indexFile, size_t position, const ShotIndexEntry &entry);
     bool createEarlyIndexEntry();
-    void updateIndexCompletion(uint32_t shotId, const ShotLogHeader &finalHeader);
     void saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);
     void startRecording();


### PR DESCRIPTION
Use upsert for shot creation 
Add some logging on write failures
Add index/header checks
Remove shot history limit and implement free space check to see if old shots should be erased
Fix old shots not being removed from index on cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shot history storage reliability with enhanced index validation and comprehensive error handling
  * Optimized automatic cleanup of old shot history and associated files to better manage device storage space
  * Strengthened shot record finalization with improved consistency and safety checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->