### PR TITLE
fix: Improve controller OTA update reliability

### DIFF
--- a/lib/OTA/src/ControllerOTA.cpp
+++ b/lib/OTA/src/ControllerOTA.cpp
@@ -18,17 +18,25 @@ void ControllerOTA::init(NimBLEClient *client, const ctr_progress_callback_t &pr
     }
 }
 
-void ControllerOTA::update(WiFiClientSecure &wifi_client, const String &release_url) {
+bool ControllerOTA::update(WiFiClientSecure &wifi_client, const String &release_url) {
     if (SPIFFS.exists("/board-firmware.bin")) {
         ESP_LOGI("ControllerOTA", "Removing previous update file");
         SPIFFS.remove("/board-firmware.bin");
     }
     if (!downloadFile(wifi_client, release_url)) {
         ESP_LOGE("ControllerOTA", "Download of firmware file failed");
+        return false;
     }
     File file = SPIFFS.open("/board-firmware.bin", FILE_READ);
-    runUpdate(file, file.size());
+    if (!file || file.size() == 0) {
+        ESP_LOGE("ControllerOTA", "Firmware file is invalid or empty");
+        if (file)
+            file.close();
+        return false;
+    }
+    bool success = runUpdate(file, file.size());
     file.close();
+    return success;
 }
 
 bool ControllerOTA::downloadFile(WiFiClientSecure &wifi_client, const String &release_url) {
@@ -39,7 +47,7 @@ bool ControllerOTA::downloadFile(WiFiClientSecure &wifi_client, const String &re
     }
 
     http.useHTTP10(true);
-    http.setTimeout(1800);
+    http.setTimeout(15000);
     http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     http.setUserAgent("ESP32-http-Update");
     http.addHeader("Cache-Control", "no-cache");
@@ -59,10 +67,16 @@ bool ControllerOTA::downloadFile(WiFiClientSecure &wifi_client, const String &re
     }
 
     WiFiClient *tcp = http.getStreamPtr();
-    delay(100);
 
-    if (tcp->peek() != 0xE9) {
-        ESP_LOGE("ControllerOTA", "Magic header does not start with 0xE9");
+    // Wait for first byte with timeout (data may not arrive immediately after headers)
+    int waitAttempts = 0;
+    while (tcp->available() == 0 && tcp->connected() && waitAttempts < 50) { // 5 seconds max
+        delay(100);
+        waitAttempts++;
+    }
+
+    if (tcp->available() == 0 || tcp->peek() != 0xE9) {
+        ESP_LOGE("ControllerOTA", "Magic header check failed (available=%d, waited=%dms)", tcp->available(), waitAttempts * 100);
         http.end();
         return false;
     }
@@ -85,8 +99,12 @@ bool ControllerOTA::downloadFile(WiFiClientSecure &wifi_client, const String &re
     return true;
 }
 
-void ControllerOTA::runUpdate(Stream &in, uint32_t size) {
+bool ControllerOTA::runUpdate(Stream &in, uint32_t size) {
     ESP_LOGI("ControllerOTA", "Sending update instructions over BLE. File Size: %d", size);
+    if (size == 0) {
+        ESP_LOGE("ControllerOTA", "Firmware file is empty, aborting update");
+        return false;
+    }
     fileParts = (size + PART_SIZE - 1) / PART_SIZE;
     currentPart = 0;
 
@@ -110,6 +128,7 @@ void ControllerOTA::runUpdate(Stream &in, uint32_t size) {
     sendData(updateStart, 1);
     ESP_LOGI("ControllerOTA", "Waiting for signal from controller");
 
+    bool success = false;
     while (client->isConnected()) {
         uint8_t signal = lastSignal;
         lastSignal = 0x00;
@@ -120,11 +139,16 @@ void ControllerOTA::runUpdate(Stream &in, uint32_t size) {
             currentPart++;
             notifyUpdate();
         } else if (signal == 0xF2 || signal == 0xFF) {
+            success = true;
             break;
         }
         delay(50);
     }
-    ESP_LOGI("ControllerOTA", "Controller update finished");
+    if (!success) {
+        ESP_LOGE("ControllerOTA", "BLE connection lost during transfer");
+    }
+    ESP_LOGI("ControllerOTA", "Controller update finished (success=%d)", success);
+    return success;
 }
 
 void ControllerOTA::sendData(uint8_t *data, uint16_t len) const {
@@ -162,6 +186,8 @@ void ControllerOTA::fillBuffer(Stream &in, uint8_t *buffer, uint16_t len) const 
 }
 
 void ControllerOTA::notifyUpdate() const {
+    if (fileParts == 0)
+        return;
     double progress = (static_cast<double>(currentPart) / static_cast<double>(fileParts)) * 50.0 + 50.0;
     progressCallback(static_cast<int>(progress));
 }

--- a/lib/OTA/src/ControllerOTA.h
+++ b/lib/OTA/src/ControllerOTA.h
@@ -20,11 +20,11 @@ class ControllerOTA {
     ~ControllerOTA() = default;
     void init(NimBLEClient *client, const ctr_progress_callback_t &progress_callback);
 
-    void update(WiFiClientSecure &wifi_client, const String &release_url);
+    bool update(WiFiClientSecure &wifi_client, const String &release_url);
 
   private:
     bool downloadFile(WiFiClientSecure &wifi_client, const String &release_url);
-    void runUpdate(Stream &in, uint32_t size);
+    bool runUpdate(Stream &in, uint32_t size);
     void sendPart(Stream &in, uint32_t totalSize) const;
     void sendData(uint8_t *data, uint16_t len) const;
     void fillBuffer(Stream &in, uint8_t *buffer, uint16_t len) const;

--- a/lib/OTA/src/GitHubOTA.cpp
+++ b/lib/OTA/src/GitHubOTA.cpp
@@ -87,9 +87,13 @@ void GitHubOTA::update(bool controller, bool display) {
         ESP_LOGI(TAG, "Controller update is required, running firmware update.");
         this->phase = PHASE_CONTROLLER_FW;
         this->_phase_callback(PHASE_CONTROLLER_FW);
-        _controller_ota.update(_wifi_client, _latest_url + _controller_firmware_name);
-        ESP_LOGI(TAG, "Controller update successful. Restarting...\n");
-        updateExecuted = true;
+        bool controllerSuccess = _controller_ota.update(_wifi_client, _latest_url + _controller_firmware_name);
+        if (controllerSuccess) {
+            ESP_LOGI(TAG, "Controller update successful. Restarting...\n");
+            updateExecuted = true;
+        } else {
+            ESP_LOGE(TAG, "Controller update failed.\n");
+        }
     }
 
     if (display && update_required(_latest_version, _version)) {


### PR DESCRIPTION
## Problem

When updating the controller firmware via the web UI, the update silently fails — the UI shows "Finished" but the controller stays on the old version. In some cases, the display board crashes and reboots due to a Task Watchdog timeout.

**Root cause:** The display downloads the controller firmware from GitHub before relaying it to the controller over BLE. If the download fails (which happens frequently due to an aggressive 1.8s HTTP timeout and a race condition on the magic byte check), execution falls through to the BLE transfer step with an empty/missing file. This causes an infinite loop that blocks the main thread and triggers a watchdog crash.

## Changes

### Critical fixes

- **Add missing `return` on download failure** — `ControllerOTA::update()` now returns `false` immediately if the download fails, instead of falling through to `runUpdate()` with a nonexistent file
- **Validate firmware file before transfer** — Check that the downloaded file exists and is non-empty before starting the BLE relay
- **Increase HTTP timeout** from 1.8s to 15s — The ESP32 needs time for DNS resolution, GitHub→Azure CDN redirect, and TLS handshake
- **Replace fixed `delay(100)` with polling loop** for the magic byte check — Waits up to 5s using `tcp->available()` and `tcp->connected()` instead of assuming data arrives within 100ms

### Error propagation

- **`ControllerOTA::update()` now returns `bool`** — The caller (`GitHubOTA`) can distinguish success from failure and avoids blindly restarting the ESP32 after a failed update
- **`runUpdate()` now returns `bool`** — Returns `true` only when the controller signals successful receipt (`0xF2`/`0xFF`), `false` if BLE disconnects mid-transfer. This prevents reporting success on a partial transfer.

### Defensive guards

- **Guard `runUpdate()` against zero-size input** — Prevents the infinite `while(client->isConnected())` loop if ever called with an empty file
- **Guard `notifyUpdate()` against division by zero** — Prevents undefined behavior when `fileParts` is 0

## Files changed

| File | What |
|------|------|
| `lib/OTA/src/ControllerOTA.cpp` | Download reliability, error handling, BLE transfer result, defensive guards |
| `lib/OTA/src/ControllerOTA.h` | `update()` and `runUpdate()` return type: `void` → `bool` |
| `lib/OTA/src/GitHubOTA.cpp` | Check controller update result before restarting |

## Testing

- Verified compilation: `pio run -e display` passes cleanly
- Traced all callers of changed functions — only `GitHubOTA.cpp` calls `ControllerOTA::update()`, and `GitHubOTA::update()` signature is unchanged (`void`)
- No impact on brewing logic, UI, or other plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling during firmware updates to prevent false success reports and unwanted restarts.
  * Better detection and logging when downloads fail, payloads are missing/invalid, or transfers drop mid-update.
  * Avoid progress callbacks or actions when there is no update data.

* **Improvements**
  * Increased download timeout for more reliable OTA transfers.
  * Update flow now returns explicit success/failure status so outcomes are clear and restarts are gated on success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->