### PR TITLE
fix: semver check for nightly releases 

### DIFF
--- a/lib/OTA/src/semver_extensions.cpp
+++ b/lib/OTA/src/semver_extensions.cpp
@@ -37,6 +37,9 @@ semver_t from_string(const string &version) {
         size_t n = prerelease.length();
         prerelease_ptr = (char *)calloc(n + 1, 1);
         if (n > 0) {
+            if (prerelease_ptr == nullptr) {
+                return {0, 0, 0, nullptr, nullptr};
+            }
             prerelease.copy(prerelease_ptr, n);
         }
     } else {

--- a/lib/OTA/src/semver_extensions.cpp
+++ b/lib/OTA/src/semver_extensions.cpp
@@ -34,10 +34,10 @@ semver_t from_string(const string &version) {
     if (split_at != string::npos) {
         patch = atoi(numbers.at(2).substr(0, split_at).c_str());
         auto prerelease = numbers.at(2).substr(split_at + 1);
-        prerelease_ptr = (char *)malloc(prerelease.length() + 1);
-        if (prerelease_ptr != nullptr) {
-            prerelease.copy(prerelease_ptr, prerelease.length());
-            prerelease_ptr[prerelease.length()] = '\0';
+        size_t n = prerelease.length();
+        prerelease_ptr = (char *)calloc(n + 1, 1);
+        if (n > 0) {
+            prerelease.copy(prerelease_ptr, n);
         }
     } else {
         patch = atoi(numbers.at(2).c_str());


### PR DESCRIPTION
I noticed that after updating to the latest nightly, it sometimes shows as if there is another update available. Looking at the code, I believe this could be a potential fix.

I believe the issue is that the prerelease comparison is done character by character. If we don’t properly copy the null terminator (\0), any garbage in memory may lead to incorrect comparison results.

This kind of issue is somewhat tricky to reproduce in real life scenarios, as it would require building and testing directly in my repository and change all pointing to there. However, I did run some unit tests to validate the behavior. I chose not to include the full test suite changes in this PR to keep small as possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory safety in OTA version parsing: safer prerelease handling to avoid malformed reads, only processes prerelease data when present, and ensures a safe early return on allocation failure to reduce risk of update errors or crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->