### PR TITLE
Remove redundant sntp code and turn off smooth corrections

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -235,9 +235,6 @@ void Controller::setupWifi() {
             configTzTime(resolve_timezone(settings.getTimezone()), NTP_SERVER);
             setenv("TZ", resolve_timezone(settings.getTimezone()), 1);
             tzset();
-            sntp_set_sync_mode(SNTP_SYNC_MODE_SMOOTH);
-            sntp_setservername(0, NTP_SERVER);
-            sntp_init();
         } else {
             WiFi.disconnect(true, true);
             ESP_LOGI(LOG_TAG, "Timed out while connecting to WiFi");


### PR DESCRIPTION
The existing setup uses SNTP_SYNC_MODE_SMOOTH which only corrects the time really really slowly unless you're more than 35 minutes out.  On boot of a coffee machine it should probably just instantaneously correct.

The other two lines are just redundant since they're already taken care of by configTzTime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified Wi‑Fi startup: timezone configuration on successful Wi‑Fi remains, while automatic network time client initialization during startup has been removed to streamline connection flow and avoid redundant steps. Connection, fallback, and update behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->