### PR TITLE
fix(brew): wait for BLE scale tare to settle + scale-stuck guardrail

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -313,6 +313,22 @@ void Controller::loop() {
                 brewProcess->updateFlow(currentPumpFlow);
             }
             currentProcess->progress();
+            // Scale-stuck guardrail: if a volumetric brew has pumped meaningful
+            // water without seeing any weight change on the BLE scale, something
+            // is wrong (scale missed its pre-brew tare, portafilter off the scale,
+            // scale lost BLE mid-shot, etc.). Emit a one-shot warning; we do NOT
+            // abort the shot from here — that's a policy decision for the
+            // maintainer / user to dial in. Warn-only by design for this PR.
+            if (currentProcess != nullptr && currentProcess->getType() == MODE_BREW) {
+                auto *bp = static_cast<BrewProcess *>(currentProcess);
+                if (bp->target == ProcessTarget::VOLUMETRIC && isVolumetricAvailable() &&
+                    !bp->isScaleStuckWarned() && bp->isScaleStuck()) {
+                    bp->markScaleStuckWarned();
+                    pluginManager->trigger("controller:brew:scale-stuck");
+                    ESP_LOGW(LOG_TAG, "BLE scale stuck at 0g after pumping %.1fg of water; shot yield will be wrong",
+                             bp->waterPumped);
+                }
+            }
             if (!isActive()) {
                 deactivate();
             }

--- a/src/display/core/process/BrewProcess.h
+++ b/src/display/core/process/BrewProcess.h
@@ -2,6 +2,7 @@
 #define BREWPROCESS_H
 
 #include <algorithm>
+#include <cmath>
 #include <display/core/constants.h>
 #include <display/core/predictive.h>
 #include <display/core/process/Process.h>
