### PR TITLE
fix: restore brew-by-weight mode — wire UI toggles, honor settings.isVolumetricTarget()

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -105,3 +105,15 @@ build_flags =
     -std=c++17
     -std=gnu++17
 	-DCORE_DEBUG_LEVEL=3
+
+[env:native]
+platform = native
+framework =
+test_framework = unity
+test_build_src = true
+lib_deps =
+build_flags =
+    -std=gnu++17
+    -DUNIT_TEST
+    -I src
+build_src_filter = -<*> +<display/core/brew_target.cpp>

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -1,5 +1,6 @@
 #include "Controller.h"
 #include "ArduinoJson.h"
+#include "brew_target.h"
 #include "esp_sntp.h"
 #include <SD_MMC.h>
 #include <SPIFFS.h>
@@ -579,13 +580,13 @@ void Controller::activate() {
     }
     delay(200);
     switch (mode) {
-    case MODE_BREW:
-        startProcess(new BrewProcess(profileManager->getSelectedProfile(),
-                                     profileManager->getSelectedProfile().isVolumetric() && isVolumetricAvailable()
-                                         ? ProcessTarget::VOLUMETRIC
-                                         : ProcessTarget::TIME,
-                                     settings.getBrewDelay()));
+    case MODE_BREW: {
+        const Profile &selectedProfile = profileManager->getSelectedProfile();
+        const ProcessTarget brewTarget =
+            chooseBrewTarget(selectedProfile.isVolumetric(), settings.isVolumetricTarget(), isVolumetricAvailable());
+        startProcess(new BrewProcess(selectedProfile, brewTarget, settings.getBrewDelay()));
         break;
+    }
     case MODE_STEAM:
         startProcess(new SteamProcess(STEAM_SAFETY_DURATION_MS, settings.getSteamPumpPercentage()));
         break;

--- a/src/display/core/brew_target.cpp
+++ b/src/display/core/brew_target.cpp
@@ -1,0 +1,5 @@
+#include "brew_target.h"
+
+ProcessTarget chooseBrewTarget(bool isVolumetricProfile, bool userPrefersVolumetric, bool scaleHealthy) {
+    return (isVolumetricProfile && userPrefersVolumetric && scaleHealthy) ? ProcessTarget::VOLUMETRIC : ProcessTarget::TIME;
+}

--- a/src/display/core/brew_target.h
+++ b/src/display/core/brew_target.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef BREW_TARGET_H
+#define BREW_TARGET_H
+
+#include "process/Process.h"
+
+// Selects the ProcessTarget for a brew based on three independent inputs:
+//   isVolumetricProfile    - the active profile defines a weight target
+//   userPrefersVolumetric  - the user's settings.isVolumetricTarget() preference
+//   scaleHealthy           - isVolumetricAvailable() (e.g. paired BLE scale reporting)
+// VOLUMETRIC requires all three; otherwise TIME.
+ProcessTarget chooseBrewTarget(bool isVolumetricProfile, bool userPrefersVolumetric, bool scaleHealthy);
+
+#endif // BREW_TARGET_H

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -666,10 +666,12 @@ void DefaultUI::setupReactive() {
             _ui_flag_modify(ui_BrewScreen_modeSwitch, LV_OBJ_FLAG_HIDDEN,
                             brewScreenState == BrewScreenState::Brew && volumetricAvailable);
             if (volumetricAvailable) {
-                lv_img_set_src(ui_BrewScreen_volumetricButton, bluetoothScales ? &ui_img_1424216268 : &ui_img_flowmeter_png);
+                // Reflect the current brew target (mode) on the button, not just scale availability —
+                // otherwise the icon never changes when the user toggles the target.
+                lv_img_set_src(ui_BrewScreen_volumetricButton, volumetricMode ? &ui_img_1424216268 : &ui_img_360122106);
             }
         },
-        &brewScreenState, &volumetricAvailable, &bluetoothScales);
+        &brewScreenState, &volumetricAvailable, &volumetricMode);
     effect_mgr.use_effect(
         [=] { return currentScreen == ui_BrewScreen; },
         [=]() {

--- a/src/display/ui/default/lvgl/ui_events.cpp
+++ b/src/display/ui/default/lvgl/ui_events.cpp
@@ -91,7 +91,15 @@ void onGrindScreen(lv_event_t *e) {
     controller.setMode(MODE_GRIND);
 }
 
-void onVolumetricClick(lv_event_t *e) {}
+void onVolumetricClick(lv_event_t *e) {
+    if (volumetricHoldTriggered) {
+        // The click event that follows a long-press release should not also
+        // toggle the brew target — the hold handler already tared the scale.
+        volumetricHoldTriggered = false;
+        return;
+    }
+    controller.onTargetToggle();
+}
 
 void onPreviousProfile(lv_event_t *e) { controller.getUI()->onPreviousProfile(); }
 

--- a/test/test_controller_activate/test_main.cpp
+++ b/test/test_controller_activate/test_main.cpp
@@ -1,0 +1,45 @@
+#include <unity.h>
+
+#include "display/core/brew_target.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Bug C reproducer: prior to the fix, Controller::activate() picked VOLUMETRIC
+// whenever the profile was volumetric and the scale was healthy, ignoring the
+// user's `settings.isVolumetricTarget()` preference. These tests pin the new
+// three-input selector so the bug cannot regress.
+
+void test_volumetric_when_profile_user_and_scale_all_agree(void) {
+    TEST_ASSERT_EQUAL(static_cast<int>(ProcessTarget::VOLUMETRIC),
+                      static_cast<int>(chooseBrewTarget(/*isVolumetricProfile=*/true,
+                                                        /*userPrefersVolumetric=*/true,
+                                                        /*scaleHealthy=*/true)));
+}
+
+void test_time_when_user_prefers_time_even_if_profile_volumetric(void) {
+    TEST_ASSERT_EQUAL(static_cast<int>(ProcessTarget::TIME), static_cast<int>(chooseBrewTarget(/*isVolumetricProfile=*/true,
+                                                                                               /*userPrefersVolumetric=*/false,
+                                                                                               /*scaleHealthy=*/true)));
+}
+
+void test_time_when_profile_is_not_volumetric(void) {
+    TEST_ASSERT_EQUAL(static_cast<int>(ProcessTarget::TIME), static_cast<int>(chooseBrewTarget(/*isVolumetricProfile=*/false,
+                                                                                               /*userPrefersVolumetric=*/true,
+                                                                                               /*scaleHealthy=*/true)));
+}
+
+void test_time_when_scale_is_unhealthy(void) {
+    TEST_ASSERT_EQUAL(static_cast<int>(ProcessTarget::TIME), static_cast<int>(chooseBrewTarget(/*isVolumetricProfile=*/true,
+                                                                                               /*userPrefersVolumetric=*/true,
+                                                                                               /*scaleHealthy=*/false)));
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_volumetric_when_profile_user_and_scale_all_agree);
+    RUN_TEST(test_time_when_user_prefers_time_even_if_profile_volumetric);
+    RUN_TEST(test_time_when_profile_is_not_volumetric);
+    RUN_TEST(test_time_when_scale_is_unhealthy);
+    return UNITY_END();
+}

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -198,6 +198,13 @@ const ProcessControls = props => {
   // to avoid confusion for users who might be in grind mode when settings change
   const showGrindTab = isGrindAvailable || mode === 4;
 
+  // The Time/Weight target toggle renders for both brew and grind modes whenever a scale is
+  // paired and no process is active — outer gate hoisted so brew isn't accidentally excluded.
+  const canShowTargetToggle = !active && !finished && status.value.volumetricAvailable;
+  const showBrewTargetToggle = canShowTargetToggle && brew;
+  const showGrindTargetToggle = canShowTargetToggle && grind && showGrindTab && isGrindAvailable;
+  const showTargetToggle = showBrewTargetToggle || showGrindTargetToggle;
+
   // Determine if we should show expanded view
   const shouldExpand =
     (brew && (active || finished || (brew && !active && !finished))) ||
@@ -452,37 +459,32 @@ const ProcessControls = props => {
       )}
 
       <div className='mt-4 flex flex-col items-center gap-4 space-y-4'>
-        {grind &&
-          showGrindTab &&
-          !active &&
-          !finished &&
-          isGrindAvailable &&
-          status.value.volumetricAvailable && (
-            <div className='bg-base-300 flex w-full max-w-xs rounded-full p-1'>
-              <button
-                className={`flex-1 cursor-pointer rounded-full px-3 py-1 text-sm transition-all duration-200 lg:py-2 ${
-                  (brew && !brewTarget) || (grind && status.value.grindTarget === 0)
-                    ? 'bg-primary text-primary-content font-medium'
-                    : 'text-base-content/60 hover:text-base-content'
-                }`}
-                onClick={() => changeTarget(0)}
-              >
-                <FontAwesomeIcon icon={faClock} />
-                <span className='ml-1'>Time</span>
-              </button>
-              <button
-                className={`flex-1 cursor-pointer rounded-full px-3 py-1 text-sm transition-all duration-200 lg:py-2 ${
-                  (brew && brewTarget) || (grind && status.value.grindTarget === 1)
-                    ? 'bg-primary text-primary-content font-medium'
-                    : 'text-base-content/60 hover:text-base-content'
-                }`}
-                onClick={() => changeTarget(1)}
-              >
-                <FontAwesomeIcon icon={faWeightScale} />
-                <span className='ml-1'>Weight</span>
-              </button>
-            </div>
-          )}
+        {showTargetToggle && (
+          <div className='bg-base-300 flex w-full max-w-xs rounded-full p-1'>
+            <button
+              className={`flex-1 cursor-pointer rounded-full px-3 py-1 text-sm transition-all duration-200 lg:py-2 ${
+                (brew && !brewTarget) || (grind && status.value.grindTarget === 0)
+                  ? 'bg-primary text-primary-content font-medium'
+                  : 'text-base-content/60 hover:text-base-content'
+              }`}
+              onClick={() => changeTarget(0)}
+            >
+              <FontAwesomeIcon icon={faClock} />
+              <span className='ml-1'>Time</span>
+            </button>
+            <button
+              className={`flex-1 cursor-pointer rounded-full px-3 py-1 text-sm transition-all duration-200 lg:py-2 ${
+                (brew && brewTarget) || (grind && status.value.grindTarget === 1)
+                  ? 'bg-primary text-primary-content font-medium'
+                  : 'text-base-content/60 hover:text-base-content'
+              }`}
+              onClick={() => changeTarget(1)}
+            >
+              <FontAwesomeIcon icon={faWeightScale} />
+              <span className='ml-1'>Weight</span>
+            </button>
+          </div>
+        )}
         {/* Controls for different modes */}
         {mode === 1 && (
           <div className='flex flex-col items-center gap-4 space-y-4'>


### PR DESCRIPTION
## What

Restores **brew-by-weight** as a reachable mode on the GaggiMate Pro display + web UI. Three independent wiring bugs together made it impossible to route a paired BLE scale into the brew flow:

1. **Bug C (highest leverage)** — `Controller::activate()` ignored `settings.isVolumetricTarget()` and used `(profile.isVolumetric() && isVolumetricAvailable())` directly. With a volumetric profile + a healthy scale, the user could *never* run that profile in Time mode without unpairing the scale.
2. **Bug A** — `onVolumetricClick` (the touchscreen mode-switch handler) was an empty body; tapping the button silently did nothing. The brew-screen icon was also bound to *scale availability* rather than *mode state*, so even after fixing the click handler the visible UI gave no feedback when the mode flipped.
3. **Bug B** — `ProcessControls.jsx` only rendered the Time/Weight toggle when `grind && showGrindTab && isGrindAvailable` — i.e. never on the Brew tab. The supporting plumbing (`changeTarget`, button highlighted-state logic) already worked; only the outer render gate was wrong.

Refs #667.

## Why this approach (TDD)

Each bug was approached test-first:

- **Bug C** got a real unit test. A new `[env:native]` PlatformIO env runs Unity tests on host clang (no ESP32 toolchain involvement). The selection logic was lifted into a pure free function `chooseBrewTarget(isVolumetricProfile, userPrefersVolumetric, scaleHealthy)` so the test can pin all four corners of the matrix without instantiating `Controller` (which depends on Arduino / WiFi / NimBLE / SPIFFS / preferences).
- **Bugs A and B** got written manual-verification plans before any code change. Those scratch files were deleted before the PR was opened — they're commit-message material, not code.

The `[env:native]` is intentionally minimal — it only compiles `brew_target.cpp`. It's a foothold for future host-side tests, not an attempt to mock the firmware.

## Commits

1. **`test:`** — add `[env:native]`, `chooseBrewTarget(...)` helper, and the failing-then-passing test (verified `RED`→`GREEN` locally).
2. **`fix: Controller::activate()`** — wire the helper into the brew path. Brings brew into alignment with `Controller::activateGrind()`, which was already correct.
3. **`fix: onVolumetricClick`** — wire the empty handler to `controller.onTargetToggle()`, preserving the existing `volumetricHoldTriggered` short-circuit so a long-press release doesn't double-fire.
4. **`fix: brew-screen mode-switch icon`** — bind to `volumetricMode` instead of `bluetoothScales` so the icon actually reflects the toggled state. (Optional polish — flagged separately so reviewers can drop it if the icon swap is contentious.)
5. **`fix: web UI Time/Weight toggle in brew`** — hoist the outer gate into a `showTargetToggle` boolean and add a brew branch alongside the grind branch.

Happy to split this into three (or four) separate PRs per bug if reviewers prefer per-fix review — just say the word and I'll re-stack.

## Manual verification recipe (for a reviewer with hardware)

Paste this into the DevTools console at `http://gaggimate.local` — it prints live `gt = (isVolumetricAvailable() && isVolumetricTarget()) ? 1 : 0` from the WebSocket so you can watch the preference flip:

```js
(() => {
  const ws = new WebSocket(`${location.protocol === 'https:' ? 'wss://' : 'ws://'}${location.host}/ws`);
  ws.onopen = () => console.log('listening...');
  ws.onmessage = (e) => {
    try {
      const d = JSON.parse(e.data);
      if ('gt' in d) console.log('gt =', d.gt);
    } catch {}
  };
})();
```

Preconditions: machine on, BLE scale paired, a volumetric profile selected.

- **Bug C:** With `gt = 1` (Weight mode), tap the start/activate button. Brew should run with `ProcessTarget::VOLUMETRIC`. With `gt = 0`, the same profile should run with `ProcessTarget::TIME` (the broken behavior was that `gt = 0` was unreachable on the brew path even though the toggle in the UI claimed otherwise). Cross-check: `Controller::activateGrind()` (line 633 on master) already used `settings.isVolumetricTarget()` and was correct.
- **Bug A:** On the touchscreen brew screen, tap the mode-switch icon. The console should log `gt = 1` and the on-device icon should flip from clock → equality. Tap again to flip back. Long-press should still tare the scale (and the click that fires on release should NOT also toggle).
- **Bug B:** Open the Brew tab in the web UI with a paired scale. The Time/Weight toggle should render between the profile chart and the activate button. Click Weight → `brewTarget` becomes `true`, the brew target switches from seconds to grams. Click Time → reverts. Switch to Grind tab → toggle still works there (regression check).

## Local verification status

- `pio test -e native -f test_controller_activate` — **4/4 PASS** (host clang).
- `cd web && npm run build` — **PASS**.
- `cd web && npm run lint:check` — **PASS** (no errors).
- `cd web && npx prettier --check src/pages/Home/ProcessControls.jsx` — **PASS**.
- `platformio run -e controller` / `-e display-headless` — **NOT RUN LOCALLY**. macOS Tahoe (Darwin 25.3.0) gates the freshly-installed PlatformIO ESP32 toolchain via `com.apple.provenance` xattr, which standard userland tools cannot remove. The firmware-side changes are small and reviewable by inspection — happy to fix any CI-detected breakages.
- `platformio check -e controller` / `-e display` static analysis — **NOT RUN LOCALLY** for the same reason.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time/weight target toggle now available during brew operations, in addition to grind mode.
  * Improved long-press interaction handling on the volumetric mode button.

* **Bug Fixes**
  * Fixed volumetric mode button icon refresh to update correctly when target mode changes.

* **Tests**
  * Added comprehensive unit tests for brew target selection logic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->