### PR TITLE
Refactor profile forms adding Utility toggle

### DIFF
--- a/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
@@ -8,6 +8,7 @@ import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+import { ProfileMainInformation } from './ProfileMainInformation.jsx';
 
 export function ExtendedProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
@@ -75,57 +76,13 @@ export function ExtendedProfileForm(props) {
       }}
     >
       <div className='grid grid-cols-1 gap-4 lg:grid-cols-10'>
-        <Card sm={10} title='Profile Information'>
-          <div className='form-control'>
-            <label htmlFor='label' className='mb-2 block text-sm font-medium'>
-              Title
-            </label>
-            <input
-              id='label'
-              name='label'
-              className='input input-bordered w-full'
-              value={data?.label}
-              onChange={e => onFieldChange('label', e.target.value)}
-              aria-label='Enter a name for this profile'
-              required
-            />
-          </div>
-          <div className='form-control'>
-            <label htmlFor='description' className='mb-2 block text-sm font-medium'>
-              Description
-            </label>
-            <input
-              id='description'
-              name='description'
-              className='input input-bordered w-full'
-              value={data?.description}
-              onChange={e => onFieldChange('description', e.target.value)}
-              aria-label='Optional description for this profile'
-            />
-          </div>
-          <div className='form-control'>
-            <label htmlFor='temperature' className='mb-2 block text-sm font-medium'>
-              Temperature
-            </label>
-            <div className='input-group'>
-              <label htmlFor='temperature' className='input w-full'>
-                <input
-                  id='temperature'
-                  name='temperature'
-                  type='number'
-                  className='grow'
-                  value={data?.temperature}
-                  onChange={e => onFieldChange('temperature', e.target.value)}
-                  aria-label='Temperature in degrees Celsius'
-                  min='0'
-                  max='150'
-                  step='0.1'
-                />
-                <span aria-label='degrees Celsius'>°C</span>
-              </label>
-            </div>
-          </div>
-        </Card>
+        <ProfileMainInformation
+          data={data}
+          onChangeLabel={e => onFieldChange('label', e.target.value)}
+          onChangeDescription={e => onFieldChange('description', e.target.value)}
+          onChangeTemperature={e => onFieldChange('temperature', e.target.value)}
+          onChangeUtility={e => onFieldChange('utility', !!e.target.checked)}
+        />
         <Card sm={10}>
           <ExtendedProfileChart
             data={data}