@@ -23,6 +24,7 @@ class BrewProcess : public Process {
     float currentFlow = 0.0f;
     float currentPressure = 0.0f;
     float waterPumped = 0.0f;
+    float totalWaterPumped = 0.0f; // persists across phase transitions, unlike waterPumped
     VolumetricRateCalculator volumetricRateCalculator{PREDICTIVE_TIME};
 
     explicit BrewProcess(Profile profile, ProcessTarget target, double brewDelay = 0.0)
@@ -37,10 +39,29 @@ class BrewProcess : public Process {
 
     void updateVolume(double volume) override { // called even after the Process is no longer active
         currentVolume = volume;
+        if (std::abs(volume) > SCALE_STUCK_WEIGHT_THRESHOLD_G && firstFlowSeenAt == 0) {
+            firstFlowSeenAt = millis();
+        }
         if (processPhase != ProcessPhase::FINISHED) { // only store measurements while active
             volumetricRateCalculator.addMeasurement(volume);
         }
     }
+
+    // Scale-stuck guardrail. If we've pumped a meaningful amount of water but
+    // the BLE scale has not reported any weight change yet, the scale either
+    // missed its pre-brew tare or the portafilter is off the scale. Consumed
+    // by Controller::loop to emit a one-shot warning event.
+    static constexpr float SCALE_STUCK_WEIGHT_THRESHOLD_G = 1.0f;
+    static constexpr float SCALE_STUCK_WATER_PUMPED_G = 15.0f;
+    bool hasSeenFlow() const { return firstFlowSeenAt != 0; }
+    bool isScaleStuck() const {
+        // Use totalWaterPumped (persists across phases) so we don't false-positive
+        // on a dense puck during the short Fill phase, where waterPumped (per-phase)
+        // might hit the threshold before flow reaches the cup.
+        return !hasSeenFlow() && totalWaterPumped > SCALE_STUCK_WATER_PUMPED_G;
+    }
+    bool isScaleStuckWarned() const { return scaleStuckWarned; }
+    void markScaleStuckWarned() { scaleStuckWarned = true; }
 
     void updatePressure(float pressure) { currentPressure = pressure; }
 
@@ -134,7 +155,9 @@ class BrewProcess : public Process {
 
     void progress() override {
         // Progress should be called around every 100ms, as defined in PROGRESS_INTERVAL, while the Process is active
-        waterPumped += currentFlow / 10.0f; // Add current flow divided to 100ms to water pumped counter
+        const float pumpedDelta = currentFlow / 10.0f; // 100ms tick
+        waterPumped += pumpedDelta; // per-phase, reset when a phase advances below
+        totalWaterPumped += pumpedDelta; // shot-total, never resets here
         while (isCurrentPhaseFinished() && processPhase == ProcessPhase::RUNNING) {
             previousPhaseFinished = millis();
             if (phaseIndex + 1 < profile.phases.size()) {
@@ -167,6 +190,10 @@ class BrewProcess : public Process {
   private:
     float phaseStartPressure = 0.0f;
     float phaseStartFlow = 0.0f;
+
+    // Guardrail state (see hasSeenFlow / isScaleStuck above).
+    unsigned long firstFlowSeenAt = 0;
+    bool scaleStuckWarned = false;
 
     float effectivePressure = 0.0f;
     float effectiveFlow = 0.0f;

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -207,16 +207,53 @@ void BLEScalePlugin::disconnect() {
 }
 
 void BLEScalePlugin::onProcessStart() const {
-    if (scale != nullptr && scale->isConnected()) {
-        // Double tare with validation
-        scale->tare();
-        delay(50);
-
-        // Check if scale is still connected before second tare
-        if (scale != nullptr && scale->isConnected()) {
-            scale->tare();
-        }
+    if (scale == nullptr || !scale->isConnected()) {
+        return;
     }
+
+    // Double-send the tare command: BLE packet loss happens occasionally on
+    // the ESP32-S3 radio, and a missed first tare would leave the scale with
+    // a non-zero baseline for the entire shot.
+    scale->tare();
+    delay(50);
+    if (scale == nullptr || !scale->isConnected()) {
+        return;
+    }
+    scale->tare();
+
+    // Wait for the scale to actually settle at ~0g. Bookoo and most BLE
+    // espresso scales take 200-800 ms for a physical tare to complete and
+    // the first post-tare weight sample to arrive. If the pump starts
+    // before this settles, water flowing onto the portafilter prevents the
+    // scale from finishing the tare — the baseline becomes non-zero and the
+    // volumetric stop fires against a wrong reference, throwing the shot
+    // yield off by the in-progress weight.
+    constexpr unsigned long TARE_TIMEOUT_MS = 1500;
+    constexpr unsigned long TARE_STABLE_MS = 200;  // sustained within tolerance
+    constexpr float TARE_TOLERANCE_G = 0.3f;
+    const unsigned long start = millis();
+    unsigned long stableSince = 0;
+    while (millis() - start < TARE_TIMEOUT_MS) {
+        if (scale == nullptr || !scale->isConnected()) {
+            return;  // BLE dropped mid-wait; nothing we can do
+        }
+        const float w = scale->getWeight();
+        if (std::abs(w) <= TARE_TOLERANCE_G) {
+            if (stableSince == 0) {
+                stableSince = millis();
+            }
+            if (millis() - stableSince >= TARE_STABLE_MS) {
+                ESP_LOGI("BLEScalePlugin", "Tare confirmed at %.2fg after %lums", w, millis() - start);
+                return;
+            }
+        } else {
+            stableSince = 0;
+        }
+        delay(20);  // yield to FreeRTOS; Bookoo pushes ~10Hz so 20ms is fine
+    }
+    ESP_LOGW("BLEScalePlugin",
+             "Tare did not settle within %lums, last weight %.2fg -- proceeding anyway; shot yield may be off",
+             TARE_TIMEOUT_MS, scale != nullptr ? scale->getWeight() : 0.0f);
 }
 
 void BLEScalePlugin::tare() const { onProcessStart(); }


### PR DESCRIPTION
## Summary

Two small fixes to the BLE scale handling during a volumetric brew. Independent of PR #669 (auto-tune convergence).

## Problem

On my GaggiMate Pro + Bookoo Themis Ultra, I hit an edge case where the volumetric stop fires against a non-zero baseline:

1. `Controller::activate` fires `controller:brew:prestart`, which reaches `BLEScalePlugin::onProcessStart`.
2. `onProcessStart` sends two tare commands 50 ms apart (defense against BLE packet loss).
3. `Controller::activate` immediately does `delay(200)` and then calls `startProcess(new BrewProcess(...))` — **the pump starts**.
4. For Bookoo (and most BLE espresso scales), a physical tare takes **200-800 ms** to actually complete and report a zero weight back to the firmware.
5. During that window, water begins flowing into the portafilter. The scale can no longer establish a stable zero reference — it either latches the tare at the in-progress weight or aborts the tare entirely.
6. The shot runs with a non-zero baseline. Volumetric stop fires late; final weight is off by whatever weight was on the scale when the tare was attempted.

Observed symptom: intermittent shot-yield misses with a visible non-zero `v` at sample 0 of the shot log, despite the scale being connected and receiving measurements before start.

## Fixes

### Commit 1: wait for scale tare to settle before starting pump

`src/display/plugins/BLEScalePlugin.cpp:209` — rewrite `onProcessStart` to:
1. Send two tare commands (preserves the existing double-send defense against BLE loss).
2. Poll `scale->getWeight()` until it has stayed within `TARE_TOLERANCE_G = 0.3g` of zero for `TARE_STABLE_MS = 200ms` — proving the physical tare completed and a fresh 0 g sample has arrived over BLE.
3. Time out at `TARE_TIMEOUT_MS = 1500ms` with `ESP_LOGW` warning and proceed anyway (better to let the shot run with a caveat than block indefinitely on a misbehaving scale).
4. `delay(20)` between poll iterations to yield to FreeRTOS (Bookoo push cadence is ~100 ms; 20 ms gives plenty of margin).

**Why no tare-ACK packet is observable:** confirmed against the [Bookoo open-source protocol](https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md). The `0x0A` tare command is fire-and-forget — the scale has no ACK primitive. Watching the reported weight settle near 0 is the only reliable completion signal. Same applies to most other BLE espresso scales in the `remote_scales_plugin_registry` (Acaia, Decent, Felicita, Timemore, etc.).

### Commit 2: scale-stuck mid-shot guardrail

`src/display/core/process/BrewProcess.h` + `src/display/core/Controller.cpp` — add a one-shot warning when:

- Target is `ProcessTarget::VOLUMETRIC`
- `isVolumetricAvailable()` is still true (scale still connected)
- `totalWaterPumped > SCALE_STUCK_WATER_PUMPED_G` (15 g accumulated across all phases)
- `|currentVolume| has never exceeded SCALE_STUCK_WEIGHT_THRESHOLD_G` (1 g)

`BrewProcess` gains a persistent `totalWaterPumped` that accumulates in `progress()` alongside the existing per-phase `waterPumped` (which resets at phase transitions — using that directly would false-positive during dense-puck Fill phases). It also gains `firstFlowSeenAt` which latches when the scale first reports a non-noise weight.

`Controller.cpp` loop, right after `currentProcess->progress()`, checks these accessors and — if the predicate fires — sets `scaleStuckWarned` (one-shot), triggers a `controller:brew:scale-stuck` event, and logs a warning with the current pumped volume.

**Policy: warn-only, no shot interruption.** Whether to hard-abort, fall back to TIME mode, or just log is a decision I'd rather leave to the maintainer — starting with event + log is conservative and gives real-world data to calibrate thresholds before doing anything more invasive.

## Bookoo protocol notes (answering my own questions during this investigation)

Per the [official Bookoo protocol spec](https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md), the `0x0B` weight notification (20 bytes, pushed ~10 Hz) contains a lot more than this firmware currently consumes:

| Bytes | Field | Firmware today | Could benefit? |
|---|---|---|---|
| 0-1 | Headers | yes | — |
| 2-4 | Scale-internal ms timestamp | no | cross-check shot timing |
| 6 | Weight sign | yes | — |
| 7-9 | Weight × 100 (g) | yes | — |
| 10 | Flow sign | **no** | — |
| **11-12** | **Flow rate × 100 (g/s)** | **no** | **yes** — replace the EMA in `ShotHistoryPlugin.cpp:125` with the scale's native, pre-smoothed flow. Likely more accurate and lag-free. |
| 13 | Battery % | no | UI indicator |
| 14-15 | Standby time (min) | no | detect scale about to sleep |
| 16 | Buzzer setting | no | — |
| 17 | Flow-smoothing switch | no | — |
| 18-19 | Checksum | yes | — |

Flagging the flow-rate channel in particular as a clear follow-up: the firmware currently computes flow from weight deltas with `currentBluetoothFlow = currentBluetoothFlow * 0.75 + btFlow * 0.25` (α=0.25 EMA, ~250 ms lag). The scale already computes a better one internally.

Bringing this into the codebase would require extending the `RemoteScales` abstraction with `getFlowRate()` / `getBatteryLevel()` / `getTimer()` accessors and implementing them in each of the 11 supported scale drivers. That's the right scope for a separate, larger PR. **Not in this one.**

## Verification

- `pio run -e display` on Codespaces against current `master` (`233a00b9`) — **PASS** (`firmware.bin` builds clean in ~1:22 incremental).
- Hardware (user action): flash, then for a volumetric shot observe the serial log for:
  - `Tare confirmed at X.XXg after Yms` — expected on every shot when scale is connected. Y should be in 200-800 ms range typically.
  - `Tare did not settle within 1500ms` — only if the scale is genuinely misbehaving. Shot still proceeds.
  - `BLE scale stuck at 0g after pumping X.Xg of water` — rare path, indicates the tare-race actually occurred or scale got disconnected mid-shot. This is the diagnostic for the symptom this PR addresses.
- Shot-log analysis: sample 0's `v` should be `0.0 ± 0.3g` consistently post-fix.

## Files touched

- `src/display/plugins/BLEScalePlugin.cpp` — new polling logic in `onProcessStart` (commit 1)
- `src/display/core/process/BrewProcess.h` — `totalWaterPumped`, `firstFlowSeenAt`, `scaleStuckWarned` + accessors (commit 2)
- `src/display/core/Controller.cpp` — guardrail check + event trigger after `progress()` (commit 2)

Total: 3 files, ~80 lines added, ~7 removed.

## Out of scope

- Not a PR against `jniebuhr/gaggimate:master` with PR #669 as base — this branch is off `master` directly so it can land independently.
- No other scale drivers modified (the fix is in the generic `BLEScalePlugin`).
- No new `Settings` fields.
- `delay(200)` in `Controller::activate` is now partially redundant with the tare-settle wait; leaving it alone to keep diff minimal — happy to remove in a follow-up once this PR proves out.
- Using scale-native flow rate / battery / timer is a follow-up that requires extending `RemoteScales` across all 11 driver implementations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scale-stuck guardrail during volumetric brews that emits a one-time warning (includes water-pumped info) if the scale appears stuck without aborting the shot.
  * Brew tracking now accumulates total water pumped across phases for improved reporting and diagnostics.

* **Bug Fixes**
  * Improved scale initialization: dual tare sequence with a short stabilization wait and timeout to reduce false readings.
  * More robust handling of scale disconnections during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->