### PR TITLE
Fix BLE connection race condition and add status indicator

### DIFF
--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -52,6 +52,8 @@ void NimBLEClientController::registerVolumetricMeasurementCallback(const float_c
 
 void NimBLEClientController::registerTofMeasurementCallback(const int_callback_t &callback) { tofMeasurementCallback = callback; }
 
+void NimBLEClientController::registerDisconnectCallback(const void_callback_t &callback) { disconnectCallback = callback; }
+
 std::string NimBLEClientController::readInfo() const {
     if (infoChar != nullptr && infoChar->canRead()) {
         return infoChar->readValue();
@@ -236,6 +238,9 @@ void NimBLEClientController::onResult(NimBLEAdvertisedDevice *advertisedDevice) 
 
 void NimBLEClientController::onDisconnect(NimBLEClient *pServer) {
     ESP_LOGI(LOG_TAG, "Disconnected from server, trying to reconnect...");
+    if (disconnectCallback != nullptr) {
+        disconnectCallback();
+    }
     scan();
 }
 

--- a/lib/NimBLEComm/src/NimBLEClientController.h
+++ b/lib/NimBLEComm/src/NimBLEClientController.h
@@ -31,6 +31,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void registerAutotuneResultCallback(const pid_control_callback_t &callback);
     void registerVolumetricMeasurementCallback(const float_callback_t &callback);
     void registerTofMeasurementCallback(const int_callback_t &callback);
+    void registerDisconnectCallback(const void_callback_t &callback);
     std::string readInfo() const;
     NimBLEClient *getClient() const { return client; };
 
@@ -68,6 +69,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     sensor_read_callback_t sensorCallback = nullptr;
     float_callback_t volumetricMeasurementCallback = nullptr;
     int_callback_t tofMeasurementCallback = nullptr;
+    void_callback_t disconnectCallback = nullptr;
 
     String _lastOutputControl = "";
 

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -172,6 +172,9 @@ void Controller::setupBluetooth() {
         ESP_LOGV(LOG_TAG, "Received new TOF distance: %d", value);
         pluginManager->trigger("controller:tof:change", "value", value);
     });
+    clientController.registerDisconnectCallback([this]() {
+        pluginManager->trigger("controller:bluetooth:disconnect");
+    });
     pluginManager->trigger("controller:bluetooth:init");
 }
 
@@ -255,6 +258,16 @@ void Controller::loop() {
 
     if (screenReady) {
         connect();
+    }
+
+    // Re-scan for controller board if initial BLE connection was never established
+    if (!loaded && !clientController.isConnected() && !clientController.isReadyForConnection()) {
+        unsigned long now_ble = millis();
+        if (now_ble - lastBleScanRetry > 15000) {
+            lastBleScanRetry = now_ble;
+            ESP_LOGI(LOG_TAG, "BLE controller not found, retrying scan...");
+            clientController.scan();
+        }
     }
 
     if (clientController.isReadyForConnection()) {

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -152,6 +152,7 @@ class Controller {
     unsigned long lastPing = 0;
     unsigned long lastProgress = 0;
     unsigned long lastAction = 0;
+    unsigned long lastBleScanRetry = 0;
     bool loaded = false;
     bool updating = false;
     bool autotuning = false;

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -150,6 +150,7 @@ void DefaultUI::init() {
         }
     });
     pluginManager->on("controller:bluetooth:connect", [this](Event const &) {
+        bleConnected = true;
         rerender = true;
         if (lv_scr_act() == ui_InitScreen) {
             Settings &settings = controller->getSettings();
@@ -157,6 +158,10 @@ void DefaultUI::init() {
                                                    : changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init);
         }
         pressureAvailable = controller->getSystemInfo().capabilities.pressure;
+    });
+    pluginManager->on("controller:bluetooth:disconnect", [this](Event const &) {
+        bleConnected = false;
+        rerender = true;
     });
     pluginManager->on("controller:wifi:connect", [this](Event const &event) {
         rerender = true;
@@ -475,9 +480,11 @@ void DefaultUI::setupReactive() {
                                   }
                               } else if (autotuning) {
                                   lv_label_set_text_fmt(ui_InitScreen_mainLabel, "Autotuning...");
+                              } else if (!bleConnected) {
+                                  lv_label_set_text_fmt(ui_InitScreen_mainLabel, "Connecting to controller...");
                               }
                           },
-                          &updateAvailable, &error, &autotuning);
+                          &updateAvailable, &error, &autotuning, &bleConnected);
     effect_mgr.use_effect([=] { return currentScreen == ui_BrewScreen; },
                           [=]() {
                               if (volumetricMode) {
@@ -682,8 +689,15 @@ void DefaultUI::updateStandbyScreen() {
     } else {
         lv_obj_add_flag(ui_StandbyScreen_time, LV_OBJ_FLAG_HIDDEN);
     }
-    controller->getClientController()->isConnected() ? lv_obj_clear_flag(ui_StandbyScreen_bluetoothIcon, LV_OBJ_FLAG_HIDDEN)
-                                                     : lv_obj_add_flag(ui_StandbyScreen_bluetoothIcon, LV_OBJ_FLAG_HIDDEN);
+    if (bleConnected) {
+        lv_obj_clear_flag(ui_StandbyScreen_bluetoothIcon, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_opa(ui_StandbyScreen_bluetoothIcon, LV_OPA_100, LV_PART_MAIN | LV_STATE_DEFAULT);
+    } else {
+        // Show bluetooth icon flashing to indicate scanning/reconnecting
+        lv_obj_clear_flag(ui_StandbyScreen_bluetoothIcon, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_opa(ui_StandbyScreen_bluetoothIcon, heatingFlash ? LV_OPA_30 : LV_OPA_100,
+                             LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
     !apActive &&WiFi.status() == WL_CONNECTED ? lv_obj_clear_flag(ui_StandbyScreen_wifiIcon, LV_OBJ_FLAG_HIDDEN)
                                               : lv_obj_add_flag(ui_StandbyScreen_wifiIcon, LV_OBJ_FLAG_HIDDEN);
 }

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -84,6 +84,7 @@ class DefaultUI {
     int updateAvailable = false;
     int updateActive = false;
     int apActive = false;
+    int bleConnected = false;
     int error = false;
     int autotuning = false;
     int volumetricAvailable = false;


### PR DESCRIPTION
## Summary
- Fix a race condition where the display unit's initial 10-second BLE scan misses the controller board if it boots slower, leaving the machine unable to heat with no recovery path
- Add periodic BLE re-scanning (every 15s) until the controller board is found
- Add `controller:bluetooth:disconnect` event to the plugin system via a new disconnect callback in `NimBLEClientController`
- Show "Connecting to controller..." on the init screen while BLE is not connected
- Flash the bluetooth icon on the standby screen when disconnected/scanning instead of hiding it

## Test plan
- [ ] Power on both boards simultaneously and verify the display connects and heats normally
- [ ] Power on the display first, then the controller board ~20s later — verify the display auto-connects after a re-scan
- [ ] While connected, verify the standby screen shows a solid bluetooth icon
- [ ] Disconnect the controller board and verify the bluetooth icon starts flashing on the standby screen
- [ ] Verify the init screen shows "Connecting to controller..." before BLE connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic Bluetooth reconnection retry mechanism that rescans every 15 seconds if connection is not established.
  * Added visual Bluetooth status indicator that flashes when disconnected to show reconnection in progress.
  * Added "Connecting to controller..." message during initialization.

* **Bug Fixes**
  * Enhanced stability with additional safety checks in status screen updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->