--- a/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
+++ b/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
@@ -53,7 +53,7 @@ export function ProfileMainInformation(props) {
         </div>
       </div>
       <div className='form-control'>
-        <label htmlFor='utility' className='mb-2 block text-sm font-medium'>
+        <label className='mb-2 block text-sm font-medium'>
           Type
         </label>
         <input

--- a/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
+++ b/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
@@ -1,0 +1,71 @@
+import Card from '../../components/Card.jsx';
+
+export function ProfileMainInformation(props) {
+  console.log(props.data);
+  return (
+    <Card sm={10} title='Profile Information'>
+      <div className='form-control'>
+        <label htmlFor='label' className='mb-2 block text-sm font-medium'>
+          Title
+        </label>
+        <input
+          id='label'
+          name='label'
+          className='input input-bordered w-full'
+          value={props.data?.label}
+          onChange={props.onChangeLabel}
+          aria-label='Enter a name for this profile'
+          required
+        />
+      </div>
+      <div className='form-control'>
+        <label htmlFor='description' className='mb-2 block text-sm font-medium'>
+          Description
+        </label>
+        <input
+          id='description'
+          name='description'
+          className='input input-bordered w-full'
+          value={props.data?.description}
+          onChange={props.onChangeDescription}
+          aria-label='Optional description for this profile'
+        />
+      </div>
+      <div className='form-control'>
+        <label htmlFor='temperature' className='mb-2 block text-sm font-medium'>
+          Temperature
+        </label>
+        <div className='input-group'>
+          <label htmlFor='temperature' className='input w-full'>
+            <input
+              id='temperature'
+              name='temperature'
+              type='number'
+              className='grow'
+              value={props.data?.temperature}
+              onChange={props.onChangeTemperature}
+              aria-label='Temperature in degrees Celsius'
+              min='0'
+              max='150'
+              step='0.1'
+            />
+            <span aria-label='degrees Celsius'>°C</span>
+          </label>
+        </div>
+      </div>
+      <div className='form-control'>
+        <label htmlFor='utility' className='mb-2 block text-sm font-medium'>
+          Utility
+        </label>
+        <input
+          id='utility'
+          name='utility'
+          type='checkbox'
+          className='toggle toggle-primary'
+          checked={!!props.data?.utility}
+          onChange={props.onChangeUtility}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
+++ b/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
@@ -1,7 +1,6 @@
 import Card from '../../components/Card.jsx';
 
 export function ProfileMainInformation(props) {
-  console.log(props.data);
   return (
     <Card sm={10} title='Profile Information'>
       <div className='form-control'>
@@ -55,17 +54,21 @@ export function ProfileMainInformation(props) {
       </div>
       <div className='form-control'>
         <label htmlFor='utility' className='mb-2 block text-sm font-medium'>
-          Utility
+          Type
         </label>
         <input
           id='utility'
           name='utility'
           type='checkbox'
-          className='toggle toggle-primary'
+          className='toggle border-primary checked:border-primary text-primary checked:text-primary'
           checked={!!props.data?.utility}
           onChange={props.onChangeUtility}
         />
+        <label htmlFor='utility' className='ml-2'>
+          {props.data?.utility ? 'Utility' : 'Extraction'}
+        </label>
       </div>
     </Card>
   );
 }
+

--- a/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
+++ b/web/src/pages/ProfileEdit/ProfileMainInformation.jsx
@@ -53,22 +53,18 @@ export function ProfileMainInformation(props) {
         </div>
       </div>
       <div className='form-control'>
-        <label className='mb-2 block text-sm font-medium'>
-          Type
-        </label>
-        <input
-          id='utility'
-          name='utility'
-          type='checkbox'
-          className='toggle border-primary checked:border-primary text-primary checked:text-primary'
-          checked={!!props.data?.utility}
-          onChange={props.onChangeUtility}
-        />
-        <label htmlFor='utility' className='ml-2'>
-          {props.data?.utility ? 'Utility' : 'Extraction'}
-        </label>
+        <label htmlFor='utility' className='mb-2 block text-sm font-medium'>Utility</label>
+        <div className='form-control mt-2'>
+          <input
+            id='utility'
+            name='utility'
+            type='checkbox'
+            className='toggle  checked:border-primary checked:text-primary'
+            checked={!!props.data?.utility}
+            onChange={props.onChangeUtility}
+          />
+        </div>
       </div>
     </Card>
   );
 }
-

--- a/web/src/pages/ProfileEdit/StandardProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/StandardProfileForm.jsx
@@ -6,6 +6,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { Tooltip } from '../../components/Tooltip.jsx';
+import { ProfileMainInformation } from './ProfileMainInformation.jsx';
+
 
 export function StandardProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
@@ -63,57 +65,13 @@ export function StandardProfileForm(props) {
       }}
     >
       <div className='grid grid-cols-1 gap-4 lg:grid-cols-10'>
-        <Card sm={10} title='Profile Information'>
-          <div className='form-control'>
-            <label htmlFor='label' className='mb-2 block text-sm font-medium'>
-              Title
-            </label>
-            <input
-              id='label'
-              name='label'
-              className='input input-bordered w-full'
-              value={data?.label}
-              onChange={e => onFieldChange('label', e.target.value)}
-              aria-label='Enter a name for this profile'
-              required
-            />
-          </div>
-          <div className='form-control'>
-            <label htmlFor='description' className='mb-2 block text-sm font-medium'>
-              Description
-            </label>
-            <input
-              id='description'
-              name='description'
-              className='input input-bordered w-full'
-              value={data?.description}
-              onChange={e => onFieldChange('description', e.target.value)}
-              aria-label='Optional description for this profile'
-            />
-          </div>
-          <div className='form-control'>
-            <label htmlFor='temperature' className='mb-2 block text-sm font-medium'>
-              Temperature
-            </label>
-            <div className='input-group'>
-              <label htmlFor='temperature' className='input w-full'>
-                <input
-                  id='temperature'
-                  name='temperature'
-                  type='number'
-                  className='grow'
-                  value={data?.temperature}
-                  onChange={e => onFieldChange('temperature', e.target.value)}
-                  aria-label='Temperature in degrees Celsius'
-                  min='0'
-                  max='150'
-                  step='0.1'
-                />
-                <span aria-label='degrees Celsius'>°C</span>
-              </label>
-            </div>
-          </div>
-        </Card>
+        <ProfileMainInformation
+          data={data}
+          onChangeLabel={e => onFieldChange('label', e.target.value)}
+          onChangeDescription={e => onFieldChange('description', e.target.value)}
+          onChangeTemperature={e => onFieldChange('temperature', e.target.value)}
+          onChangeUtility={e => onFieldChange('utility', !!e.target.checked)}
+        />
 
         <Card sm={10} title='Brew Phases'>
           <div className='space-y-4' role='group' aria-label='Brew phases configuration'>

--- a/web/src/pages/ProfileEdit/index.jsx
+++ b/web/src/pages/ProfileEdit/index.jsx
@@ -6,7 +6,6 @@ import { ApiServiceContext, machine } from '../../services/ApiService.js';
 import { computed } from '@preact/signals';
 import { Spinner } from '../../components/Spinner.jsx';
 import { ExtendedProfileForm } from './ExtendedProfileForm.jsx';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 
 const connected = computed(() => machine.value.connected);
@@ -26,6 +25,7 @@ export function ProfileEdit() {
           label: 'New Profile',
           description: '',
           temperature: 93,
+          utility: false,
           phases: [
             {
               name: 'Pump',


### PR DESCRIPTION
- Extracted reusable `ProfileMainInformation` component for profile details.
- Added toggle for the `utility` field in profile data.


https://github.com/user-attachments/assets/eb7b5731-2122-4a7b-a006-c412667ae3e4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New profiles now include a "utility" field by default (defaults to Extraction mode).

* **Refactor**
  * The "Profile Information" section was moved into a shared component used by all profile edit forms for consistent UI and behavior.

* **Chores**
  * Removed an unused icon import to tidy the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->