### PR TITLE
fix: fix being unable to type decimals in extended phase targets

### DIFF
--- a/web/src/pages/ProfileEdit/ExtendedPhaseTarget.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedPhaseTarget.jsx
@@ -59,12 +59,16 @@ export function ExtendedPhaseTarget({ onChange, target, index, onRemove }) {
                   className='grow'
                   type='number'
                   value={target.value || 0}
-                  onChange={e =>
-                    onChange({
-                      ...target,
-                      value: parseFloat(e.target.value),
-                    })
-                  }
+                  onChange={e => {
+                    const newValue = Number.parseFloat(e.target.value)
+                    if (newValue !== target.value) {
+                      onChange({
+                        ...target,
+                        value: newValue,
+                      }
+                      )
+                    }
+                  }}
                   aria-label={`Target value in ${targetType.unit}`}
                   min='0'
                   step='0.1'


### PR DESCRIPTION
Fixes being unable to type in decimals in extended phase targets.

The issue was due to the input being a `number`, `e.target.value` is implicitly passed through `parseFloat`. What this would result in is:

- User types in an incomplete decimal (e.g. `3.`)
- `onChange` fires
- `e.target.value` = `3`
- `onChange` prop callback fires, but because a new object ref is created, that changes `phase.targets` a few layers up
- Due to props changing, component re-renders, passing in `target.value` (which is still 3), effectively eating the decimal input

The fix here is to only do the callback if the parsed value actually changes. This means that a decimal can be typed now. It's still a little janky when deleting (i.e. going from `3.1` -> `3.`) as it gets parsed and deletes the decimal point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric input in the Profile Editor now avoids redundant change events: updates only trigger when the value actually changes, reducing unnecessary processing.
  * Typing or pasting an identical value no longer invokes duplicate callbacks, improving responsiveness and preventing repeated save/validation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->