### PR TITLE
fix(bookoo): parse full weight notification, use recommended commands, guard ounce mode

### DIFF
--- a/lib/esp-arduino-ble-scales/.editorconfig
+++ b/lib/esp-arduino-ble-scales/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*.{h,hpp,c,cpp}]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{h,hpp,c,cpp}]
+cpp_new_line_before_open_brace_namespace = same_line
+cpp_new_line_before_open_brace_function = same_line
+cpp_new_line_before_open_brace_type = same_line
+
+[**.{md,adoc}]
+indent_style = space
+trim_trailing_whitespace = unset
+insert_final_newline = unset
+
+[platformio.ini]
+indent_style = tab

--- a/lib/esp-arduino-ble-scales/.gitignore
+++ b/lib/esp-arduino-ble-scales/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+.vscode/
+.pio/
+src/.theia/
+src/build

--- a/lib/esp-arduino-ble-scales/LICENSE
+++ b/lib/esp-arduino-ble-scales/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 kstam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/esp-arduino-ble-scales/README.md
+++ b/lib/esp-arduino-ble-scales/README.md
@@ -1,0 +1,35 @@
+# Bluetooth scales library for ESP on Arduino Framework
+
+This library defines3 main abstract concepts:
+* A `RemoteScales`  which is used as a common interface to connect to scales, retrieve their weight and tare. It also supports a callback that is triggered when a new weight is received. 
+* A `RemoteScalesScanner` which is used to scan for `RemoteScales` instances that are supported, and
+* A `RemoteScalesPluginRegistry` which holds all the scales that are supported by the library. 
+
+This allows for easy extention of the library for more bluetooth enabled scales. 
+
+### Currently implemented scales
+
+* [Acaia Lunar](https://acaia.co/collections/coffee-scales/products/lunar_2021) - [Tested]
+* [Acaia Pearl](https://acaia.co/collections/coffee-scales/products/pearl) - [Tested]
+* [Acaia Pearl S](https://acaia.co/collections/coffee-scales/products/pearl-model-s) - [Tested]
+* [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/?coupon=gaggiuino) - [Tested]
+* [Decent Scale](https://decentespresso.com/decentscale) - [Tested]
+* [Difluid microbalance](https://digitizefluid.com/products/microbalance) - [Tested]
+* [Difluid microbalance Ti](https://digitizefluid.com/collections/m-series/products/microbalance-ti) - [Tested]
+* [Eclair](https://makerworld.com/en/models/664430#profileId-591777) - [Tested]
+* [Felicita Arc](http://www.felicitacoffee.com/PRODUCT_1/10.html) - [Tested]
+* [Timemore Black Mirror DUO](https://www.timemore.com/collections/coffee-scale/products/timemore-coffee-scale-black-mirror-duo) - [Tested]
+* [Varia AKU /Mini](https://www.variabrewing.com/products/varia-aku-scale) - [Tested]
+* [Varia AKU Pro](https://www.variabrewing.com/collections/aku-new/products/varia-aku-pro)
+* [Eureka Precisa](https://www.eureka.co.it/de/accessory/id/187.aspx)
+* [Smart Kitchen Scale / MyScale (Model: KP2048B)](https://de.aliexpress.com/item/1005005916581185.html)  [Tested]
+
+Want a specific model? Implement it 🚀 Read on to find out how... 
+
+### How do implement new scales
+
+We can do this either in this repo or in a separate repo. In both cases we need to:
+1. Create a class for the new Scales (i.e. `AcaiaScales`) that implements the protocol of the scales and extends `RemoteScales`. This is 99.9% of the work as it involves reverse engineering or reading the datasheet of the scales and implementing it accordingly. 
+2. Create a plugin (i.e. `AcaiaScalesPlugin`) that extends `RemoteScalesPlugin` and implement an `apply()` method which should register the plugin to the `RemoteScalesPluginRegistry` singleton.
+3. Import your new library together with the `remote_scales` library and apply your plugin (i.e. `MyScalesPlugin::apply()`) during the initialisaion phase. 
+

--- a/lib/esp-arduino-ble-scales/VENDORING.md
+++ b/lib/esp-arduino-ble-scales/VENDORING.md
@@ -1,0 +1,31 @@
+# Vendored: esp-arduino-ble-scales
+
+This is a local copy of [gaggimate/esp-arduino-ble-scales](https://github.com/gaggimate/esp-arduino-ble-scales)
+at commit `d34e692` (Apr 2026), vendored to allow atomic review of Bookoo-driver
+enhancements alongside the firmware consumers that use them.
+
+## Why vendored?
+
+This PR makes changes to the Bookoo driver (new field parsing, improved commands)
+that are meaningful only when paired with matching firmware-side consumers
+(`BLEScalePlugin`, `ShotHistoryPlugin`, `Controller`, shot-log format). Shipping
+the driver changes as a separate PR to the library repo + a dependent PR here
+would be possible but awkward to review — reviewers would have to context-switch
+between two repos to judge correctness.
+
+## Unvendoring later
+
+Once the maintainer agrees on the driver changes, they can be re-upstreamed:
+
+1. Cherry-pick the commits under `src/remote_scales.{h,cpp}` and
+   `src/scales/bookoo.{h,cpp}` to a fresh branch off `gaggimate/esp-arduino-ble-scales`.
+2. Open a PR there.
+3. Once merged, delete this `lib/esp-arduino-ble-scales/` tree here and
+   restore the `https://github.com/gaggimate/esp-arduino-ble-scales` entry in
+   the firmware's `platformio.ini`.
+
+## Scope of local changes
+
+See the commit history for `src/remote_scales.{h,cpp}` and `src/scales/bookoo.{h,cpp}`.
+Every other scale driver (Acaia, Decent, Felicita, etc.) is bit-for-bit identical
+to the upstream library.

--- a/lib/esp-arduino-ble-scales/VENDORING.md
+++ b/lib/esp-arduino-ble-scales/VENDORING.md
@@ -1,31 +1,41 @@
 # Vendored: esp-arduino-ble-scales
 
 This is a local copy of [gaggimate/esp-arduino-ble-scales](https://github.com/gaggimate/esp-arduino-ble-scales)
-at commit `d34e692` (Apr 2026), vendored to allow atomic review of Bookoo-driver
-enhancements alongside the firmware consumers that use them.
+at commit [`46bae8c7`](https://github.com/gaggimate/esp-arduino-ble-scales/commit/46bae8c7) (2026-03-18, "Add RSSI property to DiscoveredDevice and RemoteScales"),
+vendored to allow atomic review of Bookoo-driver enhancements alongside the
+firmware consumers that use them.
 
-## Why vendored?
+## Upstream PR
 
-This PR makes changes to the Bookoo driver (new field parsing, improved commands)
-that are meaningful only when paired with matching firmware-side consumers
-(`BLEScalePlugin`, `ShotHistoryPlugin`, `Controller`, shot-log format). Shipping
-the driver changes as a separate PR to the library repo + a dependent PR here
-would be possible but awkward to review — reviewers would have to context-switch
-between two repos to judge correctness.
+The driver changes in this vendored copy are now open as an upstream PR:
+[gaggimate/esp-arduino-ble-scales#29](https://github.com/gaggimate/esp-arduino-ble-scales/pull/29)
+— "fix(bookoo): full protocol parsing + framing/correctness fixes".
 
-## Unvendoring later
+The vendored copy will be removed and `platformio.ini` restored to use the
+upstream library once that PR merges.
 
-Once the maintainer agrees on the driver changes, they can be re-upstreamed:
+## Why vendored (originally)?
 
-1. Cherry-pick the commits under `src/remote_scales.{h,cpp}` and
-   `src/scales/bookoo.{h,cpp}` to a fresh branch off `gaggimate/esp-arduino-ble-scales`.
-2. Open a PR there.
-3. Once merged, delete this `lib/esp-arduino-ble-scales/` tree here and
-   restore the `https://github.com/gaggimate/esp-arduino-ble-scales` entry in
-   the firmware's `platformio.ini`.
+This PR makes changes to the Bookoo driver (new field parsing, improved commands,
+correctness fixes) that are meaningful only when paired with matching firmware-side
+consumers (`BLEScalePlugin`, `ShotHistoryPlugin`, `Controller`, shot-log format).
+Shipping the driver changes as a separate PR to the library repo + a dependent PR
+here would have made the initial review awkward — reviewers would have had to
+context-switch between two repos to judge correctness.
+
+Now that the design is validated, the driver changes are upstreamed (see above);
+vendoring is temporary.
 
 ## Scope of local changes
 
-See the commit history for `src/remote_scales.{h,cpp}` and `src/scales/bookoo.{h,cpp}`.
-Every other scale driver (Acaia, Decent, Felicita, etc.) is bit-for-bit identical
-to the upstream library.
+See the commit history for `src/remote_scales.h` and `src/scales/bookoo.{h,cpp}`.
+Every other scale driver (Acaia, Decent, Felicita, Timemore, Varia, WeighMyBrew,
+MyScale, Difluid, Eclair, Eureka) is bit-for-bit identical to the upstream library.
+
+## Removing this vendoring (after upstream merges)
+
+1. Delete this `lib/esp-arduino-ble-scales/` tree.
+2. Restore the `https://github.com/gaggimate/esp-arduino-ble-scales` entry in
+   the firmware's `platformio.ini` `lib_deps_default` (pin to the merge commit
+   or a tag).
+3. Rebuild + reflash to confirm parity.

--- a/lib/esp-arduino-ble-scales/library.json
+++ b/lib/esp-arduino-ble-scales/library.json
@@ -1,0 +1,4 @@
+{
+  "name": "esp-arduino-ble-scales",
+  "version": "0.0.0+20260417195659"
+}

--- a/lib/esp-arduino-ble-scales/platformio.ini
+++ b/lib/esp-arduino-ble-scales/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:test]
+framework = arduino
+platform = https://github.com/platformio/platform-espressif32.git
+build_flags =
+	-std=gnu++2a
+	-frtti
+board = lolin_s3
+lib_deps =
+	ArduinoFake
+	h2zero/NimBLE-Arduino@^1.4.1
+lib_compat_mode = off
+build_unflags =
+	-std=gnu++11

--- a/lib/esp-arduino-ble-scales/src/lru_cache.h
+++ b/lib/esp-arduino-ble-scales/src/lru_cache.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <unordered_map>
+#include <list>
+#include <string>
+
+class LRUCache {
+public:
+  LRUCache(size_t capacity) : capacity(capacity) {}
+
+  bool exists(std::string value) {
+    auto it = cacheMap.find(value);
+    if (it != cacheMap.end()) {
+      // Value is already in cache, move it to the front
+      usageList.erase(it->second);
+      usageList.push_front(value);
+      it->second = usageList.begin();
+      return true;
+    }
+    if (usageList.size() >= capacity) {
+      // Cache is full, remove the least recently used device
+      auto last = usageList.back();
+      cacheMap.erase(last);
+      usageList.pop_back();
+    }
+    // Insert or update the device at the front of the list
+    usageList.push_front(value);
+    cacheMap[value] = usageList.begin();
+    return false;
+  }
+
+  void cleanup() {
+    cacheMap.clear();
+    usageList.clear();
+  }
+
+private:
+  size_t capacity;
+  std::list<std::string> usageList; // Doubly-linked list of device IDs
+  std::unordered_map<std::string, std::list<std::string>::iterator> cacheMap; // Maps device IDs to positions in the list
+};

--- a/lib/esp-arduino-ble-scales/src/remote_scales.cpp
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.cpp
@@ -1,0 +1,152 @@
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+
+// ---------------------------------------------------------------------------------------
+// ------------------------   Common RemoteScales methods    ------------------------------
+// ---------------------------------------------------------------------------------------
+
+RemoteScales::RemoteScales(const DiscoveredDevice& device) : device(device) {}
+
+void RemoteScales::log(std::string msgFormat, ...) {
+  if (!this->logCallback) return;
+
+  va_list args;
+  va_start(args, msgFormat);
+  int length = vsnprintf(nullptr, 0, msgFormat.c_str(), args); // Find length of string
+  va_end(args); // End before restarting
+
+  if (length < 0) {
+    logCallback("Scale[" + device.getName() + "] Error: Invalid message format");
+    return;
+  }
+
+  va_start(args, msgFormat); // Restart for the actual printing
+  std::string formattedMessage(length + 1, '\0'); // Instantiate formatted strigng with correct length
+  vsnprintf(&formattedMessage[0], length + 1, msgFormat.c_str(), args); // print formatted message in the string
+  formattedMessage.resize(length); // Remove the trailing null character
+  va_end(args);
+  logCallback("Scale[" + device.getName() + "] " + formattedMessage);
+}
+
+void RemoteScales::setWeight(float newWeight) {
+  float previousWeight = weight;
+  weight = newWeight;
+
+  if (weightCallback == nullptr) {
+    return;
+  }
+  if (weightCallbackOnlyChanges && previousWeight == newWeight) {
+    return;
+  }
+  weightCallback(newWeight);
+}
+
+void RemoteScales::setWeightUpdatedCallback(void (*callback)(float), bool onlyChanges) {
+  weightCallbackOnlyChanges = onlyChanges;
+  this->weightCallback = callback;
+}
+
+bool RemoteScales::clientConnect() {
+  clientCleanup();
+  log("Connecting to BLE client\n");
+  client = NimBLEDevice::createClient(device.getAddress());
+  return client->connect();
+}
+
+void RemoteScales::clientCleanup() {
+  if (client == nullptr) {
+    return;
+  }
+  log("Cleaning up BLE client\n");
+  NimBLEDevice::deleteClient(client);
+  client = nullptr;
+}
+
+NimBLERemoteService* RemoteScales::clientGetService(const NimBLEUUID uuid) {
+  if (!clientIsConnected()) {
+    log("Cannot get service, client is not connected\n");
+    return nullptr;
+  }
+  return client->getService(uuid);
+}
+
+bool RemoteScales::clientIsConnected() { return client != nullptr && client->isConnected(); };
+
+std::string RemoteScales::byteArrayToHexString(const uint8_t* byteArray, size_t length) {
+  std::string hexString;
+  hexString.reserve(length * 3); // Reserve space for the resulting string
+
+  char hex[4];
+  for (size_t i = 0; i < length; i++) {
+    snprintf(hex, sizeof(hex), "%02X ", byteArray[i]);
+    hexString.append(hex);
+  }
+
+  return hexString;
+}
+
+
+// ---------------------------------------------------------------------------------------
+// ------------------------   RemoteScales methods    ------------------------------
+// ---------------------------------------------------------------------------------------
+
+void RemoteScalesScanner::initializeAsyncScan() {
+  if (isRunning) return;
+  cleanupDiscoveredScales();
+
+  // We set the second parameter to true to prevent the library from storing BLEAdvertisedDevice objects
+  // for devices we're not interested in. This is important because the library will otherwise run out of
+  // memory after a while.
+  NimBLEDevice::getScan()->setAdvertisedDeviceCallbacks(this, true);
+  NimBLEDevice::getScan()->setInterval(500);
+  NimBLEDevice::getScan()->setWindow(100);
+  NimBLEDevice::getScan()->setMaxResults(0);
+  NimBLEDevice::getScan()->setDuplicateFilter(false);
+  NimBLEDevice::getScan()->setActiveScan(true);
+  NimBLEDevice::getScan()->start(0, nullptr, false); // Set to 0 for continuous
+  isRunning = true;
+}
+
+void RemoteScalesScanner::stopAsyncScan() {
+  if (!isRunning) return;
+  NimBLEDevice::getScan()->stop();
+  NimBLEDevice::getScan()->clearResults();
+  alreadySeenAddresses.cleanup();
+  isRunning = false;
+}
+
+void RemoteScalesScanner::restartAsyncScan() {
+  stopAsyncScan();
+  initializeAsyncScan();
+}
+
+void RemoteScalesScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+  if (std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getNative()), 6); alreadySeenAddresses.exists(addrStr)) {
+    return;
+  }
+  if (RemoteScalesPluginRegistry::getInstance()->containsPluginForDevice(advertisedDevice)) {
+    discoveredScales.emplace_back(advertisedDevice);
+  }
+}
+
+void RemoteScalesScanner::cleanupDiscoveredScales() {
+  discoveredScales.clear();
+}
+
+bool RemoteScalesScanner::isScanRunning() const {
+  return isRunning;
+}
+
+
+
+// ---------------------------------------------------------------------------------------
+// ------------------------   RemoteScalesFactory methods    -----------------------------
+// ---------------------------------------------------------------------------------------
+RemoteScalesFactory* RemoteScalesFactory::instance = nullptr;
+
+std::unique_ptr<RemoteScales> RemoteScalesFactory::create(DiscoveredDevice device) {
+  if (!RemoteScalesPluginRegistry::getInstance()->containsPluginForDevice(device)) {
+    return nullptr;
+  }
+  return RemoteScalesPluginRegistry::getInstance()->initialiseRemoteScales(device);
+}

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -70,7 +70,7 @@ public:
   virtual void disconnect() = 0;
   virtual void update() = 0;
 
-  ~RemoteScales() { clientCleanup(); }
+  virtual ~RemoteScales() { clientCleanup(); }
 protected:
   RemoteScales(const DiscoveredDevice& device);
   const DiscoveredDevice& getDevice() const { return device; }

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -21,12 +21,41 @@ private:
   int rssi;
 };
 
+// Weight unit reported by the scale. Some BLE espresso scales can switch to
+// ounces, which would silently corrupt volumetric targets unless the firmware
+// detects the unit. UNKNOWN is the conservative default for drivers that don't
+// report the field.
+enum class ScaleWeightUnit : uint8_t { UNKNOWN = 0, GRAM = 1, OUNCE = 2 };
+
+// Sentinel for "driver has no battery reading available".
+constexpr uint8_t REMOTE_SCALES_BATTERY_UNKNOWN = 0xFF;
+
 class RemoteScales {
 
 public:
   using LogCallback = void (*)(std::string);
 
+  // Core weight (always available).
   float getWeight() const { return weight; }
+
+  // Optional native fields. Drivers that parse these should call the matching
+  // protected setters from their notification handler AND override the
+  // matching hasX() virtuals to return true. Defaults are safe no-ops for the
+  // drivers (Acaia, Decent, Felicita, Timemore, ...) that only parse weight.
+  float getFlowRate() const { return flowRate; }            // g/s, native from scale when available
+  uint8_t getBatteryLevel() const { return batteryLevel; }  // 0-100 %, or REMOTE_SCALES_BATTERY_UNKNOWN
+  uint32_t getScaleTimerMs() const { return scaleTimerMs; } // scale's internal stopwatch
+  ScaleWeightUnit getWeightUnit() const { return weightUnit; }
+  uint8_t getAutoModeStopCondition() const { return autoModeStopCondition; } // driver-defined
+
+  // Capability flags. Default false; each driver overrides to true for the
+  // fields it actually parses. Consumers should check these before trusting
+  // the corresponding getter.
+  virtual bool hasFlowRate() const { return false; }
+  virtual bool hasBatteryLevel() const { return false; }
+  virtual bool hasScaleTimer() const { return false; }
+  virtual bool hasWeightUnit() const { return false; }
+  virtual bool hasAutoModeStopCondition() const { return false; }
 
   void setWeightUpdatedCallback(void (*callback)(float), bool onlyChanges = false);
   void setLogCallback(LogCallback logCallback) { this->logCallback = logCallback; }
@@ -52,6 +81,16 @@ protected:
   NimBLERemoteService* clientGetService(const NimBLEUUID uuid);
 
   void setWeight(float newWeight);
+
+  // Setters for optional fields. Drivers that parse these call from their
+  // notification handler. Stored centrally so consumers can read via the
+  // public getters without caring which driver the scale is.
+  void setFlowRate(float newFlow) { flowRate = newFlow; }
+  void setBatteryLevel(uint8_t pct) { batteryLevel = pct; }
+  void setScaleTimerMs(uint32_t t) { scaleTimerMs = t; }
+  void setWeightUnit(ScaleWeightUnit u) { weightUnit = u; }
+  void setAutoModeStopCondition(uint8_t c) { autoModeStopCondition = c; }
+
   void log(std::string msgFormat, ...);
   std::string byteArrayToHexString(const uint8_t* byteArray, size_t length);
 
@@ -59,6 +98,11 @@ private:
   using WeightCallback = void (*)(float);
 
   float weight = 0.f;
+  float flowRate = 0.0f;
+  uint8_t batteryLevel = REMOTE_SCALES_BATTERY_UNKNOWN;
+  uint32_t scaleTimerMs = 0;
+  ScaleWeightUnit weightUnit = ScaleWeightUnit::UNKNOWN;
+  uint8_t autoModeStopCondition = 0;
 
   NimBLEClient* client = nullptr;
   DiscoveredDevice device;

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -56,6 +56,7 @@ public:
   virtual bool hasScaleTimer() const { return false; }
   virtual bool hasWeightUnit() const { return false; }
   virtual bool hasAutoModeStopCondition() const { return false; }
+  virtual bool hasTimerControl() const { return false; }
 
   void setWeightUpdatedCallback(void (*callback)(float), bool onlyChanges = false);
   void setLogCallback(LogCallback logCallback) { this->logCallback = logCallback; }
@@ -69,6 +70,10 @@ public:
   virtual bool connect() = 0;
   virtual void disconnect() = 0;
   virtual void update() = 0;
+
+  virtual void startTimer() {}
+  virtual void stopTimer() {}
+  virtual void resetTimer() {}
 
   virtual ~RemoteScales() { clientCleanup(); }
 protected:

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -75,7 +75,15 @@ public:
   virtual void stopTimer()  { /* default no-op; drivers with hasTimerControl()==true override this */ }
   virtual void resetTimer() { /* default no-op; drivers with hasTimerControl()==true override this */ }
 
-  virtual ~RemoteScales() noexcept { clientCleanup(); }
+  virtual ~RemoteScales() noexcept {
+    try {
+      clientCleanup();
+    } catch (...) {
+      // Swallow: destructors must not propagate exceptions (noexcept guarantee).
+      // clientCleanup calls into NimBLE stack which in practice doesn't throw,
+      // but being explicit satisfies the type system and SonarCloud S1048.
+    }
+  }
 protected:
   RemoteScales(const DiscoveredDevice& device);
   const DiscoveredDevice& getDevice() const { return device; }

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -1,0 +1,112 @@
+#pragma once
+#include <NimBLEDevice.h>
+#include <Arduino.h>
+#include <vector>
+#include <memory>
+#include <lru_cache.h>
+
+
+class DiscoveredDevice {
+public:
+  DiscoveredDevice(NimBLEAdvertisedDevice* device) :
+  name(device->getName()), address(device->getAddress()), manufacturerData(device->getManufacturerData()), rssi(device->getRSSI()) {}
+  const std::string& getName() const { return name; }
+  const NimBLEAddress& getAddress() const { return address; }
+  const std::string& getManufacturerData() const { return manufacturerData; }
+  const int getRSSI() const { return rssi; }
+private:
+  std::string name;
+  NimBLEAddress address;
+  std::string manufacturerData;
+  int rssi;
+};
+
+class RemoteScales {
+
+public:
+  using LogCallback = void (*)(std::string);
+
+  float getWeight() const { return weight; }
+
+  void setWeightUpdatedCallback(void (*callback)(float), bool onlyChanges = false);
+  void setLogCallback(LogCallback logCallback) { this->logCallback = logCallback; }
+
+  std::string getDeviceName() const { return device.getName(); }
+  std::string getDeviceAddress() const { return device.getAddress().toString(); }
+  int getRSSI() const { return client != nullptr ? client->getRssi() : 0; }
+
+  virtual bool tare() = 0;
+  virtual bool isConnected() = 0;
+  virtual bool connect() = 0;
+  virtual void disconnect() = 0;
+  virtual void update() = 0;
+
+  ~RemoteScales() { clientCleanup(); }
+protected:
+  RemoteScales(const DiscoveredDevice& device);
+  const DiscoveredDevice& getDevice() const { return device; }
+
+  bool clientConnect();
+  void clientCleanup();
+  bool clientIsConnected();
+  NimBLERemoteService* clientGetService(const NimBLEUUID uuid);
+
+  void setWeight(float newWeight);
+  void log(std::string msgFormat, ...);
+  std::string byteArrayToHexString(const uint8_t* byteArray, size_t length);
+
+private:
+  using WeightCallback = void (*)(float);
+
+  float weight = 0.f;
+
+  NimBLEClient* client = nullptr;
+  DiscoveredDevice device;
+  LogCallback logCallback = nullptr;
+  WeightCallback weightCallback = nullptr;
+  bool weightCallbackOnlyChanges = false;
+};
+
+// ---------------------------------------------------------------------------------------
+// ---------------------------   RemoteScalesScanner    -----------------------------------
+// ---------------------------------------------------------------------------------------
+class RemoteScalesScanner : public NimBLEAdvertisedDeviceCallbacks {
+private:
+  bool isRunning = false;
+  LRUCache alreadySeenAddresses = LRUCache(100);
+  std::vector<DiscoveredDevice> discoveredScales;
+  void cleanupDiscoveredScales();
+  void onResult(NimBLEAdvertisedDevice* advertisedDevice) override;
+
+public:
+  std::vector<DiscoveredDevice> getDiscoveredScales() { return discoveredScales; }
+
+  void initializeAsyncScan();
+  void stopAsyncScan();
+  void restartAsyncScan();
+  bool isScanRunning() const;
+};
+
+// ---------------------------------------------------------------------------------------
+// ---------------------------   RemoteScalesFactory    ----------------------------------
+// ---------------------------------------------------------------------------------------
+
+// This is a singleton class that is used to create RemoteScales objects from BLEAdvertisedDevice objects.
+class RemoteScalesFactory {
+public:
+  std::unique_ptr<RemoteScales> create(DiscoveredDevice device);
+
+  static RemoteScalesFactory* getInstance() {
+    if (instance == nullptr) {
+      instance = new RemoteScalesFactory();
+    }
+    return instance;
+  }
+
+  RemoteScalesFactory(RemoteScalesFactory& other) = delete;
+  void operator=(const RemoteScalesFactory&) = delete;
+
+private:
+  static RemoteScalesFactory* instance;
+  RemoteScalesFactory() {}  // Private constructor to enforce singleton
+};

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -57,6 +57,12 @@ public:
   virtual bool hasWeightUnit() const { return false; }
   virtual bool hasAutoModeStopCondition() const { return false; }
   virtual bool hasTimerControl() const { return false; }
+  // Scale-side flow-rate EMA state. Drivers that can detect whether the
+  // peripheral currently has its own flow smoothing enabled should override
+  // (Bookoo does this via byte 17 of the weight notification). Default: false
+  // (unknown / not reported). Useful for verifying commands like
+  // disableScaleSmoothing() were honored by the peripheral.
+  virtual bool isFlowSmoothingOn() const { return false; }
 
   void setWeightUpdatedCallback(void (*callback)(float), bool onlyChanges = false);
   void setLogCallback(LogCallback logCallback) { this->logCallback = logCallback; }

--- a/lib/esp-arduino-ble-scales/src/remote_scales.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales.h
@@ -71,11 +71,11 @@ public:
   virtual void disconnect() = 0;
   virtual void update() = 0;
 
-  virtual void startTimer() {}
-  virtual void stopTimer() {}
-  virtual void resetTimer() {}
+  virtual void startTimer() { /* default no-op; drivers with hasTimerControl()==true override this */ }
+  virtual void stopTimer()  { /* default no-op; drivers with hasTimerControl()==true override this */ }
+  virtual void resetTimer() { /* default no-op; drivers with hasTimerControl()==true override this */ }
 
-  virtual ~RemoteScales() { clientCleanup(); }
+  virtual ~RemoteScales() noexcept { clientCleanup(); }
 protected:
   RemoteScales(const DiscoveredDevice& device);
   const DiscoveredDevice& getDevice() const { return device; }

--- a/lib/esp-arduino-ble-scales/src/remote_scales_plugin_registry.cpp
+++ b/lib/esp-arduino-ble-scales/src/remote_scales_plugin_registry.cpp
@@ -1,0 +1,36 @@
+#include "remote_scales_plugin_registry.h"
+
+// ---------------------------------------------------------------------------------------
+// ------------------------   RemoteScalesPluginRegistry    -------------------------------
+// ---------------------------------------------------------------------------------------
+RemoteScalesPluginRegistry* RemoteScalesPluginRegistry::instance = nullptr;
+
+void RemoteScalesPluginRegistry::registerPlugin(RemoteScalesPlugin plugin) {
+  // Check if a plugin with the same ID already exists
+  for (const auto& existingPlugin : plugins) {
+    if (existingPlugin.id == plugin.id) {
+      return;
+    }
+  }
+
+  plugins.push_back(plugin);
+}
+
+bool RemoteScalesPluginRegistry::containsPluginForDevice(const DiscoveredDevice& device) {
+  for (const auto& plugin : plugins) {
+    if (plugin.handles(device)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::unique_ptr<RemoteScales> RemoteScalesPluginRegistry::initialiseRemoteScales(const DiscoveredDevice& device) {
+  for (const auto& plugin : plugins) {
+    if (plugin.handles(device)) {
+      return plugin.initialise(device);
+    }
+  }
+  return nullptr;
+}
+

--- a/lib/esp-arduino-ble-scales/src/remote_scales_plugin_registry.h
+++ b/lib/esp-arduino-ble-scales/src/remote_scales_plugin_registry.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "remote_scales.h"
+
+struct RemoteScalesPlugin {
+  using RemoteScalesFilter = bool (*)(const DiscoveredDevice& device);
+  using RemoteScalesInitialiser = std::unique_ptr<RemoteScales> (*)(const DiscoveredDevice& device);
+  std::string id;
+  RemoteScalesFilter handles;
+  RemoteScalesInitialiser initialise;
+};
+
+class RemoteScalesPluginRegistry {
+public:
+  static RemoteScalesPluginRegistry* getInstance() {
+    if (instance == nullptr) {
+      instance = new RemoteScalesPluginRegistry();
+    }
+    return instance;
+  }
+
+  RemoteScalesPluginRegistry(RemoteScalesPluginRegistry& other) = delete;
+  void operator=(const RemoteScalesPluginRegistry&) = delete;
+
+  void registerPlugin(RemoteScalesPlugin plugin);
+  bool containsPluginForDevice(const DiscoveredDevice& device);
+  std::unique_ptr<RemoteScales> initialiseRemoteScales(const DiscoveredDevice& device);
+
+private:
+  static RemoteScalesPluginRegistry* instance;
+  std::vector<RemoteScalesPlugin> plugins;
+  RemoteScalesPluginRegistry() {}  // Private constructor to enforce singleton
+};

--- a/lib/esp-arduino-ble-scales/src/scales/acaia.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/acaia.cpp
@@ -1,0 +1,468 @@
+#include "acaia.h"
+#include "remote_scales_plugin_registry.h"
+
+/**
+* Structure inside each packet.
+* Checksums are calculated over Payload.
+* ---------------------------------------------------------------
+* |  0xEF  |  0xDD  |  0x00 |  0x00   | ....... | 0x00   | 0x00
+* ---------------------------------------------------------------
+* |     Header      |  Mesg |      Payload      |    Checksum
+* |  byte1 |  byte2 |  Type | Length  |   Data  | byte1   | byte2
+* ---------------------------------------------------------------
+*
+* Note: Acaia Umbra Lunar scales use the same protocol but with:
+* - Different BLE service/characteristic UUIDs (fe40/fe41/fe42 instead of standard UUIDs)
+* - Weight data in bytes 2-3 instead of 0-1 (big-endian order)
+*/
+
+enum class AcaiaHeader : uint8_t {
+  HEADER1 = 0xEF,
+  HEADER2 = 0xDD,
+};
+
+enum class AcaiaEventType : uint8_t {
+  WEIGHT = 0x05,
+  BATTERY = 0x06,
+  TIMER = 0x07,
+  KEY = 0x08,
+  ACK = 0x0B,
+};
+
+enum class AcaiaEventKey : uint8_t {
+  TARE = 0x05,
+  START = 0x07,
+  RESET = 0x08,
+  STOP = 0x09,
+};
+
+const size_t HEADER_LENGTH = 3;
+const size_t CHECKSUM_LENGTH = 2;
+const size_t MIN_MESSAGE_LENGTH = HEADER_LENGTH + CHECKSUM_LENGTH + 1;
+
+const NimBLEUUID serviceUUID("49535343-fe7d-4ae5-8fa9-9fafd205e455");
+const NimBLEUUID weightCharacteristicUUID("49535343-1e4d-4bd9-ba61-23c647249616");
+const NimBLEUUID commandCharacteristicUUID("49535343-8841-43f4-a8d4-ecbe34729bb3");
+
+const NimBLEUUID oldServiceUUID("00001820-0000-1000-8000-00805f9b34fb");
+const NimBLEUUID oldCharacteristicUUID("00002a80-0000-1000-8000-00805f9b34fb");
+
+// Acaia Umbra Lunar uses different BLE UUIDs but the same protocol
+const NimBLEUUID umbraServiceUUID("0000fe40-cc7a-482a-984a-7f2ed5b3e58f");
+const NimBLEUUID umbraCommandCharacteristicUUID("0000fe41-8e22-4541-9d4c-21edae82ed19");
+const NimBLEUUID umbraWeightCharacteristicUUID("0000fe42-8e22-4541-9d4c-21edae82ed19");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+AcaiaScales::AcaiaScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool AcaiaScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+  subscribeToNotifications();
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void AcaiaScales::disconnect() {
+  RemoteScales::clientCleanup();
+}
+
+bool AcaiaScales::isConnected() {
+  return RemoteScales::clientIsConnected();
+}
+
+void AcaiaScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    connect();
+    markedForReconnection = false;
+  }
+  else {
+    sendHeartbeat();
+  }
+}
+
+bool AcaiaScales::tare() {
+  if (!isConnected()) return false;
+  uint8_t payload[] = { 0x00 };
+  sendMessage(AcaiaMessageType::TARE, payload, sizeof(payload));
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+static void cleanupJunkData(std::vector<uint8_t>& dataBuffer);
+static std::pair<uint8_t, uint8_t> calculateChecksum(const uint8_t* message, size_t length);
+
+void AcaiaScales::notifyCallback(
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+  uint8_t* pData,
+  size_t length,
+  bool isNotify
+) {
+  dataBuffer.insert(dataBuffer.end(), pData, pData + length);
+  bool result = true;
+  while (result) {
+    result = decodeAndHandleNotification();
+  }
+}
+
+bool AcaiaScales::decodeAndHandleNotification() {
+  cleanupJunkData(dataBuffer);
+
+  if (dataBuffer.size() < MIN_MESSAGE_LENGTH) {
+    return false;
+  }
+
+  size_t messageLength = HEADER_LENGTH + dataBuffer[3] + CHECKSUM_LENGTH;
+  if (messageLength > dataBuffer.size()) {
+    return false;
+  }
+
+  uint8_t* payload = dataBuffer.data() + HEADER_LENGTH;
+  size_t payloadLength = messageLength - (HEADER_LENGTH + CHECKSUM_LENGTH);
+
+  auto checksumBytes = calculateChecksum(payload, payloadLength);
+  if (checksumBytes.first != dataBuffer[messageLength - 2] || checksumBytes.second != dataBuffer[messageLength - 1]) {
+    RemoteScales::log("Checksum failed: calc[%02X  %02X] but actual[%02X %02X]. Discarding.\n",
+      checksumBytes.first, checksumBytes.second,
+      dataBuffer[messageLength - 2], dataBuffer[messageLength - 1]
+    );
+    dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
+    return false;
+  }
+
+  AcaiaMessageType messageType = static_cast<AcaiaMessageType>(dataBuffer[2]);
+
+  if (messageType == AcaiaMessageType::EVENT) {
+    handleScaleEventPayload(payload, payloadLength);
+  }
+  else if (messageType == AcaiaMessageType::STATUS) {
+    handleScaleStatusPayload(payload, payloadLength);
+  }
+  else if (messageType == AcaiaMessageType::INFO) {
+    RemoteScales::log("Got info message: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+
+    // For some reason, Acaia Pearl S sends this info message upon connection.
+    // It can safely be ignored; otherwise, the scale will almost never successfully connect.
+    if(RemoteScales::getDeviceName().find("PEARLS")!=0){
+      // This normally means that something went wrong with the establishing a connection so we disconnect.
+      markedForReconnection = true;
+    }
+
+  }
+  else {
+    RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+  }
+
+  //Remove processed data packet from the buffer.
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
+  return dataBuffer.size() >= MIN_MESSAGE_LENGTH;
+}
+
+void AcaiaScales::handleScaleEventPayload(const uint8_t* payload, size_t length) {
+  AcaiaEventType eventType = static_cast<AcaiaEventType>(payload[1]);
+  if (eventType == AcaiaEventType::WEIGHT) {
+    RemoteScales::setWeight(decodeWeight(payload + 2));
+  }
+  else if (eventType == AcaiaEventType::ACK) {
+    // Ignore for now.
+    // Example: 0B 00 E0 05 5C 17 00 00 01 02 29 48
+    // RemoteScales::log("ACK - %s\n", byteArrayToHexString(payload, length).c_str());
+    // RemoteScales::log("Heartbeat response (weight: %0.1f time: %0.1f)\n", weight, time);
+    // RemoteScales::setWeight(decodeWeight(payload + 4));
+  }
+  else if (eventType == AcaiaEventType::TIMER) {
+    // Ignore for now
+    // time = decodeTime(payload + 1);
+    // RemoteScales::log("TIMER - %s", byteArrayToHexString(payload, length).c_str());
+    // RemoteScales::log("Time:  %0.1f\n", time);
+  }
+  else if (eventType == AcaiaEventType::KEY) {
+    // Ignore for now
+    // AcaiaEventKey eventKey = static_cast<AcaiaEventKey>(payload[1]);
+    // if (eventKey == AcaiaEventKey::TARE) {
+    //   RemoteScales::setWeight(decodeWeight(payload + 2));
+    //   RemoteScales::log("TARE - %s", byteArrayToHexString(payload, length).c_str());
+    //   RemoteScales::log("Tare (weight:  %0.1f)\n", RemoteScales::getWeight());
+    // }
+    // else if (eventKey == AcaiaEventKey::START) {
+    //   RemoteScales::setWeight(decodeWeight(payload + 2));
+    //   RemoteScales::log("START - %s", byteArrayToHexString(payload, length).c_str());
+    //   RemoteScales::log("Start (weight:  %0.1f)\n", RemoteScales::getWeight());
+    // }
+    // else if (eventKey == AcaiaEventKey::STOP) {
+    //   time = decodeTime(payload + 2);
+    //   RemoteScales::setWeight(decodeWeight(payload + 6));
+    //   RemoteScales::log("STOP - %s", byteArrayToHexString(payload, length).c_str());
+    //   RemoteScales::log("Stop (weight:  %0.1f, time:  %0.1f)\n", RemoteScales::getWeight(), time);
+    // }
+    // else if (eventKey == AcaiaEventKey::RESET) {
+    //   time = decodeTime(payload + 2);
+    //   RemoteScales::setWeight(decodeWeight(payload + 6));
+    //   // 08 08 05 00 00 00 00 01 01 13 0E
+    //   // 08 0A 05 03 00 00 00 01 01 18 0E
+    //   RemoteScales::log("RESET - %s", byteArrayToHexString(payload, length).c_str());
+    //   RemoteScales::log("Reset (weight:  %0.1f, time:  %0.1f)\n", RemoteScales::getWeight(), time);
+    // }
+    // else {
+    //   RemoteScales::log("Unknown key %02X(%d) - %s\n", eventKey, eventKey, byteArrayToHexString(payload, length).c_str());
+    // }
+  }
+  else {
+    RemoteScales::log("unknown event type %02x(%d): %s\n", eventType, eventType, RemoteScales::byteArrayToHexString(payload, length).c_str());
+  }
+}
+
+void AcaiaScales::handleScaleStatusPayload(const uint8_t* payload, size_t length) {
+  battery = payload[1] & 0x7F;
+  if (payload[2] == 2) {
+    weightUnits = "grams";
+  }
+  else if (payload[2] == 5) {
+    weightUnits = "ounces";
+  }
+  else {
+    weightUnits = "";
+  }
+  // uint8_t auto_off = payload[4] * 5;
+  // bool beep_on = (payload[6] == 1);
+}
+
+float AcaiaScales::decodeWeight(const uint8_t* weightPayload) {
+  float value;
+  uint8_t scaling;
+
+  // Umbra scales use different byte positions for weight data
+  if (isUmbraModel()) {
+    // Umbra: weight is in bytes 2-3 (big-endian: byte 2 is MSB, byte 3 is LSB)
+    value = (weightPayload[2] << 8) | weightPayload[3];
+    scaling = weightPayload[4];
+  } else {
+    // Standard Acaia scales: weight is in bytes 0-1
+    value = (weightPayload[1] << 8) | weightPayload[0];
+    scaling = weightPayload[4];
+  }
+
+  switch (scaling) {
+  case 1:
+    value /= 10.0f;
+    break;
+  case 2:
+    value /= 100.0f;
+    break;
+  case 3:
+    value /= 1000.0f;
+    break;
+  case 4:
+    value /= 10000.0f;
+    break;
+  default:
+    RemoteScales::log("Invalid scaling %02X - %s \n", scaling, RemoteScales::byteArrayToHexString(weightPayload, 6).c_str());
+    return -1;
+  }
+
+  if (weightPayload[5] & 0x02) {
+    value *= -1.0f;
+  }
+
+  return value;
+}
+
+float AcaiaScales::decodeTime(const uint8_t* timePayload) {
+  return timePayload[0] * 60.0f + timePayload[1] + timePayload[2] / 10.0f;
+}
+
+bool AcaiaScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  if (RemoteScales::clientGetService(oldServiceUUID)) {
+    service = RemoteScales::clientGetService(oldServiceUUID);
+  }
+  else if (RemoteScales::clientGetService(serviceUUID)) {
+    service = RemoteScales::clientGetService(serviceUUID);
+  }
+  else if (RemoteScales::clientGetService(umbraServiceUUID)) {
+    service = RemoteScales::clientGetService(umbraServiceUUID);
+  }
+  else {
+    RemoteScales::log("No compatible service found\n");
+    clientCleanup();
+    return false;
+  }
+
+  if (service->getUUID().equals(umbraServiceUUID)) {
+    // Umbra fe40 service uses fe41 for commands, fe42 for weight notifications
+    weightCharacteristic = service->getCharacteristic(umbraWeightCharacteristicUUID);
+    commandCharacteristic = service->getCharacteristic(umbraCommandCharacteristicUUID);
+  }
+  else if (service->getCharacteristic(oldCharacteristicUUID)) {
+    weightCharacteristic = service->getCharacteristic(oldCharacteristicUUID);
+    commandCharacteristic = service->getCharacteristic(oldCharacteristicUUID);
+  }
+  else {
+    weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+    commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  }
+
+  if (weightCharacteristic == nullptr || commandCharacteristic == nullptr) {
+    RemoteScales::log("Failed to find required characteristics\n");
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
+
+  // Subscribe to notifications
+  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+  RemoteScales::log("Got notifyDescriptor\n");
+  if (notifyDescriptor != nullptr) {
+    uint8_t value[2] = { 0x01, 0x00 };
+    notifyDescriptor->writeValue(value, 2, true);
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  // Identify
+  sendId();
+  RemoteScales::log("Send ID\n");
+  sendNotificationRequest();
+  RemoteScales::log("Sent notification request\n");
+  lastHeartbeat = millis();
+  return true;
+}
+
+void AcaiaScales::sendId() {
+  const uint8_t payload[] = { 0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d };
+  sendMessage(AcaiaMessageType::IDENTIFY, payload, 15, false);
+}
+
+void AcaiaScales::sendNotificationRequest() {
+  uint8_t payload[] = { 0, 1, 1, 2, 2, 5, 3, 4 };
+  sendEvent(payload, 8);
+}
+
+void AcaiaScales::sendEvent(const uint8_t* payload, size_t length) {
+  auto bytes = std::make_unique<uint8_t[]>(length + 1);
+  bytes[0] = static_cast<uint8_t>(length + 1);
+
+  for (size_t i = 0; i < length; ++i) {
+    bytes[i + 1] = payload[i] & 0xFF;
+  }
+
+  sendMessage(AcaiaMessageType::EVENT, bytes.get(), length + 1);
+}
+
+void AcaiaScales::sendHeartbeat() {
+  if (!isConnected()) {
+    return;
+  }
+
+  uint32_t now = millis();
+  if (now - lastHeartbeat < 2000) {
+    return;
+  }
+
+  uint8_t payload1[] = { 0x02,0x00 };
+  sendMessage(AcaiaMessageType::SYSTEM, payload1, 2);
+  sendNotificationRequest();
+  uint8_t payload2[] = { 0x00 };
+  sendMessage(AcaiaMessageType::HANDSHAKE, payload2, 1);
+  lastHeartbeat = now;
+}
+
+void AcaiaScales::subscribeToNotifications() {
+  RemoteScales::log("subscribeToNotifications\n");
+
+  auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(characteristic, data, length, isNotify);
+    };
+
+  if (weightCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+
+  if (commandCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for command characteristic\n");
+    commandCharacteristic->subscribe(true, callback);
+  }
+}
+
+void AcaiaScales::sendMessage(AcaiaMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse) {
+  size_t messageSize = HEADER_LENGTH + length + CHECKSUM_LENGTH;
+  auto bytes = std::make_unique<uint8_t[]>(messageSize);
+
+  // Header
+  bytes[0] = static_cast<uint8_t>(AcaiaHeader::HEADER1);
+  bytes[1] = static_cast<uint8_t>(AcaiaHeader::HEADER2);
+  bytes[2] = static_cast<uint8_t>(msgType);
+
+  // Payload
+  memcpy(bytes.get() + HEADER_LENGTH, payload, length);
+
+  // Checksum
+  auto checksums = calculateChecksum(payload, length);
+  bytes[length + 3] = (checksums.first & 0xFF);
+  bytes[length + 4] = (checksums.second & 0xFF);
+
+  commandCharacteristic->writeValue(bytes.get(), messageSize, waitResponse);
+};
+
+// Calculate the checksum for the payload of the message
+static std::pair<uint8_t, uint8_t> calculateChecksum(const uint8_t* payload, size_t length) {
+  uint8_t cksum1 = 0;
+  uint8_t cksum2 = 0;
+
+  for (size_t i = 0; i < length; i++) {
+    if (i % 2 == 0) {
+      cksum1 += payload[i];
+    }
+    else {
+      cksum2 += payload[i];
+    }
+  }
+
+  return { cksum1 & 0xFF, cksum2 & 0xFF };
+}
+
+// Discard junk data so that the first element of the buffer is the start of a message
+static void cleanupJunkData(std::vector<uint8_t>& dataBuffer) {
+  int messageStart = 0;
+
+  // Find the start of the message
+  while (messageStart < dataBuffer.size() - 1
+    && dataBuffer[messageStart] != (uint8_t)AcaiaHeader::HEADER1
+    && dataBuffer[messageStart + 1] != (uint8_t)(AcaiaHeader::HEADER2)
+    ) {
+    messageStart++;
+  }
+
+  // Clear everything before the start of the message
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageStart);
+  if (messageStart == dataBuffer.size() - 1 && dataBuffer[messageStart] != (uint8_t)AcaiaHeader::HEADER1) {
+    dataBuffer.clear();
+  }
+}
+
+bool AcaiaScales::isUmbraModel() const {
+  return RemoteScales::getDeviceName().find("UMBRA") != std::string::npos;
+}

--- a/lib/esp-arduino-ble-scales/src/scales/acaia.h
+++ b/lib/esp-arduino-ble-scales/src/scales/acaia.h
@@ -1,0 +1,99 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEScan.h>
+#include <vector>
+#include <memory>
+
+enum class AcaiaMessageType : uint8_t {
+  SYSTEM = 0x00,
+  TARE = 0x04,
+  HANDSHAKE = 0x06,
+  INFO = 0x07,
+  STATUS = 0x08,
+  IDENTIFY = 0x0B,
+  EVENT = 0x0C,
+};
+
+class AcaiaScales : public RemoteScales {
+
+public:
+  AcaiaScales(const DiscoveredDevice& device);
+  void update() override;
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  std::string weightUnits;
+  float time;
+  uint8_t battery;
+
+  uint32_t lastHeartbeat = 0;
+
+  bool markedForReconnection = false;
+
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  std::vector<uint8_t> dataBuffer;
+
+  bool performConnectionHandshake();
+  void subscribeToNotifications();
+
+  void sendMessage(AcaiaMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendEvent(const uint8_t* payload, size_t length);
+  void sendHeartbeat();
+  void sendNotificationRequest();
+  void sendId();
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+  bool decodeAndHandleNotification();
+  void handleScaleEventPayload(const uint8_t* pData, size_t length);
+  void handleScaleStatusPayload(const uint8_t* pData, size_t length);
+  float decodeWeight(const uint8_t* weightPayload);
+  float decodeTime(const uint8_t* timePayload);
+  
+  // Helper to identify Umbra model scales which use slightly different BLE characteristics
+  bool isUmbraModel() const;
+};
+
+class ScaleStatus {
+public:
+  ScaleStatus(uint8_t battery, const std::string& units, uint8_t auto_off, bool beep_on)
+    : battery(battery), units(units), auto_off(auto_off), beep_on(beep_on) {
+  }
+
+private:
+  uint8_t battery;
+  std::string units;
+  uint8_t auto_off;
+  bool beep_on;
+};
+
+class AcaiaScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-acaia",
+      .handles = [](const DiscoveredDevice& device) { return AcaiaScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<AcaiaScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() && (
+      deviceName.find("ACAIA") == 0
+      || deviceName.find("PYXIS") == 0
+      || deviceName.find("LUNAR") == 0
+      || deviceName.find("PEARL") == 0
+      || deviceName.find("PROCH") == 0
+      || deviceName.find("UMBRA") == 0);
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -200,7 +200,7 @@ bool BookooScales::decodeAndHandleNotification() {
     RemoteScales::setAutoModeStopCondition(dataBuffer[18]);
   }
   else if (productNumber == 0x03 && messageType == BookooMessageType::SYSTEM) {
-    BookooScales::tare();
+    RemoteScales::log("Inbound SYSTEM message ignored: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
   }
   else {
     RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -76,7 +76,7 @@ bool BookooScales::tare() {
   // future-proof if we ever want to cross-check shot timing against the scale.
   // sendMessage() computes and writes the final checksum byte.
   uint8_t payload[6] = { 0x03, 0x0A, 0x07, 0x00, 0x00, 0x00 };
-  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  sendMessage(payload, sizeof(payload));
 
   return true;
 };
@@ -90,7 +90,7 @@ void BookooScales::disableScaleSmoothing() {
   // can then apply their own filtering or use the raw signal directly --
   // avoiding a double-EMA pipeline that adds lag with no accuracy benefit.
   uint8_t payload[6] = { 0x03, 0x0A, 0x08, 0x00, 0x00, 0x00 };
-  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  sendMessage(payload, sizeof(payload));
 };
 
 //-----------------------------------------------------------------------------------/
@@ -265,7 +265,7 @@ void BookooScales::sendEvent(const uint8_t* payload, size_t length) {
     bytes[i + 1] = payload[i] & 0xFF;
   }
 
-  sendMessage(BookooMessageType::SYSTEM, bytes.get(), length + 1);
+  sendMessage(bytes.get(), length + 1);
 }
 
 void BookooScales::sendHeartbeat() {
@@ -279,10 +279,10 @@ void BookooScales::sendHeartbeat() {
   }
 
   uint8_t payload1[] = { 0x02,0x00 };
-  sendMessage(BookooMessageType::SYSTEM, payload1, 2);
+  sendMessage(payload1, 2);
   sendNotificationRequest();
   uint8_t payload2[] = { 0x00 };
-  sendMessage(BookooMessageType::SYSTEM, payload2, 1);
+  sendMessage(payload2, 1);
   lastHeartbeat = now;
 }
 
@@ -304,7 +304,8 @@ void BookooScales::subscribeToNotifications() {
   }
 }
 
-void BookooScales::sendMessage(BookooMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse) {
+// NOTE: the last byte of `payload` is overwritten with the XOR checksum — callers must reserve it.
+void BookooScales::sendMessage(const uint8_t* payload, size_t length, bool waitResponse) {
 
   auto bytes = std::make_unique<uint8_t[]>(length);
 

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -122,7 +122,7 @@ bool BookooScales::decodeAndHandleNotification() {
   BookooMessageType messageType = static_cast<BookooMessageType>(dataBuffer[1]);
   uint8_t productNumber = dataBuffer[0];
 
-  size_t messageLength = dataBuffer.size();
+  size_t messageLength = RECEIVE_PROTOCOL_LENGTH;
 
   // Handle different message types
   if (productNumber == 0x03 && messageType == BookooMessageType::WEIGHT) {
@@ -207,10 +207,10 @@ bool BookooScales::decodeAndHandleNotification() {
   }
 
   // Remove processed message from the buffer
-  dataBuffer.erase(dataBuffer.begin(), dataBuffer.end());
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
 
   // Return whether there's more data to process
-  return dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH;
+  return dataBuffer.size() >= RECEIVE_PROTOCOL_LENGTH;
 }
 
 bool BookooScales::performConnectionHandshake() {

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -34,6 +34,13 @@ bool BookooScales::connect() {
   }
   subscribeToNotifications();
   RemoteScales::setWeight(0.f);
+
+  // Disable the scale-side flow-smoothing EMA so consumers see raw per-sample
+  // flow in getFlowRate(). Firmware-side code (ShotHistoryPlugin,
+  // VolumetricRateCalculator) is free to filter if needed; running both EMAs
+  // compounds lag without adding accuracy.
+  disableScaleSmoothing();
+
   return true;
 }
 
@@ -60,11 +67,30 @@ void BookooScales::update() {
 
 bool BookooScales::tare() {
   if (!isConnected()) return false;
-  RemoteScales::log("Tare sent");
-  uint8_t payload[6] = { 0x03, 0x0a, 0x01, 0x00, 0x00, 0x08 };
+  RemoteScales::log("Tare+StartTimer sent (cmd 0x07)");
+  // Use command 0x07 (Tare + Start Timer), officially recommended by Bookoo over
+  // the plain 0x01 tare: it atomically resets the weight AND marks the scale as
+  // "shot is in progress", which prevents the scale from auto-sleeping or drifting
+  // during a long brew. The firmware does not currently consume the scale's timer
+  // output, so this is behaviorally equivalent to 0x01 for our purposes, but is
+  // future-proof if we ever want to cross-check shot timing against the scale.
+  // sendMessage() computes and writes the final checksum byte.
+  uint8_t payload[6] = { 0x03, 0x0A, 0x07, 0x00, 0x00, 0x00 };
   sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
 
   return true;
+};
+
+void BookooScales::disableScaleSmoothing() {
+  if (!isConnected()) return;
+  RemoteScales::log("Flow-smoothing OFF (cmd 0x08 0x00)");
+  // Command 0x08 disables the scale's own EMA on its reported flow rate, so
+  // getFlowRate() returns raw per-sample flow rather than scale-side filtered
+  // output. Firmware consumers (ShotHistoryPlugin, VolumetricRateCalculator)
+  // can then apply their own filtering or use the raw signal directly --
+  // avoiding a double-EMA pipeline that adds lag with no accuracy benefit.
+  uint8_t payload[6] = { 0x03, 0x0A, 0x08, 0x00, 0x00, 0x00 };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
 };
 
 //-----------------------------------------------------------------------------------/
@@ -116,13 +142,62 @@ bool BookooScales::decodeAndHandleNotification() {
       return false;
     }
 
-    float weight = (dataBuffer[7] << 16) | (dataBuffer[8] << 8) | dataBuffer[9];
+    // Parse the full 20-byte weight notification per the Bookoo protocol spec:
+    // https://github.com/BooKooCode/OpenSource/blob/main/bookoo_ultra_scale/protocols.md
+    //
+    // Byte layout (0-indexed):
+    //   [0]    product id (0x03)
+    //   [1]    message type (0x0B = weight)
+    //   [2-4]  scale-internal timestamp (ms, 3 bytes unsigned)
+    //   [5]    weight unit (0x01 = ounce, 0x02 = gram)
+    //   [6]    weight sign ('+' = 0x2B, '-' = 0x2D)
+    //   [7-9]  weight * 100 in grams (3 bytes unsigned)
+    //   [10]   flow sign
+    //   [11-12] flow rate * 100 in g/s (2 bytes unsigned)
+    //   [13]   battery percentage (0-100)
+    //   [14-15] standby timer (minutes, 2 bytes unsigned) -- not surfaced yet
+    //   [16]   buzzer gear                                 -- not surfaced yet
+    //   [17]   flow-smoothing switch (0/1)                 -- not surfaced yet
+    //   [18]   Ultra: auto-mode stop condition (0/1); Mini: reserved
+    //   [19]   checksum
 
-    if (dataBuffer[6] == 45) { // Check if the value is negative
-      weight = -weight;
+    // Scale timer (bytes 2-4, 3 bytes big-endian unsigned, milliseconds).
+    const uint32_t timerMs = (static_cast<uint32_t>(dataBuffer[2]) << 16) |
+                             (static_cast<uint32_t>(dataBuffer[3]) << 8)  |
+                              static_cast<uint32_t>(dataBuffer[4]);
+    RemoteScales::setScaleTimerMs(timerMs);
+
+    // Weight unit (byte 5).
+    switch (dataBuffer[5]) {
+      case 0x01: RemoteScales::setWeightUnit(ScaleWeightUnit::OUNCE); break;
+      case 0x02: RemoteScales::setWeightUnit(ScaleWeightUnit::GRAM); break;
+      default:   RemoteScales::setWeightUnit(ScaleWeightUnit::UNKNOWN); break;
     }
 
-    RemoteScales::setWeight(weight * 0.01f); // Convert to floating point
+    // Weight (sign byte 6 + value bytes 7-9, 0.01g resolution).
+    int32_t rawWeight = (static_cast<int32_t>(dataBuffer[7]) << 16) |
+                        (static_cast<int32_t>(dataBuffer[8]) << 8)  |
+                         static_cast<int32_t>(dataBuffer[9]);
+    if (dataBuffer[6] == 0x2D) { // '-'
+      rawWeight = -rawWeight;
+    }
+    RemoteScales::setWeight(rawWeight * 0.01f);
+
+    // Flow rate (sign byte 10 + value bytes 11-12, 0.01 g/s resolution).
+    int32_t rawFlow = (static_cast<int32_t>(dataBuffer[11]) << 8) |
+                       static_cast<int32_t>(dataBuffer[12]);
+    if (dataBuffer[10] == 0x2D) { // '-'
+      rawFlow = -rawFlow;
+    }
+    RemoteScales::setFlowRate(rawFlow * 0.01f);
+
+    // Battery percentage (byte 13).
+    RemoteScales::setBatteryLevel(dataBuffer[13]);
+
+    // Auto-mode stop condition (byte 18) -- only meaningful on Ultra scales
+    // where hasAutoModeStopCondition() returns true. We still store it so an
+    // Ultra-aware subclass (or a future firmware-side model check) can read it.
+    RemoteScales::setAutoModeStopCondition(dataBuffer[18]);
   }
   else if (productNumber == 0x03 && messageType == BookooMessageType::SYSTEM) {
     BookooScales::tare();

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -15,7 +15,12 @@ const NimBLEUUID commandCharacteristicUUID("FF12");
 //-----------------------------------------------------------------------------------/
 //---------------------------        PUBLIC       -----------------------------------/
 //-----------------------------------------------------------------------------------/
-BookooScales::BookooScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+BookooScales::BookooScales(const DiscoveredDevice& device)
+  : RemoteScales(device),
+    // Model discrimination at construction time — see the header for the rationale.
+    // BOOKOO_SC_U<serial> = Ultra; everything else (BOOKOO_SC_M<serial>, unknown)
+    // defaults to the Mini-compatible subset. rfind(..., 0) == 0 is a prefix match.
+    isUltra_(device.getName().rfind("BOOKOO_SC_U", 0) == 0) {}
 
 bool BookooScales::connect() {
   if (RemoteScales::clientIsConnected()) {
@@ -125,6 +130,20 @@ void BookooScales::resetTimer() {
   if (!isConnected()) return;
   RemoteScales::log("Timer RESET (cmd 0x0A 0x06)");
   std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x06, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
+}
+
+void BookooScales::setAutoModeStopConditionOnScale(bool onContainerRemoval) {
+  if (!isConnected() || !isUltra_) return; // Mini firmware silently ignores 0x0B
+  RemoteScales::log("Set auto-mode stop condition (cmd 0x0A 0x0B %u)", onContainerRemoval ? 1 : 0);
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x0B, static_cast<uint8_t>(onContainerRemoval ? 0x01 : 0x00), 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
+}
+
+void BookooScales::calibrate() {
+  if (!isConnected() || !isUltra_) return; // 0x09 not defined in the Mini protocol
+  RemoteScales::log("Calibrate (cmd 0x0A 0x09)");
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x09, 0x00, 0x00, 0x00 };
   sendMessage(payload.data(), payload.size());
 }
 

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -228,7 +228,7 @@ bool BookooScales::decodeAndHandleNotification() {
     RemoteScales::log("Inbound SYSTEM message ignored: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
   }
   else {
-    RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+    RemoteScales::log("Unknown message type %02X: %s\n", static_cast<uint8_t>(messageType), RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
   }
 
   // Remove processed message from the buffer

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -202,12 +202,18 @@ bool BookooScales::decodeAndHandleNotification() {
                               static_cast<uint32_t>(dataBuffer[4]);
     RemoteScales::setScaleTimerMs(timerMs);
 
-    // Weight unit (byte 5).
-    switch (dataBuffer[5]) {
-      case 0x01: RemoteScales::setWeightUnit(ScaleWeightUnit::OUNCE); break;
-      case 0x02: RemoteScales::setWeightUnit(ScaleWeightUnit::GRAM); break;
-      default:   RemoteScales::setWeightUnit(ScaleWeightUnit::UNKNOWN); break;
-    }
+    // Byte 5 is the scale's *display* unit indicator (0x01 = Ounce shown on
+    // the LCD, 0x02 = Gram shown on the LCD) -- NOT the unit of the weight
+    // value in bytes 7-9. Per the Bookoo Ultra protocol spec:
+    //   https://github.com/BooKooCode/OpenSource/blob/main/bookoo_ultra_scale/protocols.md
+    //   > The weight value returned in the data packet is always in grams
+    // Consequently getWeightUnit() must always report GRAM for Bookoo so
+    // that Controller::isVolumetricAvailable()'s ounce guard (which assumes
+    // the reported weight unit matches the *value* unit) doesn't block
+    // volumetric routing when the user has the scale's display toggled to
+    // oz. The value-level math is always correct because the values are
+    // always grams.
+    RemoteScales::setWeightUnit(ScaleWeightUnit::GRAM);
 
     // Weight (sign byte 6 + value bytes 7-9, 0.01g resolution).
     int32_t rawWeight = (static_cast<int32_t>(dataBuffer[7]) << 16) |

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -258,18 +258,6 @@ bool BookooScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x00, 0x01 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   sendNotificationRequest();
   RemoteScales::log("Sent notification request\n");
   lastHeartbeat = millis();

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -258,6 +258,11 @@ bool BookooScales::decodeAndHandleNotification() {
     // where hasAutoModeStopCondition() returns true. We still store it so an
     // Ultra-aware subclass (or a future firmware-side model check) can read it.
     RemoteScales::setAutoModeStopCondition(dataBuffer[18]);
+
+    // Flow-smoothing switch (byte 17) — we disable it via cmd 0x08 0x00 in
+    // connect() so firmware consumers see raw per-sample flow. Track the
+    // scale's reported state so we can verify the command was honored.
+    lastFlowSmoothingOn_ = (dataBuffer[17] != 0x00);
   }
   else if (productNumber == 0x03 && messageType == BookooMessageType::SYSTEM) {
     RemoteScales::log("Inbound SYSTEM message ignored: %s\n", RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -93,6 +93,30 @@ void BookooScales::disableScaleSmoothing() {
   sendMessage(payload, sizeof(payload));
 };
 
+// Note: on Bookoo Ultra these are only effective in timing-mode/ratio-mode
+// (no BLE mode-switch command exists); Mini has no restriction. Use tare()
+// (0x07 = tare + start timer) for unconditional start.
+void BookooScales::startTimer() {
+  if (!isConnected()) return;
+  RemoteScales::log("Timer START (cmd 0x0A 0x04)");
+  uint8_t payload[6] = { 0x03, 0x0A, 0x04, 0x00, 0x00, 0x00 };
+  sendMessage(payload, sizeof(payload));
+}
+
+void BookooScales::stopTimer() {
+  if (!isConnected()) return;
+  RemoteScales::log("Timer STOP (cmd 0x0A 0x05)");
+  uint8_t payload[6] = { 0x03, 0x0A, 0x05, 0x00, 0x00, 0x00 };
+  sendMessage(payload, sizeof(payload));
+}
+
+void BookooScales::resetTimer() {
+  if (!isConnected()) return;
+  RemoteScales::log("Timer RESET (cmd 0x0A 0x06)");
+  uint8_t payload[6] = { 0x03, 0x0A, 0x06, 0x00, 0x00, 0x00 };
+  sendMessage(payload, sizeof(payload));
+}
+
 //-----------------------------------------------------------------------------------/
 //---------------------------       PRIVATE       -----------------------------------/
 //-----------------------------------------------------------------------------------/

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -318,13 +318,30 @@ void BookooScales::subscribeToNotifications() {
     notifyCallback(characteristic, data, length, isNotify);
     };
 
+  // Belt-and-suspenders CCCD enable. NimBLE-Arduino issue #340 reports that
+  // subscribe(true, ...) can return without actually writing CCCD on some
+  // ESP32 builds, which leaves the scale silent despite a healthy GATT link.
+  // Explicitly write 0x0001 (LE, notifications enabled) to the 0x2902
+  // descriptor before subscribe(), so a silent subscribe() failure still
+  // leaves the peripheral configured. Subscribe() is still called to wire
+  // the callback on our side.
+  auto writeCccdNotify = [](NimBLERemoteCharacteristic* ch) {
+    if (ch == nullptr) return;
+    NimBLERemoteDescriptor* cccd = ch->getDescriptor(NimBLEUUID(static_cast<uint16_t>(0x2902)));
+    if (cccd == nullptr) return;
+    uint8_t enable[2] = { 0x01, 0x00 }; // LE 0x0001 = notifications
+    cccd->writeValue(enable, 2, true);
+  };
+
   if (weightCharacteristic->canNotify()) {
     RemoteScales::log("Registering callback for weight characteristic\n");
+    writeCccdNotify(weightCharacteristic);
     weightCharacteristic->subscribe(true, callback);
   }
 
   if (commandCharacteristic->canNotify()) {
     RemoteScales::log("Registering callback for command characteristic\n");
+    writeCccdNotify(commandCharacteristic);
     commandCharacteristic->subscribe(true, callback);
   }
 }

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -1,0 +1,246 @@
+#include "bookoo.h"
+#include "remote_scales_plugin_registry.h"
+
+/*
+Handle protocol according to the spec found at
+https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md
+*/
+const size_t RECEIVE_PROTOCOL_LENGTH = 20;
+
+const NimBLEUUID serviceUUID("0FFE");
+const NimBLEUUID weightCharacteristicUUID("FF11");
+const NimBLEUUID commandCharacteristicUUID("FF12");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+BookooScales::BookooScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool BookooScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+  subscribeToNotifications();
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void BookooScales::disconnect() {
+  RemoteScales::clientCleanup();
+}
+
+bool BookooScales::isConnected() {
+  return RemoteScales::clientIsConnected();
+}
+
+void BookooScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    connect();
+    markedForReconnection = false;
+  }
+  else {
+    sendHeartbeat();
+    RemoteScales::log("Heartbeat sent.\n");
+  }
+}
+
+bool BookooScales::tare() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Tare sent");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x01, 0x00, 0x00, 0x08 };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+void BookooScales::notifyCallback(
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+  uint8_t* pData,
+  size_t length,
+  bool isNotify
+) {
+  dataBuffer.insert(dataBuffer.end(), pData, pData + length);
+  bool result = true;
+  while (result) {
+    result = decodeAndHandleNotification();
+  }
+}
+
+/*
+Handle protocol according to the spec found at
+https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md#receiving-weight
+*/
+bool BookooScales::decodeAndHandleNotification() {
+  // Minimum message length check (20 bytes based on protocol definition)
+  if (dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH) {
+    return false;
+  }
+
+  BookooMessageType messageType = static_cast<BookooMessageType>(dataBuffer[1]);
+  uint8_t productNumber = dataBuffer[0];
+
+  size_t messageLength = dataBuffer.size();
+
+  // Handle different message types
+  if (productNumber == 0x03 && messageType == BookooMessageType::WEIGHT) {
+    // Checksum validation: XOR of Header1 ^ Header2 ^ Data0 ^ Data1 ^ ... ^ DataN should equal DataSUM
+    uint8_t checksum = dataBuffer[0];
+    for (size_t i = 1; i < messageLength - 1; i++) {
+      checksum ^= dataBuffer[i];
+    }
+
+    // The last byte in the message is DataSUM
+    uint8_t dataSUM = dataBuffer[messageLength - 1];
+
+    if (checksum != dataSUM) {
+      RemoteScales::log("Checksum failed: calc[%02X] but actual[%02X]. Discarding.\n",
+        checksum, dataSUM);
+      dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
+      return false;
+    }
+
+    float weight = (dataBuffer[7] << 16) | (dataBuffer[8] << 8) | dataBuffer[9];
+
+    if (dataBuffer[6] == 45) { // Check if the value is negative
+      weight = -weight;
+    }
+
+    RemoteScales::setWeight(weight * 0.01f); // Convert to floating point
+  }
+  else if (productNumber == 0x03 && messageType == BookooMessageType::SYSTEM) {
+    BookooScales::tare();
+  }
+  else {
+    RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+  }
+
+  // Remove processed message from the buffer
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.end());
+
+  // Return whether there's more data to process
+  return dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH;
+}
+
+bool BookooScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  service = RemoteScales::clientGetService(serviceUUID);
+  if (service != nullptr) {
+    RemoteScales::log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  if (weightCharacteristic == nullptr || commandCharacteristic == nullptr) {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
+
+  // Subscribe
+  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+  RemoteScales::log("Got notifyDescriptor\n");
+  if (notifyDescriptor != nullptr) {
+    uint8_t value[2] = { 0x00, 0x01 };
+    notifyDescriptor->writeValue(value, 2, true);
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  sendNotificationRequest();
+  RemoteScales::log("Sent notification request\n");
+  lastHeartbeat = millis();
+  return true;
+}
+
+void BookooScales::sendNotificationRequest() {
+  uint8_t payload[] = { 0, 0, 0, 0, 0, 0 };
+  sendEvent(payload, 6);
+  RemoteScales::log("Sent event.\n");
+}
+
+void BookooScales::sendEvent(const uint8_t* payload, size_t length) {
+  auto bytes = std::make_unique<uint8_t[]>(length + 1);
+  bytes[0] = static_cast<uint8_t>(length + 1);
+
+  for (size_t i = 0; i < length; ++i) {
+    bytes[i + 1] = payload[i] & 0xFF;
+  }
+
+  sendMessage(BookooMessageType::SYSTEM, bytes.get(), length + 1);
+}
+
+void BookooScales::sendHeartbeat() {
+  if (!isConnected()) {
+    return;
+  }
+
+  uint32_t now = millis();
+  if (now - lastHeartbeat < 2000) {
+    return;
+  }
+
+  uint8_t payload1[] = { 0x02,0x00 };
+  sendMessage(BookooMessageType::SYSTEM, payload1, 2);
+  sendNotificationRequest();
+  uint8_t payload2[] = { 0x00 };
+  sendMessage(BookooMessageType::SYSTEM, payload2, 1);
+  lastHeartbeat = now;
+}
+
+void BookooScales::subscribeToNotifications() {
+  RemoteScales::log("subscribeToNotifications\n");
+
+  auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(characteristic, data, length, isNotify);
+    };
+
+  if (weightCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+
+  if (commandCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for command characteristic\n");
+    commandCharacteristic->subscribe(true, callback);
+  }
+}
+
+void BookooScales::sendMessage(BookooMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse) {
+
+  auto bytes = std::make_unique<uint8_t[]>(length);
+
+  memcpy(bytes.get(), payload, length);
+
+  // Checksum Calculation (XOR of all bytes except checksum byte)
+  uint8_t checksum = bytes[0];
+  for (size_t i = 1; i < length - 1; i++) {
+    checksum ^= bytes[i];
+  }
+  bytes[length - 1] = checksum;
+
+  commandCharacteristic->writeValue(bytes.get(), length, waitResponse);
+}

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -33,7 +33,17 @@ bool BookooScales::connect() {
   if (!performConnectionHandshake()) {
     return false;
   }
+  // Subscribe BEFORE issuing the start-notifications command. The scale's
+  // weight characteristic only begins emitting notifications once its CCCD
+  // descriptor is enabled; if we send sendNotificationRequest() first, the
+  // scale processes it while CCCD is still off and silently never starts.
+  // Symptom: GATT link is up, scale->isConnected() returns true, but no
+  // weight notifications ever arrive and the UI shows no live weight. This
+  // regressed when the manual CCCD write in performConnectionHandshake()
+  // was removed (9e1ec2a5) in favor of NimBLE's subscribe(true, ...) —
+  // subscribe() does the right thing, it just needs to run first.
   subscribeToNotifications();
+  sendNotificationRequest();
   RemoteScales::setWeight(0.f);
 
   // Disable the scale-side flow-smoothing EMA so consumers see raw per-sample
@@ -258,8 +268,10 @@ bool BookooScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  sendNotificationRequest();
-  RemoteScales::log("Sent notification request\n");
+  // Notification-request command is issued in connect() AFTER
+  // subscribeToNotifications() so the scale's CCCD is already enabled
+  // when it receives the start command — otherwise the scale silently
+  // ignores it and never emits weight notifications.
   lastHeartbeat = millis();
   return true;
 }

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.cpp
@@ -1,5 +1,6 @@
 #include "bookoo.h"
 #include "remote_scales_plugin_registry.h"
+#include <array>
 
 /*
 Handle protocol according to the spec found at
@@ -75,8 +76,8 @@ bool BookooScales::tare() {
   // output, so this is behaviorally equivalent to 0x01 for our purposes, but is
   // future-proof if we ever want to cross-check shot timing against the scale.
   // sendMessage() computes and writes the final checksum byte.
-  uint8_t payload[6] = { 0x03, 0x0A, 0x07, 0x00, 0x00, 0x00 };
-  sendMessage(payload, sizeof(payload));
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x07, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
 
   return true;
 };
@@ -89,8 +90,8 @@ void BookooScales::disableScaleSmoothing() {
   // output. Firmware consumers (ShotHistoryPlugin, VolumetricRateCalculator)
   // can then apply their own filtering or use the raw signal directly --
   // avoiding a double-EMA pipeline that adds lag with no accuracy benefit.
-  uint8_t payload[6] = { 0x03, 0x0A, 0x08, 0x00, 0x00, 0x00 };
-  sendMessage(payload, sizeof(payload));
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x08, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
 };
 
 // Note: on Bookoo Ultra these are only effective in timing-mode/ratio-mode
@@ -99,22 +100,22 @@ void BookooScales::disableScaleSmoothing() {
 void BookooScales::startTimer() {
   if (!isConnected()) return;
   RemoteScales::log("Timer START (cmd 0x0A 0x04)");
-  uint8_t payload[6] = { 0x03, 0x0A, 0x04, 0x00, 0x00, 0x00 };
-  sendMessage(payload, sizeof(payload));
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x04, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
 }
 
 void BookooScales::stopTimer() {
   if (!isConnected()) return;
   RemoteScales::log("Timer STOP (cmd 0x0A 0x05)");
-  uint8_t payload[6] = { 0x03, 0x0A, 0x05, 0x00, 0x00, 0x00 };
-  sendMessage(payload, sizeof(payload));
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x05, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
 }
 
 void BookooScales::resetTimer() {
   if (!isConnected()) return;
   RemoteScales::log("Timer RESET (cmd 0x0A 0x06)");
-  uint8_t payload[6] = { 0x03, 0x0A, 0x06, 0x00, 0x00, 0x00 };
-  sendMessage(payload, sizeof(payload));
+  std::array<uint8_t, 6> payload = { 0x03, 0x0A, 0x06, 0x00, 0x00, 0x00 };
+  sendMessage(payload.data(), payload.size());
 }
 
 //-----------------------------------------------------------------------------------/

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -55,7 +55,7 @@ private:
   bool performConnectionHandshake();
   void subscribeToNotifications();
 
-  void sendMessage(BookooMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendMessage(const uint8_t* payload, size_t length, bool waitResponse = false);
   void sendEvent(const uint8_t* payload, size_t length);
   void sendHeartbeat();
   void sendNotificationRequest();

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -23,11 +23,25 @@ public:
   bool isConnected() override;
   bool tare() override;
 
-private:
-  std::string weightUnits;
-  float time;
-  uint8_t battery;
+  // Capability overrides — Bookoo parses all of these out of the 20-byte
+  // weight notification (0x0B). See decodeAndHandleNotification() for layout.
+  bool hasFlowRate() const override { return true; }
+  bool hasBatteryLevel() const override { return true; }
+  bool hasScaleTimer() const override { return true; }
+  bool hasWeightUnit() const override { return true; }
+  // NOTE: byte 18 of the weight notification is "auto-mode stop condition" on
+  // Ultra-tier scales and reserved (0x00) on Mini. Without a way to identify
+  // Ultra vs Mini at discovery time we can't claim this safely — consumers
+  // reading getAutoModeStopCondition() on a Mini would get a meaningless 0.
+  // Leaving hasAutoModeStopCondition() at its default (false) until an
+  // Ultra-specific subclass or discovery path exists.
 
+  // Ask the scale to turn off its own flow-rate EMA so firmware consumers
+  // see raw native flow instead of double-filtered output. Idempotent;
+  // safe to call repeatedly. Does nothing if disconnected.
+  void disableScaleSmoothing();
+
+private:
   uint32_t lastHeartbeat = 0;
 
   bool markedForReconnection = false;

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -1,0 +1,68 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEScan.h>
+#include <vector>
+#include <memory>
+
+enum class BookooMessageType : uint8_t {
+  SYSTEM = 0x0A,
+  WEIGHT = 0x0B
+};
+
+class BookooScales : public RemoteScales {
+
+public:
+  BookooScales(const DiscoveredDevice& device);
+  void update() override;
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  std::string weightUnits;
+  float time;
+  uint8_t battery;
+
+  uint32_t lastHeartbeat = 0;
+
+  bool markedForReconnection = false;
+
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  std::vector<uint8_t> dataBuffer;
+
+  bool performConnectionHandshake();
+  void subscribeToNotifications();
+
+  void sendMessage(BookooMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendEvent(const uint8_t* payload, size_t length);
+  void sendHeartbeat();
+  void sendNotificationRequest();
+  void sendId();
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+  bool decodeAndHandleNotification();
+};
+
+class BookooScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-bookoo",
+      .handles = [](const DiscoveredDevice& device) { return BookooScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<BookooScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() && (deviceName.find("BOOKOO_SC") == 0);
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -34,12 +34,31 @@ public:
   bool hasScaleTimer() const override { return true; }
   bool hasTimerControl() const override { return true; }
   bool hasWeightUnit() const override { return true; }
-  // NOTE: byte 18 of the weight notification is "auto-mode stop condition" on
-  // Ultra-tier scales and reserved (0x00) on Mini. Without a way to identify
-  // Ultra vs Mini at discovery time we can't claim this safely — consumers
-  // reading getAutoModeStopCondition() on a Mini would get a meaningless 0.
-  // Leaving hasAutoModeStopCondition() at its default (false) until an
-  // Ultra-specific subclass or discovery path exists.
+  // Ultra reports an auto-mode stop condition in byte 18 of the weight
+  // notification (0 = stop on liquid-flow-stop, 1 = stop on container-removal);
+  // Mini always sends 0x00 (reserved). Gate this capability on Ultra detection
+  // via the advertising name (BOOKOO_SC_U prefix) — see isUltra_ in the
+  // constructor. Consumers reading getAutoModeStopCondition() on a Mini would
+  // otherwise see a misleading 0.
+  bool hasAutoModeStopCondition() const override { return isUltra_; }
+
+  // True when the advertised name marks this device as an Ultra (BOOKOO_SC_U
+  // prefix). Mini (and unknown future models) default to false.
+  bool isUltra() const { return isUltra_; }
+
+  // Ultra-only commands. No-op on Mini scales. See the Bookoo Ultra protocol
+  // spec for byte-level details:
+  //   https://github.com/BooKooCode/OpenSource/blob/main/bookoo_ultra_scale/protocols.md
+  //
+  // setAutoModeStopConditionOnScale: command 0x0B, writes the scale's own
+  // auto-mode stop condition (0 = liquid-flow-stop, 1 = container-removal).
+  // Only meaningful if the scale is in auto-mode; does not affect GaggiMate's
+  // own brew-by-weight flow (which uses Timer mode).
+  void setAutoModeStopConditionOnScale(bool onContainerRemoval);
+
+  // calibrate: command 0x09, triggers factory calibration. Only effective
+  // when the scale is physically in weight-mode; no-op otherwise and on Mini.
+  void calibrate();
 
   // Ask the scale to turn off its own flow-rate EMA so firmware consumers
   // see raw native flow instead of double-filtered output. Idempotent;
@@ -50,6 +69,12 @@ private:
   uint32_t lastHeartbeat = 0;
 
   bool markedForReconnection = false;
+
+  // Set once at construction time from the advertising name. Ultra devices
+  // advertise as BOOKOO_SC_U<...>; Mini as BOOKOO_SC_M<...>. Default false
+  // (Mini-compatible) for any name that doesn't match the Ultra prefix so
+  // we never accidentally enable Ultra-only commands on a Mini.
+  const bool isUltra_;
 
   NimBLERemoteService* service;
   NimBLERemoteCharacteristic* weightCharacteristic;

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -23,11 +23,16 @@ public:
   bool isConnected() override;
   bool tare() override;
 
+  void startTimer() override;
+  void stopTimer() override;
+  void resetTimer() override;
+
   // Capability overrides — Bookoo parses all of these out of the 20-byte
   // weight notification (0x0B). See decodeAndHandleNotification() for layout.
   bool hasFlowRate() const override { return true; }
   bool hasBatteryLevel() const override { return true; }
   bool hasScaleTimer() const override { return true; }
+  bool hasTimerControl() const override { return true; }
   bool hasWeightUnit() const override { return true; }
   // NOTE: byte 18 of the weight notification is "auto-mode stop condition" on
   // Ultra-tier scales and reserved (0x00) on Mini. Without a way to identify

--- a/lib/esp-arduino-ble-scales/src/scales/bookoo.h
+++ b/lib/esp-arduino-ble-scales/src/scales/bookoo.h
@@ -46,6 +46,13 @@ public:
   // prefix). Mini (and unknown future models) default to false.
   bool isUltra() const { return isUltra_; }
 
+  // Mirror of byte 17 (flow-smoothing switch) from the most recent weight
+  // notification. We send cmd 0x08 0x00 in connect() to disable the scale's
+  // own EMA so consumers see raw per-sample flow; this lets callers verify
+  // the scale actually honored the request. False until the first
+  // notification is parsed.
+  bool isFlowSmoothingOn() const override { return lastFlowSmoothingOn_; }
+
   // Ultra-only commands. No-op on Mini scales. See the Bookoo Ultra protocol
   // spec for byte-level details:
   //   https://github.com/BooKooCode/OpenSource/blob/main/bookoo_ultra_scale/protocols.md
@@ -75,6 +82,9 @@ private:
   // (Mini-compatible) for any name that doesn't match the Ultra prefix so
   // we never accidentally enable Ultra-only commands on a Mini.
   const bool isUltra_;
+
+  // Mirrors byte 17 of the most recently parsed weight notification.
+  mutable bool lastFlowSmoothingOn_ = false;
 
   NimBLERemoteService* service;
   NimBLERemoteCharacteristic* weightCharacteristic;

--- a/lib/esp-arduino-ble-scales/src/scales/decent.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/decent.cpp
@@ -1,0 +1,197 @@
+#include "decent.h"
+#include "remote_scales_plugin_registry.h"
+#include <iostream>
+
+using namespace std;
+
+const NimBLEUUID serviceUUID("FFF0");
+const NimBLEUUID readCharacteristicUUID("FFF4");
+const NimBLEUUID writeCharacteristicUUID("36F5");
+
+DecentScales::DecentScales(const DiscoveredDevice& device)
+  : RemoteScales(device) {
+}
+
+DecentScales::~DecentScales() {}
+
+bool DecentScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n",
+    RemoteScales::getDeviceName().c_str(),
+    RemoteScales::getDeviceAddress().c_str());
+
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+
+  if (!subscribeToNotifications()) {
+    return false;
+  }
+
+  // Turn on the OLED display after successful connection
+  turnOnOLED();
+
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void DecentScales::disconnect() { 
+  // Turn off the OLED display before disconnecting
+  if (isConnected()) {
+    turnOffOLED();
+  }
+  RemoteScales::clientCleanup(); 
+}
+
+bool DecentScales::isConnected() { return RemoteScales::clientIsConnected(); }
+
+void DecentScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    if (connect()) {
+      markedForReconnection = false;
+    }
+    else {
+      RemoteScales::log("Failed to reconnect\n");
+      return;
+    }
+  } else {
+    if (verifyConnected()) {
+      // Send heartbeat every 5 seconds
+      unsigned long now = millis();
+      if (now - lastHeartbeatMillis >= 5000) {
+        sendHeartbeat();
+        lastHeartbeatMillis = now;
+      }
+    }
+  }
+}
+
+void DecentScales::sendHeartbeat() {
+  // Heartbeat command: 03 0A 03 FF FF 00 0A
+  if (writeCharacteristic) {
+    uint8_t payload[] = { 0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A };
+    writeCharacteristic->writeValue(payload, sizeof(payload), false);
+    RemoteScales::log("Heartbeat sent\n");
+  }
+}
+
+void DecentScales::turnOnOLED() {
+  if (writeCharacteristic) {
+    uint8_t payload[] = { 0x03, 0x0A, 0x01 };
+    writeCharacteristic->writeValue(payload, sizeof(payload), false);
+    RemoteScales::log("OLED turned on\n");
+  }
+}
+
+void DecentScales::turnOffOLED() {
+  if (writeCharacteristic) {
+    uint8_t payload[] = { 0x03, 0x0A, 0x00 };
+    writeCharacteristic->writeValue(payload, sizeof(payload), false);
+    RemoteScales::log("OLED turned off\n");
+  }
+}
+
+bool DecentScales::tare() {
+  if (!verifyConnected())
+    return false;
+  uint8_t payload[] = { 0x03, 0x0F, 0x00, 0x00, 0x00, 0x01, 0x0C }; // should also send 01 as the last data byte of the TARE command, for example: “03 0F 01 00 00 01 0C” 
+  writeCharacteristic->writeValue(payload, sizeof(payload), false);
+  return true;
+};
+
+bool DecentScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  service = RemoteScales::clientGetService(serviceUUID);
+  if (service != nullptr) {
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got Service\n");
+
+  readCharacteristic = service->getCharacteristic(readCharacteristicUUID);
+  writeCharacteristic = service->getCharacteristic(writeCharacteristicUUID);
+  if (readCharacteristic == nullptr || writeCharacteristic == nullptr) {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got readCharacteristic and writeCharacteristic\n");
+  return true;
+}
+
+bool DecentScales::subscribeToNotifications() {
+  if (readCharacteristic->canNotify()) {
+    auto callback = [this](NimBLERemoteCharacteristic* characteristic,
+      uint8_t* data, size_t length, bool isNotify) {
+        readCallback(characteristic, data, length, isNotify);
+      };
+    if (!readCharacteristic->subscribe(true, callback, false)) {
+      clientCleanup();
+      return false;
+    }
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Registered for notify\n");
+  return true;
+}
+
+void DecentScales::readCallback(NimBLERemoteCharacteristic* pCharacteristic,
+  uint8_t* pData, size_t length, bool isNotify) {
+  if ((length == 7 || length == 10) && pData[0] == 0x03 && (pData[1] == 0xCA || pData[1] == 0xCE)) {
+    handleWeightNotification(pData, length);
+  }
+  else {
+    RemoteScales::log("Wrong packet length\n");
+  }
+}
+
+void DecentScales::handleWeightNotification(uint8_t* pData, size_t length) {
+  int16_t weight100 =
+    static_cast<int16_t>((uint16_t)((pData[2] << 8) | pData[3]));
+
+  uint8_t xorByte = pData[length - 1];
+
+  if (xorByte != 0) {
+    uint8_t xorSum = pData[0];
+
+    for (int i = 1; i < length - 1; i++) {
+      xorSum ^= pData[i];
+    }
+
+    if (xorSum != xorByte) {
+      RemoteScales::log("Wrong checksum\n");
+      return;
+    }
+  }
+
+  RemoteScales::setWeight(weight100 / 10.f);
+  RemoteScales::log("Weight received\n");
+}
+
+bool DecentScales::verifyConnected() {
+  if (markedForReconnection) {
+    return false;
+  }
+  if (!isConnected()) {
+    markedForReconnection = true;
+    return false;
+  }
+  return true;
+}

--- a/lib/esp-arduino-ble-scales/src/scales/decent.h
+++ b/lib/esp-arduino-ble-scales/src/scales/decent.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+
+class DecentScales : public RemoteScales {
+
+public:
+  DecentScales(const DiscoveredDevice& device);
+  virtual ~DecentScales(void);
+
+  bool connect(void) override;
+  void disconnect(void) override;
+  bool isConnected(void) override;
+  void update(void) override;
+  bool tare(void) override;
+
+private:
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* readCharacteristic;
+  NimBLERemoteCharacteristic* writeCharacteristic;
+
+  bool markedForReconnection = false;
+
+  unsigned long lastHeartbeatMillis = 0;
+  void sendHeartbeat();
+  void turnOnOLED();
+  void turnOffOLED();
+
+  void readCallback(NimBLERemoteCharacteristic* pCharacteristic, uint8_t* pData,
+    size_t length, bool isNotify);
+
+  bool performConnectionHandshake(void);
+  bool subscribeToNotifications(void);
+  void handleWeightNotification(uint8_t* pData, size_t length);
+  bool verifyConnected(void);
+};
+
+class DecentScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+        .id = "plugin-decent",
+        .handles =
+            [](const DiscoveredDevice& device) {
+              return DecentScalesPlugin::handles(device);
+            },
+        .initialise = [](const DiscoveredDevice& device)
+            -> std::unique_ptr<RemoteScales> {
+          return std::make_unique<DecentScales>(device);
+        },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() && (deviceName.find("Decent Scale") == 0 || deviceName.find("EspressiScale") == 0);
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/difluid.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/difluid.cpp
@@ -1,0 +1,218 @@
+#include "difluid.h"
+#include "remote_scales_plugin_registry.h"
+
+/*
+Handle protocol according to the provided specification.
+*/
+
+// Update service UUIDs and characteristic UUID
+const NimBLEUUID tiserviceUUID("00DD");
+const NimBLEUUID mbserviceUUID("00EE");
+const NimBLEUUID weightCharacteristicUUID("AA01");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+DifluidScales::DifluidScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool DifluidScales::connect() {
+    if (isConnected()) {
+        log("Already connected\n");
+        return true;
+    }
+
+    if (!clientConnect()) {
+        clientCleanup();
+        return false;
+    }
+
+    if (!performConnectionHandshake()) {
+        clientCleanup();
+        return false;
+    }
+    setWeight(0.f);
+    return true;
+}
+
+void DifluidScales::disconnect() {
+    clientCleanup();
+}
+
+bool DifluidScales::isConnected() {
+    return clientIsConnected();
+}
+
+void DifluidScales::update() {
+    if (markedForReconnection) {
+        log("Marked for reconnection. Attempting to reconnect.\n");
+        clientCleanup();
+        connect();
+        markedForReconnection = false;
+    } else {
+        sendHeartbeat();
+    }
+}
+
+// Tare function
+bool DifluidScales::tare() {
+    if (!isConnected()) return false;
+    log("Tare command sent.\n");
+    uint8_t tareCommand[] = {0xDF, 0xDF, 0x03, 0x02, 0x01, 0x01, 0x00};
+    tareCommand[6] = calculateChecksum(tareCommand, sizeof(tareCommand));
+    weightCharacteristic->writeValue(tareCommand, sizeof(tareCommand), true);
+    return true;
+}
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+
+int32_t DifluidScales::readInt32BE(const uint8_t* data) {
+    return (int32_t)(
+        ((uint32_t)data[0] << 24) |
+        ((uint32_t)data[1] << 16) |
+        ((uint32_t)data[2] << 8) |
+        (uint32_t)data[3]
+    );
+}
+
+void DifluidScales::notifyCallback(
+    NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+    uint8_t* pData,
+    size_t length,
+    bool isNotify
+) {
+    // Use the log function from RemoteScales
+    log("Notification received:\n");
+    for (size_t i = 0; i < length; i++) {
+        log("%02X ", pData[i]);
+    }
+    log("\n");
+
+    // Verify headers
+    if (length < 6 || pData[0] != 0xDF || pData[1] != 0xDF) {
+        log("Invalid data received.\n");
+        return;
+    }
+
+    // Verify checksum
+    uint8_t receivedChecksum = pData[length - 1];
+    uint8_t calculatedChecksum = calculateChecksum(pData, length);
+    if (receivedChecksum != calculatedChecksum) {
+        log("Checksum mismatch. Received: %02X, Calculated: %02X\n", receivedChecksum, calculatedChecksum);
+        return;
+    }
+
+    uint8_t func = pData[2];
+    uint8_t cmd = pData[3];
+    uint8_t dataLen = pData[4];
+
+    if (func == 0x03 && cmd == 0x00) { // Sensor Data
+        if (dataLen >= 13 && length >= 6 + dataLen) {
+            // Parse sensor data
+            int32_t weightRaw = readInt32BE(&pData[5]);
+            float weight = weightRaw / 10.0f; // Assuming weight unit is grams x10
+
+            // Handle other data fields if necessary
+            // ...
+
+            log("Weight: %.1f g\n", weight);
+
+            // Call weight updated callback
+            setWeight(weight);
+        } else {
+            log("Invalid sensor data length.\n");
+        }
+    } else if (func == 0x03 && cmd == 0x05) { // Heartbeat Acknowledgment(Get Device Status)
+        log("Heartbeat acknowledged.\n");
+        uint8_t battery_capacity = pData[6];  // Battery capacity percentage.
+    } else {
+        log("Unknown function (%02X) or command (%02X).\n", func, cmd);
+    }
+}
+
+
+bool DifluidScales::performConnectionHandshake() {
+    log("Performing handshake\n");
+
+    // Try to get the service using both UUIDs
+    service = clientGetService(mbserviceUUID);
+    if (service == nullptr) {
+        service = clientGetService(tiserviceUUID);
+    }
+
+    if (service == nullptr) {
+        log("Service not found with UUIDs 00EE or 00DD.\n");
+        return false;
+    }
+    log("Service found.\n");
+
+    weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+    if (weightCharacteristic == nullptr) {
+        log("Characteristic not found.\n");
+        return false;
+    }
+    log("Characteristic found.\n");
+
+    // Subscribe to notifications
+    if (weightCharacteristic->canNotify()) {
+        weightCharacteristic->subscribe(true, [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+            notifyCallback(characteristic, data, length, isNotify);
+        });
+    } else {
+        log("Cannot subscribe to notifications.\n");
+        return false;
+    }
+
+    // Set the scale unit to grams
+    setUnitToGram();
+
+    // Enable auto notifications
+    enableAutoNotifications();
+
+    // Initialize heartbeat timer
+    lastHeartbeat = millis();
+
+    return true;
+}
+
+void DifluidScales::setUnitToGram() {
+    uint8_t unitToGramCommand[] = {0xDF, 0xDF, 0x01, 0x04, 0x01, 0x00, 0x00}; // Last byte for checksum
+    unitToGramCommand[6] = calculateChecksum(unitToGramCommand, sizeof(unitToGramCommand));
+    weightCharacteristic->writeValue(unitToGramCommand, sizeof(unitToGramCommand), true);
+    log("Set unit to grams.\n");
+}
+
+void DifluidScales::enableAutoNotifications() {
+    uint8_t enableNotificationsCommand[] = {0xDF, 0xDF, 0x01, 0x00, 0x01, 0x01, 0x00};
+    enableNotificationsCommand[6] = calculateChecksum(enableNotificationsCommand, sizeof(enableNotificationsCommand));
+    weightCharacteristic->writeValue(enableNotificationsCommand, sizeof(enableNotificationsCommand), true);
+    log("Enabled auto notifications.\n");
+}
+
+void DifluidScales::sendHeartbeat() {
+    if (!isConnected()) {
+        markedForReconnection=true;
+        return;
+    }
+
+    uint32_t now = millis();
+    if (now - lastHeartbeat < 2000) {
+        return;
+    }
+
+    uint8_t heartbeatCommand[] = {0xDF, 0xDF, 0x03, 0x05, 0x00, 0xC6};  // Use Func 0x03 and Cmd 0x05(Get Device Status) as the heartbeat.
+    heartbeatCommand[5] = calculateChecksum(heartbeatCommand, sizeof(heartbeatCommand));
+    weightCharacteristic->writeValue(heartbeatCommand, sizeof(heartbeatCommand), true);
+    lastHeartbeat = now;
+}
+
+// Calculate checksum according to the protocol
+uint8_t DifluidScales::calculateChecksum(const uint8_t* data, size_t length) {
+    uint16_t sum = 0;
+    // Sum all bytes except the checksum byte itself
+    for (size_t i = 0; i < length - 1; i++) {
+        sum += data[i];
+    }
+    return static_cast<uint8_t>(sum & 0xFF);
+}

--- a/lib/esp-arduino-ble-scales/src/scales/difluid.h
+++ b/lib/esp-arduino-ble-scales/src/scales/difluid.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <NimBLEDevice.h>
+
+class DifluidScales : public RemoteScales
+{
+public:
+    DifluidScales(const DiscoveredDevice &device);
+
+    bool tare() override;
+    bool isConnected() override;
+    bool connect() override;
+    void disconnect() override;
+    void update() override;
+
+private:
+    NimBLERemoteService *service = nullptr;
+    NimBLERemoteCharacteristic *weightCharacteristic = nullptr;
+    uint32_t lastHeartbeat = 0;
+    bool markedForReconnection = false;
+
+    void notifyCallback(NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData, size_t length, bool isNotify);
+    bool performConnectionHandshake();
+    void setUnitToGram();
+    void enableAutoNotifications();
+    void sendHeartbeat();
+    uint8_t calculateChecksum(const uint8_t *data, size_t length);
+    int32_t readInt32BE(const uint8_t *data);
+};
+
+// Update the DifluidScalesPlugin class
+class DifluidScalesPlugin
+{
+public:
+    static void apply()
+    {
+        RemoteScalesPlugin plugin;
+        plugin.id = "plugin-difluid";
+        plugin.handles = &DifluidScalesPlugin::handles;
+        plugin.initialise = &DifluidScalesPlugin::initialise;
+        RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+    }
+
+private:
+    // Determines whether this plugin can handle the given device
+    static bool handles(const DiscoveredDevice &device)
+    {
+        const std::string &deviceName = device.getName();
+        if (deviceName.empty())
+        {
+            return false;
+        }
+        return deviceName.find("Microbalance") == 0 || deviceName.find("Mb") == 0;
+    }
+
+    static std::unique_ptr<RemoteScales> initialise(const DiscoveredDevice &device)
+    {
+        return std::make_unique<DifluidScales>(device);
+    }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/eclair.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/eclair.cpp
@@ -1,0 +1,217 @@
+#include "eclair.h"
+#include "remote_scales_plugin_registry.h"
+
+const NimBLEUUID ECLAIR_SERVICE_UUID("B905EAEA-2E63-0E04-7582-7913F10D8F81");
+const NimBLEUUID ECLAIR_DATA_CHAR_UUID("AD736C5F-BBC9-1F96-D304-CB5D5F41E160");
+const NimBLEUUID ECLAIR_CONFIG_CHAR_UUID("4F9A45BA-8E1B-4E07-E157-0814D393B968");
+
+// -----------------------------------------------------------------------------------
+// ---------------------------------   PUBLIC   --------------------------------------
+// -----------------------------------------------------------------------------------
+
+EclairScales::EclairScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool EclairScales::connect() {
+    if (RemoteScales::clientIsConnected()) {
+        RemoteScales::log("Already connected\n");
+        return true;
+    }
+
+    RemoteScales::log("Connecting to %s [%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+    bool result = RemoteScales::clientConnect();
+    if (!result) {
+        RemoteScales::log("Failed to connect to client\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    if (!performConnectionHandshake()) {
+        RemoteScales::log("Handshake failed\n");
+        return false;
+    }
+
+    subscribeToNotifications();
+    RemoteScales::setWeight(0.f);
+    lastHeartbeat = millis();  // Initialize the heartbeat timestamp
+    return true;
+}
+
+void EclairScales::disconnect() {
+    RemoteScales::clientCleanup();
+}
+
+bool EclairScales::isConnected() {
+    return RemoteScales::clientIsConnected();
+}
+
+void EclairScales::update() {
+    // Check if the device is connected; if not, attempt to reconnect
+    if (!isConnected()) {
+        RemoteScales::log("Device disconnected. Attempting to reconnect...\n");
+        if (connect()) {
+            lastHeartbeat = millis();  // Reset the heartbeat timer after reconnecting
+            RemoteScales::log("Reconnected to Eclair scale successfully.");
+        }
+    } else {
+        sendHeartbeat();  // Send the heartbeat signal if still connected
+    }
+}
+
+bool EclairScales::tare() {
+    if (!isConnected()) return false;
+    uint8_t tareCommand[2] = { static_cast<uint8_t>(EclairMessageType::TARE_COMMAND), 0x01 };
+    uint8_t checksum = calculateXOR(&tareCommand[1], 1);  // Calculate checksum
+    uint8_t message[3] = { tareCommand[0], tareCommand[1], checksum };
+    configCharacteristic->writeValue(message, sizeof(message), true);
+    RemoteScales::log("Sent tare command\n");
+    return true;
+}
+
+// -----------------------------------------------------------------------------------
+// ---------------------------------  PRIVATE  ---------------------------------------
+// -----------------------------------------------------------------------------------
+
+bool EclairScales::performConnectionHandshake() {
+    RemoteScales::log("Performing handshake\n");
+
+    service = RemoteScales::clientGetService(ECLAIR_SERVICE_UUID);
+    if (service == nullptr) {
+        RemoteScales::log("Failed to get Eclair service\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    dataCharacteristic = service->getCharacteristic(ECLAIR_DATA_CHAR_UUID);
+    configCharacteristic = service->getCharacteristic(ECLAIR_CONFIG_CHAR_UUID);
+    if (dataCharacteristic == nullptr || configCharacteristic == nullptr) {
+        RemoteScales::log("Failed to get characteristics\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    RemoteScales::log("Successfully obtained service and characteristics\n");
+    return true;
+}
+
+void EclairScales::sendMessage(EclairMessageType msgType, const uint8_t* data, size_t dataLength, bool waitResponse) {
+    size_t totalLength = 1 + dataLength + 1; // Header + Data + Checksum
+    auto bytes = std::make_unique<uint8_t[]>(totalLength);
+    bytes[0] = static_cast<uint8_t>(msgType); // Message type
+    memcpy(bytes.get() + 1, data, dataLength); // Data part
+    uint8_t checksum = calculateXOR(bytes.get() + 1, dataLength); // Calculate checksum for the data part
+    bytes[totalLength - 1] = checksum; // Add checksum byte
+
+    RemoteScales::log("Sending message: %s\n", RemoteScales::byteArrayToHexString(bytes.get(), totalLength).c_str());
+
+    configCharacteristic->writeValue(bytes.get(), totalLength, waitResponse);
+}
+
+void EclairScales::notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    RemoteScales::log("Received notification from characteristic %s: %s\n",
+        characteristic->getUUID().toString().c_str(),
+        RemoteScales::byteArrayToHexString(data, length).c_str());
+
+    if (characteristic->getUUID() == ECLAIR_DATA_CHAR_UUID) {
+        handleDataNotification(data, length);
+    } else if (characteristic->getUUID() == ECLAIR_CONFIG_CHAR_UUID) {
+        handleConfigNotification(data, length);
+    }
+}
+
+void EclairScales::handleDataNotification(uint8_t* data, size_t length) {
+    if (length < 10) { // Header (1 byte) + Data (8 bytes) + Checksum (1 byte)
+        RemoteScales::log("Data notification length too short\n");
+        return;
+    }
+
+    uint8_t header = data[0];
+    uint8_t checksum = data[length - 1];
+    uint8_t calculatedChecksum = calculateXOR(&data[1], length - 2); // Exclude header and checksum byte
+
+    if (calculatedChecksum != checksum) {
+        RemoteScales::log("Invalid checksum in data notification: calculated %02X, received %02X\n", calculatedChecksum, checksum);
+        return;
+    }
+
+    if (header == static_cast<uint8_t>(EclairMessageType::WEIGHT)) {
+        int32_t rawWeight;
+        memcpy(&rawWeight, &data[1], 4); // Assuming little-endian
+        float weight = rawWeight / 1000.0f; // Convert to grams
+        RemoteScales::setWeight(weight);
+    } else if (header == static_cast<uint8_t>(EclairMessageType::FLOW_RATE)) {
+        RemoteScales::log("Received flow rate data\n");
+    } else {
+        RemoteScales::log("Unknown data notification header: %02X\n", header);
+    }
+}
+
+void EclairScales::handleConfigNotification(uint8_t* data, size_t length) {
+    if (length < 3) { // Header (1 byte) + Data (1 byte) + Checksum (1 byte)
+        RemoteScales::log("Config notification length too short\n");
+        return;
+    }
+
+    uint8_t header = data[0];
+    uint8_t value = data[1];
+    uint8_t checksum = data[length - 1];
+    uint8_t calculatedChecksum = calculateXOR(&data[1], length - 2); // Exclude header and checksum byte
+
+    if (calculatedChecksum != checksum) {
+        RemoteScales::log("Invalid checksum in config notification: calculated %02X, received %02X\n", calculatedChecksum, checksum);
+        return;
+    }
+
+    if (header == static_cast<uint8_t>(EclairMessageType::BATTERY_STATUS)) {
+        battery = value;
+        RemoteScales::log("Battery status updated: %d%%\n", battery);
+    } else if (header == static_cast<uint8_t>(EclairMessageType::TIMER_STATUS)) {
+        RemoteScales::log("Timer status updated: %d\n", value);
+    } else {
+        RemoteScales::log("Unknown config notification header: %02X\n", header);
+    }
+}
+
+uint8_t EclairScales::calculateXOR(const uint8_t* data, size_t length) {
+    uint8_t result = 0;
+    for (size_t i = 0; i < length; i++) {
+        result ^= data[i];
+    }
+    return result;
+}
+
+void EclairScales::subscribeToNotifications() {
+    RemoteScales::log("Subscribing to notifications\n");
+
+    auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+        notifyCallback(characteristic, data, length, isNotify);
+    };
+
+    if (dataCharacteristic->canNotify()) {
+        RemoteScales::log("Subscribing to data characteristic\n");
+        dataCharacteristic->subscribe(true, callback);
+    } else {
+        RemoteScales::log("Data characteristic cannot notify\n");
+    }
+
+    if (configCharacteristic->canNotify()) {
+        RemoteScales::log("Subscribing to config characteristic\n");
+        configCharacteristic->subscribe(true, callback);
+    } else {
+        RemoteScales::log("Config characteristic cannot notify\n");
+    }
+}
+
+void EclairScales::sendHeartbeat() {
+    if (!isConnected()) {
+        return;
+    }
+
+    uint32_t now = millis();
+    if (now - lastHeartbeat < 2000) {
+        return;
+    }
+
+    uint8_t heartbeatCommand[] = { 0x00 };  // Example heartbeat command
+    sendMessage(EclairMessageType::TIMER_STATUS, heartbeatCommand, sizeof(heartbeatCommand));
+    lastHeartbeat = now;
+}

--- a/lib/esp-arduino-ble-scales/src/scales/eclair.h
+++ b/lib/esp-arduino-ble-scales/src/scales/eclair.h
@@ -1,0 +1,65 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <vector>
+#include <memory>
+
+enum class EclairMessageType : uint8_t {
+    WEIGHT = 0x57,           
+    FLOW_RATE = 0x46,        
+    TARE_COMMAND = 0x54,     
+    BATTERY_STATUS = 0x42,   
+    TIMER_STATUS = 0x43,     
+    START_TIMER = 0x53,      
+    STOP_TIMER = 0x45        
+};
+
+class EclairScales : public RemoteScales {
+public:
+    EclairScales(const DiscoveredDevice& device);
+
+    bool connect() override;
+    void disconnect() override;
+    bool isConnected() override;
+    void update() override;
+    bool tare() override;
+
+private:
+    NimBLERemoteService* service = nullptr;
+    NimBLERemoteCharacteristic* dataCharacteristic = nullptr;
+    NimBLERemoteCharacteristic* configCharacteristic = nullptr;
+    uint8_t battery = 0;
+    uint32_t lastHeartbeat = 0;
+
+    bool performConnectionHandshake();
+    void sendMessage(EclairMessageType msgType, const uint8_t* data, size_t dataLength, bool waitResponse = false);
+    void notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify);
+    void handleDataNotification(uint8_t* data, size_t length);
+    void handleConfigNotification(uint8_t* data, size_t length);
+    uint8_t calculateXOR(const uint8_t* data, size_t length);
+    void subscribeToNotifications();
+    void sendHeartbeat();
+};
+
+class EclairScalesPlugin {
+public:
+    static void apply() {
+        RemoteScalesPlugin plugin = RemoteScalesPlugin{
+            .id = "plugin-eclair",
+            .handles = [](const DiscoveredDevice& device) { return EclairScalesPlugin::handles(device); },
+            .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> {
+                return std::make_unique<EclairScales>(device);
+            },
+        };
+        RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+    }
+
+private:
+    static bool handles(const DiscoveredDevice& device) {
+        const std::string& deviceName = device.getName();
+        //Serial.printf("Discovered device: %s\n", deviceName.c_str());
+        return !deviceName.empty() && (deviceName.find("ECLAIR-") == 0);
+    }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/eureka.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/eureka.cpp
@@ -1,0 +1,174 @@
+#include "eureka.h"
+#include "remote_scales_plugin_registry.h"
+
+const size_t RECEIVE_PROTOCOL_LENGTH = 11;
+
+const NimBLEUUID serviceUUID("FFF0");
+const NimBLEUUID weightCharacteristicUUID("FFF1");
+const NimBLEUUID commandCharacteristicUUID("FFF2");
+
+const uint8_t CMD_HEADER = 0xaa;
+const uint8_t CMD_BASE = 0x02;
+const uint8_t CMD_START_TIMER = 0x33;
+const uint8_t CMD_STOP_TIMER = 0x34;
+const uint8_t CMD_RESET_TIMER = 0x35;
+const uint8_t CMD_TARE = 0x31;
+
+const uint16_t CMD_UNIT_BASE = 0x0336;
+const uint8_t CMD_UNIT_GRAM = 0x00;
+const uint8_t CMD_UNIT_OUNCE = 0x01;
+const uint8_t CMD_UNIT_ML = 0x02;
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+EurekaScales::EurekaScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool EurekaScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+  subscribeToNotifications();
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void EurekaScales::disconnect() {
+  RemoteScales::clientCleanup();
+}
+
+bool EurekaScales::isConnected() {
+  return RemoteScales::clientIsConnected();
+}
+
+void EurekaScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    connect();
+    markedForReconnection = false;
+  }
+  else {
+    sendHeartbeat();
+    RemoteScales::log("Heartbeat sent.\n");
+  }
+}
+
+bool EurekaScales::tare() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Tare sent");
+  uint8_t payload[6] = { CMD_HEADER, CMD_BASE, CMD_TARE, CMD_TARE };
+  sendMessage(payload, sizeof(payload));
+
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+void EurekaScales::notifyCallback(
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+  uint8_t* pData,
+  size_t length,
+  bool isNotify
+) {
+  dataBuffer.insert(dataBuffer.end(), pData, pData + length);
+  bool result = true;
+  while (result) {
+    result = decodeAndHandleNotification();
+  }
+}
+
+bool EurekaScales::decodeAndHandleNotification() {
+  // Minimum message length check (11 bytes based on protocol definition)
+  if (dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH) {
+    return false;
+  }
+
+  bool is_negative = dataBuffer[6];
+
+  uint8_t productNumber = dataBuffer[0];
+
+  size_t messageLength = dataBuffer.size();
+
+  float weight = (dataBuffer[8] << 8) + dataBuffer[7];
+
+  if (dataBuffer[6]) { // Check if the value is negative
+    weight = -weight;
+  }
+
+  RemoteScales::setWeight(weight * 0.1f); // Convert to floating point
+
+  // Remove processed message from the buffer
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.end());
+
+  // Return whether there's more data to process
+  return false;
+}
+
+bool EurekaScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  service = RemoteScales::clientGetService(serviceUUID);
+  if (service != nullptr) {
+    RemoteScales::log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  if (weightCharacteristic == nullptr || commandCharacteristic == nullptr) {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
+
+  return true;
+}
+
+void EurekaScales::sendHeartbeat() {
+  if (!isConnected()) {
+    return;
+  }
+
+  // No heartbeat necessary
+}
+
+void EurekaScales::subscribeToNotifications() {
+  RemoteScales::log("subscribeToNotifications\n");
+
+  auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(characteristic, data, length, isNotify);
+    };
+
+  if (weightCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+
+  if (commandCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for command characteristic\n");
+    commandCharacteristic->subscribe(true, callback);
+  }
+}
+
+void EurekaScales::sendMessage(const uint8_t* payload, size_t length, bool waitResponse) {
+  auto bytes = std::make_unique<uint8_t[]>(length);
+  memcpy(bytes.get(), payload, length);
+  commandCharacteristic->writeValue(bytes.get(), length, waitResponse);
+}

--- a/lib/esp-arduino-ble-scales/src/scales/eureka.h
+++ b/lib/esp-arduino-ble-scales/src/scales/eureka.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEScan.h>
+#include <vector>
+#include <memory>
+
+class EurekaScales : public RemoteScales {
+
+public:
+  EurekaScales(const DiscoveredDevice& device);
+  void update() override;
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  bool markedForReconnection = false;
+
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  std::vector<uint8_t> dataBuffer;
+
+  bool performConnectionHandshake();
+  void subscribeToNotifications();
+
+  void sendMessage(const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendHeartbeat();
+  void sendId();
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+  bool decodeAndHandleNotification();
+};
+
+class EurekaScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-eureka",
+      .handles = [](const DiscoveredDevice& device) { return EurekaScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<EurekaScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    if (!deviceName.empty() && (deviceName.find("CFS-9002") == 0 || deviceName.find("LSJ-001") == 0)) {
+      return true;
+    }
+    const std::string& deviceData = device.getManufacturerData();
+    char *pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) deviceData.c_str(), deviceData.length());
+    std::string md(pHex);
+    return !md.empty() && deviceName.empty() && (md.find("a6bc") != std::string::npos || md.find("042") == 0);
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/felicitaScale.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/felicitaScale.cpp
@@ -1,0 +1,135 @@
+#include "felicitaScale.h"
+#include <cstring>
+
+// Initialize UUID constants
+const NimBLEUUID FelicitaScale::DATA_SERVICE_UUID("FFE0");
+const NimBLEUUID FelicitaScale::DATA_CHARACTERISTIC_UUID("FFE1");
+
+FelicitaScale::FelicitaScale(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool FelicitaScale::connect() {
+    if (isConnected()) {
+        log("Already connected.\n");
+        return true;
+    }
+
+    if (!clientConnect()) {
+        clientCleanup();
+        return false;
+    }
+
+    if (!performConnectionHandshake()) {
+        clientCleanup();
+        return false;
+    }
+    setWeight(0.f);
+    return true;
+}
+
+void FelicitaScale::disconnect() {
+    clientCleanup();
+}
+
+bool FelicitaScale::isConnected() {
+    return clientIsConnected();
+}
+
+void FelicitaScale::update() {
+    if (markedForReconnection) {
+        log("Reconnecting...\n");
+        clientCleanup();
+        connect();
+        markedForReconnection = false;
+    } else {
+      verifyConnected();
+    }
+}
+
+bool FelicitaScale::tare() {
+    if (!verifyConnected()) return false;
+    log("Tare command sent.\n");
+    uint8_t tareCommand[] = {CMD_TARE};
+    dataCharacteristic->writeValue(tareCommand, sizeof(tareCommand), false);
+    return true;
+}
+
+bool FelicitaScale::performConnectionHandshake() {
+    log("Performing handshake...\n");
+
+    service = clientGetService(DATA_SERVICE_UUID);
+    if (!service) {
+        log("Service not found.\n");
+        return false;
+    }
+
+    dataCharacteristic = service->getCharacteristic(DATA_CHARACTERISTIC_UUID);
+    if (!dataCharacteristic) {
+        log("Characteristic not found.\n");
+        return false;
+    }
+
+    if (dataCharacteristic->canNotify()) {
+        dataCharacteristic->subscribe(true, [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+            notifyCallback(characteristic, data, length, isNotify);
+        });
+    } else {
+        log("Notifications not supported.\n");
+        return false;
+    }
+    
+    return true;
+}
+bool FelicitaScale::verifyConnected() {
+  if (markedForReconnection) {
+    return false;
+  }
+  if (!isConnected()) {
+    markedForReconnection = true;
+    return false;
+  }
+  return true;
+}
+
+void FelicitaScale::notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    log("Notification received.\n");
+    if (length < 18) {
+        log("Malformed data.\n");
+        return;
+    }
+    parseStatusUpdate(data, length);
+}
+
+void FelicitaScale::parseStatusUpdate(const uint8_t* data, size_t length) {
+    float weight = static_cast<float>(parseWeight(data)) / 100.0f;
+    setWeight(weight);
+    // log("Weight updated: %.1f g\n", weight);
+}
+
+int32_t FelicitaScale::parseWeight(const uint8_t* data) {
+    
+    bool isNegative = (data[2] == 0x2D);
+    
+    if ((data[3] | data[4] | data[5] | data[6] | data[7] | data[8]) < '0' || 
+        (data[3] & data[4] & data[5] & data[6] & data[7] & data[8]) > '9') {
+        log("Invalid digit in weight data\n");
+        return 0;
+    }
+
+    // Direct digit expansion
+    return (isNegative ? -1 : 1) * (
+        (data[3] - '0') * 100000 +
+        (data[4] - '0') * 10000 +
+        (data[5] - '0') * 1000 +
+        (data[6] - '0') * 100 +
+        (data[7] - '0') * 10 +
+        (data[8] - '0')
+    );
+}
+
+uint8_t FelicitaScale::calculateChecksum(const uint8_t* data, size_t length) {
+    uint8_t checksum = 0;
+    for (size_t i = 0; i < length - 1; ++i) {
+        checksum += data[i];
+    }
+    return checksum;
+}

--- a/lib/esp-arduino-ble-scales/src/scales/felicitaScale.h
+++ b/lib/esp-arduino-ble-scales/src/scales/felicitaScale.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <NimBLEDevice.h>
+
+class FelicitaScale : public RemoteScales {
+public:
+    FelicitaScale(const DiscoveredDevice& device);
+
+    bool tare() override;
+    bool isConnected() override;
+    bool connect() override;
+    void disconnect() override;
+    void update() override;
+
+private:
+    NimBLERemoteService* service = nullptr;
+    NimBLERemoteCharacteristic* dataCharacteristic = nullptr;
+    uint32_t lastHeartbeat = 0;
+    bool markedForReconnection = false;
+
+    void notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify);
+    bool performConnectionHandshake();
+    void toggleUnit();
+    void togglePrecision();
+    bool verifyConnected(void);
+    void parseStatusUpdate(const uint8_t* data, size_t length);
+    uint8_t calculateChecksum(const uint8_t* data, size_t length);
+    int32_t parseWeight(const uint8_t* data);
+
+    // Constants specific to Felicita Scales
+    static const NimBLEUUID DATA_SERVICE_UUID;
+    static const NimBLEUUID DATA_CHARACTERISTIC_UUID;
+    static constexpr uint8_t CMD_TARE = 0x54;
+    static constexpr uint8_t CMD_TOGGLE_UNIT = 0x55;
+    static constexpr uint8_t CMD_TOGGLE_PRECISION = 0x44;
+};
+
+
+class FelicitaScalePlugin {
+public:
+    static void apply() {
+        RemoteScalesPlugin plugin;
+        plugin.id = "plugin-felicita";
+        plugin.handles = &FelicitaScalePlugin::handles;
+        plugin.initialise = &FelicitaScalePlugin::initialise;
+        RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+    }
+
+private:
+    static bool handles(const DiscoveredDevice& device) {
+        const std::string& deviceName = device.getName();
+        return !deviceName.empty() && (deviceName.find("FELICITA") == 0);
+    }
+
+    static std::unique_ptr<RemoteScales> initialise(const DiscoveredDevice& device) {
+        return std::make_unique<FelicitaScale>(device);
+    }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/myscale.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/myscale.cpp
@@ -1,0 +1,156 @@
+#include "myscale.h"
+#include <cstring>
+
+// Initialize UUID constants
+const NimBLEUUID myscale::DATA_SERVICE_UUID("0000FFB0-0000-1000-8000-00805F9B34FB");
+const NimBLEUUID myscale::DATA_CHARACTERISTIC_UUID("0000FFB2-0000-1000-8000-00805F9B34FB");
+const NimBLEUUID myscale::WRITE_CHARACTERISTIC_UUID("0000FFB1-0000-1000-8000-00805F9B34FB");
+
+myscale::myscale(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool myscale::connect() {
+    if (isConnected()) {
+        log("Already connected.\n");
+        return true;
+    }
+
+    if (!clientConnect()) {
+        clientCleanup();
+        return false;
+    }
+
+    if (!performConnectionHandshake()) {
+        clientCleanup();
+        return false;
+    }
+    setWeight(0.f);
+    return true;
+}
+
+void myscale::disconnect() {
+    clientCleanup();
+}
+
+bool myscale::isConnected() {
+    return clientIsConnected();
+}
+
+void myscale::update() {
+    if (markedForReconnection) {
+        log("Reconnecting...\n");
+        clientCleanup();
+        connect();
+        markedForReconnection = false;
+    } else {
+      verifyConnected();
+    }
+}
+
+bool myscale::tare() {
+    if (!isConnected()) return false;
+
+    // Hex value to send on tare
+    uint8_t tare_value[] = {
+        0xAC, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xD2, 0xD2
+    };
+
+    auto writeChar = writeCharacteristic;
+    if (!writeChar) {
+        log("Write characteristic not found.\n");
+        return false;
+    }
+
+    writeChar->writeValue(tare_value, sizeof(tare_value), false); // write without response
+    log("Tare command sent.\n");
+    return true;
+}
+
+bool myscale::performConnectionHandshake() {
+    log("Performing handshake...\n");
+    
+    service = clientGetService(DATA_SERVICE_UUID);
+    if (!service) {
+        log("Service not found.\n");
+        return false;
+    }
+
+    dataCharacteristic = service->getCharacteristic(DATA_CHARACTERISTIC_UUID);
+    if (!dataCharacteristic) {
+        log("Characteristic not found.\n");
+        return false;
+    }
+
+    if (dataCharacteristic->canNotify()) {
+        auto cccd = dataCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+        if (cccd) {
+            uint8_t notifyOn[] = {0x01, 0x00};
+            cccd->writeValue(notifyOn, 2, true); // enable notifications
+        }
+        dataCharacteristic->subscribe(true, [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+            notifyCallback(characteristic, data, length, isNotify);
+        });
+    } else {
+        log("Notifications not supported.\n");
+        return false;
+    }
+
+    // Cache write characteristic once to avoid blocking discovery during tare
+    writeCharacteristic = service->getCharacteristic(WRITE_CHARACTERISTIC_UUID);
+    if (!writeCharacteristic) {
+        log("Write characteristic not found during handshake.\n");
+        return false;
+    }
+    
+    return true;
+}
+bool myscale::verifyConnected() {
+  if (markedForReconnection) {
+    return false;
+  }
+  if (!isConnected()) {
+    markedForReconnection = true;
+    return false;
+  }
+  return true;
+}
+
+void myscale::notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    if (length < 15) {
+        log("Malformed data.\n");
+        return;
+    }
+    parseStatusUpdate(data, length);
+}
+
+
+
+void myscale::parseStatusUpdate(const uint8_t* data, size_t length) {
+    int32_t raw = parseWeight(data);
+    float weight = static_cast<float>(raw) / 1000.0f; 
+    setWeight(weight);
+}
+
+
+
+int32_t myscale::parseWeight(const uint8_t* data) {
+
+    bool isNegative = ((data[2] >> 4) == 0x8 || (data[2] >> 4) == 0xC);
+
+    uint32_t raw =
+        ( (uint32_t)(data[3] & 0x0F) << 24 ) |
+        ( (uint32_t)data[4] << 16 ) |
+        ( (uint32_t)data[5] <<  8 ) |
+        ( (uint32_t)data[6]       );
+
+    return isNegative ? -static_cast<int32_t>(raw) : static_cast<int32_t>(raw);
+}
+
+uint8_t myscale::calculateChecksum(const uint8_t* data, size_t length) {
+    uint8_t checksum = 0;
+    for (size_t i = 0; i < length - 1; ++i) {
+        checksum += data[i];
+    }
+    return checksum;
+}

--- a/lib/esp-arduino-ble-scales/src/scales/myscale.h
+++ b/lib/esp-arduino-ble-scales/src/scales/myscale.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <NimBLEDevice.h>
+
+class myscale : public RemoteScales {
+public:
+    myscale(const DiscoveredDevice& device);
+
+    bool tare() override;
+    bool isConnected() override;
+    bool connect() override;
+    void disconnect() override;
+    void update() override;
+
+private:
+    NimBLERemoteService* service = nullptr;
+    NimBLERemoteCharacteristic* dataCharacteristic = nullptr;
+    NimBLERemoteCharacteristic* writeCharacteristic = nullptr;
+    uint32_t lastHeartbeat = 0;
+    bool markedForReconnection = false;
+
+    void notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify);
+    bool performConnectionHandshake();
+    void toggleUnit();
+    void togglePrecision();
+    bool verifyConnected(void);
+    void parseStatusUpdate(const uint8_t* data, size_t length);
+    uint8_t calculateChecksum(const uint8_t* data, size_t length);
+    int32_t parseWeight(const uint8_t* data);
+
+    // Constants specific to myscale Scales
+    static const NimBLEUUID DATA_SERVICE_UUID;
+    static const NimBLEUUID DATA_CHARACTERISTIC_UUID;
+    static const NimBLEUUID WRITE_CHARACTERISTIC_UUID;
+};
+
+
+class myscalePlugin {
+public:
+    static void apply() {
+        RemoteScalesPlugin plugin;
+        plugin.id = "plugin-myscale";
+        plugin.handles = &myscalePlugin::handles;
+        plugin.initialise = &myscalePlugin::initialise;
+        RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+    }
+
+private:
+    static bool handles(const DiscoveredDevice& device) {
+        const std::string& deviceName = device.getName();
+        return !deviceName.empty() && (deviceName.find("blackcoffee") == 0 || deviceName.find("my_scale") == 0 || deviceName.find("MY_SCALE") == 0);
+    }
+
+    static std::unique_ptr<RemoteScales> initialise(const DiscoveredDevice& device) {
+        return std::make_unique<myscale>(device);
+    }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/timemore.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/timemore.cpp
@@ -1,0 +1,193 @@
+#include "timemore.h"
+#include "remote_scales_plugin_registry.h"
+
+
+enum class TimemoreEventType : uint8_t {
+  WEIGHT = 0x10,
+};
+
+const size_t RECEIVE_PROTOCOL_LENGTH = 9;
+
+const NimBLEUUID serviceUUID("181D");
+const NimBLEUUID weightCharacteristicUUID("2A9D");
+const NimBLEUUID commandCharacteristicUUID("553f4e49-bf21-4468-9c6c-0e4fb5b17697");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+TimemoreScales::TimemoreScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool TimemoreScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+  subscribeToNotifications();
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void TimemoreScales::disconnect() {
+  RemoteScales::clientCleanup();
+}
+
+bool TimemoreScales::isConnected() {
+  return RemoteScales::clientIsConnected();
+}
+
+void TimemoreScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    connect();
+    markedForReconnection = false;
+  }
+  else {
+    sendHeartbeat();
+  }
+}
+
+bool TimemoreScales::tare() {
+  if (!isConnected()) return false;
+  uint8_t payload[] = { 0x00 };
+  sendMessage(TimemoreMessageType::TARE, payload, sizeof(payload));
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+void TimemoreScales::notifyCallback(
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+  uint8_t* pData,
+  size_t length,
+  bool isNotify
+) {
+  dataBuffer.insert(dataBuffer.end(), pData, pData + length);
+  bool result = true;
+  while (result) {
+    result = decodeAndHandleNotification();
+  }
+}
+
+bool TimemoreScales::decodeAndHandleNotification() {
+  // Minimum message length check
+  if (dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH) {
+    return false;
+  }
+
+  // Handle different message types
+  TimemoreEventType messageType = static_cast<TimemoreEventType>(dataBuffer[0]);
+  if (messageType == TimemoreEventType::WEIGHT) {
+    // 10 78 08 00 00 78 08 00 00
+    //   |___________|___________|
+    // Dripper Weight|Scale Weight
+    // Both are little-endian 32-bit integer
+    // E.g. 78 08 00 00 = 2168 / 10 = 216.8g
+
+    //float_t dripperWeight = dataBuffer[1] | (dataBuffer[2] << 8) | (dataBuffer[3] << 16) | (dataBuffer[4] << 24);
+    float_t scaleWeight = dataBuffer[5] | (dataBuffer[6] << 8) | (dataBuffer[7] << 16) | (dataBuffer[8] << 24);
+
+    RemoteScales::setWeight(scaleWeight / 10.0f); // Convert to floating point
+  }
+  else {
+    RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), dataBuffer.size()).c_str());
+  }
+
+  // Remove processed message from the buffer
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + RECEIVE_PROTOCOL_LENGTH);
+
+  // Return whether there's more data to process
+  return dataBuffer.size() >= RECEIVE_PROTOCOL_LENGTH;
+}
+
+bool TimemoreScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  service = RemoteScales::clientGetService(serviceUUID);
+  if (service != nullptr) {
+    RemoteScales::log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got Service\n");
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+
+  if (weightCharacteristic == nullptr || commandCharacteristic == nullptr) {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
+
+  // Subscribe
+  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+  RemoteScales::log("Got notifyDescriptor\n");
+  if (notifyDescriptor != nullptr) {
+    uint8_t value[2] = { 0x01, 0x00 };
+    notifyDescriptor->writeValue(value, 2, true);
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  sendNotificationRequest();
+  RemoteScales::log("Sent notification request\n");
+  lastHeartbeat = millis();
+  return true;
+}
+
+void TimemoreScales::sendNotificationRequest() {
+  uint8_t payload[] = { 0x02, 0x00 };
+  sendMessage(TimemoreMessageType::WEIGHT, payload, 2);
+}
+
+void TimemoreScales::sendHeartbeat() {
+  if (!isConnected()) {
+    return;
+  }
+
+  uint32_t now = millis();
+  if (now - lastHeartbeat < 2000) {
+    return;
+  }
+
+  uint8_t payload[] = { 0x00 };
+  sendMessage(TimemoreMessageType::WEIGHT, payload, 1);
+  lastHeartbeat = now;
+}
+
+void TimemoreScales::subscribeToNotifications() {
+  RemoteScales::log("subscribeToNotifications\n");
+
+  auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(characteristic, data, length, isNotify);
+  };
+
+  if (weightCharacteristic->canIndicate()) {
+    weightCharacteristic->subscribe(false, callback, true);
+  }
+}
+
+void TimemoreScales::sendMessage(TimemoreMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse) {
+  if (msgType == TimemoreMessageType::TARE) {
+    commandCharacteristic->writeValue(payload, length, true);
+  } else if (msgType == TimemoreMessageType::WEIGHT) {
+    weightCharacteristic->writeValue(payload, length, true);
+  }
+}

--- a/lib/esp-arduino-ble-scales/src/scales/timemore.h
+++ b/lib/esp-arduino-ble-scales/src/scales/timemore.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEScan.h>
+#include <vector>
+#include <memory>
+
+enum class TimemoreMessageType : uint8_t {
+  WEIGHT = 0x00,
+  TARE = 0x01,
+};
+
+class TimemoreScales : public RemoteScales {
+
+public:
+  TimemoreScales(const DiscoveredDevice& device);
+  void update() override;
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  uint32_t lastHeartbeat = 0;
+
+  bool markedForReconnection = false;
+
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  std::vector<uint8_t> dataBuffer;
+
+  bool performConnectionHandshake();
+  void subscribeToNotifications();
+
+  void sendMessage(TimemoreMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendHeartbeat();
+  void sendNotificationRequest();
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+  bool decodeAndHandleNotification();
+};
+
+class TimemoreScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-timemore",
+      .handles = [](const DiscoveredDevice& device) { return TimemoreScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<TimemoreScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() && (deviceName.find("Timemore Scale") == 0);
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/varia.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/varia.cpp
@@ -1,0 +1,201 @@
+#include "varia.h"
+#include "remote_scales_plugin_registry.h"
+
+const NimBLEUUID serviceUUID("FFF0");
+const NimBLEUUID weightCharacteristicUUID("FFF1");
+const NimBLEUUID commandCharacteristicUUID("FFF2");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+
+VariaScales::VariaScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool VariaScales::connect() {
+  if (clientIsConnected()) {
+    log("Already connected\n");
+    return true;
+  }
+
+  if (!clientConnect()) {
+    clientCleanup();
+    return false;
+  }
+
+  if (!fetchServices()) {
+    return false;
+  }
+
+  setWeight(0.f);
+
+  subscribeToNotifications();
+
+  return true;
+}
+
+void VariaScales::disconnect() {
+  clientCleanup();
+}
+
+bool VariaScales::isConnected() {
+  return clientIsConnected();
+}
+
+bool VariaScales::tare() {
+  if (!isConnected()) return false;
+  log("Sending tare command\n");
+  uint8_t cmd = static_cast<uint8_t>(VariaMessageType::TARE);
+  uint8_t payload[] = { cmd, 0x01, 0x01 };
+  sendMessage(VariaMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+
+bool VariaScales::fetchServices() {
+  service = clientGetService(serviceUUID);
+  if (service != nullptr) {
+    log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  if (weightCharacteristic != nullptr && commandCharacteristic != nullptr) {
+    log("Got Weight and Command Characteristics\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  return true;
+}
+
+void VariaScales::subscribeToNotifications() {
+  auto callback = [this](NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(pRemoteCharacteristic, data, length, isNotify);
+  };
+
+  if (weightCharacteristic->canNotify()) {
+    log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+}
+
+void VariaScales::sendMessage(VariaMessageType msgType, const uint8_t* payload, size_t payloadLen, bool waitResponse) {
+  uint8_t checksum = payload[0];
+  for (size_t i = 1; i < payloadLen; i++) {
+    checksum ^= payload[i];
+  }
+
+  const size_t msgLen = 1 + payloadLen + 1;
+
+  auto bytes = std::make_unique<uint8_t[]>(msgLen);
+
+  bytes[0] = static_cast<uint8_t>(msgType);
+  memcpy(bytes.get()+1, payload, payloadLen);
+  bytes[msgLen - 1] = checksum;
+
+  commandCharacteristic->writeValue(bytes.get(), msgLen, waitResponse);
+}
+
+void VariaScales::notifyCallback(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* data, size_t length, bool isNotify) {
+  if(length < 2) {
+    log("notifyCallback: message too short, expected at least 2 bytes, got: %s\n", byteArrayToHexString(data, length).c_str());
+    return;
+  }
+  if(data[0] != static_cast<uint8_t>(VariaMessageType::SYSTEM)) {
+    log("notifyCallback: Only system type messages are supported: %s\n", byteArrayToHexString(data, length).c_str());
+    return;
+  }
+
+  while(length > 0) {
+    VariaMessageType messageType = static_cast<VariaMessageType>(data[1]);
+
+    switch(messageType) {
+    case VariaMessageType::WEIGHT:
+    {
+      // [FA 01] 03 10 02 CD {DD}
+      const size_t msgLen = 7;
+      if(! validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      int sign = (data[3] & 0x10) == 0 ? 1 : -1;
+      int value = ((data[3] & 0x0f) << 16) + (data[4] << 8) + data[5];
+      setWeight(sign * value * 0.01f);
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::TIMER:
+    {
+      // [FA 87] 02 00 02 {87}
+      const size_t msgLen = 6;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      timerSeconds = (data[3] << 8) + data[4];
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::TIMER_START:
+    case VariaMessageType::TIMER_STOP:
+    case VariaMessageType::TIMER_RESET:
+    {
+      // [FA 88] 01 01 {88}
+      // [FA 89] 01 02 {8A}
+      // [FA 8A] 01 03 {88}
+      const size_t msgLen = 5;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      log("Timer event: %02x\n", data[1]);
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::BATTERY:
+    {
+      // [FA 85] 01 4B {CF}
+      const size_t msgLen = 5;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      batteryPercent = data[3];
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    default:
+      // log("Unknown message type %02X: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+      return;
+    }
+  }
+}
+
+bool VariaScales::validNotifiedMessage(uint8_t* data, size_t length, size_t expectedLength) {
+  if(length < expectedLength) {
+    return false;
+  }
+
+  const size_t xorFirst = 1;
+  const size_t xorLast = expectedLength - 2;
+  const size_t xorExpected = expectedLength - 1;
+
+  uint8_t sum = data[xorFirst];
+  for(size_t idx = xorFirst+1; idx <= xorLast; idx++) {
+    sum ^= data[idx];
+  }
+  return sum == data[xorExpected];
+}

--- a/lib/esp-arduino-ble-scales/src/scales/varia.h
+++ b/lib/esp-arduino-ble-scales/src/scales/varia.h
@@ -1,0 +1,64 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+
+enum class VariaMessageType : uint8_t {
+  SYSTEM = 0xFA,
+  WEIGHT = 0x01,
+  TARE = 0x82,
+  BATTERY = 0x85,
+  TIMER = 0x87,
+  TIMER_START = 0x88,
+  TIMER_STOP = 0x89,
+  TIMER_RESET = 0x8a,
+};
+
+class VariaScales : public RemoteScales {
+
+public:
+  VariaScales(const DiscoveredDevice& device);
+  void update() override {};
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  NimBLERemoteService* service = nullptr;
+  NimBLERemoteCharacteristic* weightCharacteristic = nullptr;
+  NimBLERemoteCharacteristic* commandCharacteristic = nullptr;
+
+  int batteryPercent = 0;
+  int timerSeconds = 0;
+
+  bool fetchServices();
+  void subscribeToNotifications();
+
+  void sendMessage(VariaMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+
+  bool validNotifiedMessage(uint8_t* data, size_t length, size_t expectedLength);
+};
+
+class VariaScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-varia",
+      .handles = [](const DiscoveredDevice& device) { return VariaScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<VariaScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() &&
+      (
+        deviceName.find("AKU MINI SCALE") == 0 ||
+        deviceName.find("VARIA AKU") == 0 ||
+        deviceName.find("Varia AKU") == 0 ||
+        deviceName.find("AKU SCALE") == 0
+      );
+  }
+};

--- a/lib/esp-arduino-ble-scales/src/scales/weighmybru.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/weighmybru.cpp
@@ -156,18 +156,6 @@ bool WeighMyBrewScales::performConnectionHandshake() {
   }
   RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
 
-  // Subscribe
-  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
-  RemoteScales::log("Got notifyDescriptor\n");
-  if (notifyDescriptor != nullptr) {
-    uint8_t value[2] = { 0x00, 0x01 };
-    notifyDescriptor->writeValue(value, 2, true);
-  }
-  else {
-    clientCleanup();
-    return false;
-  }
-
   sendNotificationRequest();
   RemoteScales::log("Sent notification request\n");
   lastHeartbeat = millis();

--- a/lib/esp-arduino-ble-scales/src/scales/weighmybru.cpp
+++ b/lib/esp-arduino-ble-scales/src/scales/weighmybru.cpp
@@ -1,0 +1,244 @@
+#include "weighmybru.h"
+#include "remote_scales_plugin_registry.h"
+
+/*
+Handle protocol for WeighMyBru scale
+*/
+const size_t RECEIVE_PROTOCOL_LENGTH = 20;
+
+const NimBLEUUID serviceUUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
+const NimBLEUUID weightCharacteristicUUID("6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
+const NimBLEUUID commandCharacteristicUUID("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+WeighMyBrewScales::WeighMyBrewScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool WeighMyBrewScales::connect() {
+  if (RemoteScales::clientIsConnected()) {
+    RemoteScales::log("Already connected\n");
+    return true;
+  }
+
+  RemoteScales::log("Connecting to %s[%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+  bool result = RemoteScales::clientConnect();
+  if (!result) {
+    RemoteScales::clientCleanup();
+    return false;
+  }
+
+  if (!performConnectionHandshake()) {
+    return false;
+  }
+  subscribeToNotifications();
+  RemoteScales::setWeight(0.f);
+  return true;
+}
+
+void WeighMyBrewScales::disconnect() {
+  RemoteScales::clientCleanup();
+}
+
+bool WeighMyBrewScales::isConnected() {
+  return RemoteScales::clientIsConnected();
+}
+
+void WeighMyBrewScales::update() {
+  if (markedForReconnection) {
+    RemoteScales::log("Marked for disconnection. Will attempt to reconnect.\n");
+    RemoteScales::clientCleanup();
+    connect();
+    markedForReconnection = false;
+  }
+  else {
+    sendHeartbeat();
+    RemoteScales::log("Heartbeat sent.\n");
+  }
+}
+
+bool WeighMyBrewScales::tare() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Tare sent");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x01, 0x01, 0x00, 0x08 };
+  sendMessage(WeighMyBrewMessageType::SYSTEM, payload, sizeof(payload));
+
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+void WeighMyBrewScales::notifyCallback(
+  NimBLERemoteCharacteristic* pBLERemoteCharacteristic,
+  uint8_t* pData,
+  size_t length,
+  bool isNotify
+) {
+  dataBuffer.insert(dataBuffer.end(), pData, pData + length);
+  bool result = true;
+  while (result) {
+    result = decodeAndHandleNotification();
+  }
+}
+
+/*
+Handle WeighMyBru protocol
+*/
+bool WeighMyBrewScales::decodeAndHandleNotification() {
+  // Minimum message length check (20 bytes based on protocol definition)
+  if (dataBuffer.size() < RECEIVE_PROTOCOL_LENGTH) {
+    return false;
+  }
+
+  WeighMyBrewMessageType messageType = static_cast<WeighMyBrewMessageType>(dataBuffer[1]);
+  uint8_t productNumber = dataBuffer[0];
+
+  const size_t messageLength = RECEIVE_PROTOCOL_LENGTH;
+
+  // Handle different message types
+  if (productNumber == 0x03 && messageType == WeighMyBrewMessageType::WEIGHT) {
+    // Checksum validation: XOR of Header1 ^ Header2 ^ Data0 ^ Data1 ^ ... ^ DataN should equal DataSUM
+    uint8_t checksum = dataBuffer[0];
+    for (size_t i = 1; i < messageLength - 1; i++) {
+      checksum ^= dataBuffer[i];
+    }
+
+    // The last byte in the message is DataSUM
+    uint8_t dataSUM = dataBuffer[messageLength - 1];
+
+    if (checksum != dataSUM) {
+      RemoteScales::log("Checksum failed: calc[%02X] but actual[%02X]. Discarding.\n",
+        checksum, dataSUM);
+      dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
+      return false;
+    }
+
+    float weight = (dataBuffer[7] << 16) | (dataBuffer[8] << 8) | dataBuffer[9];
+
+    if (dataBuffer[6] == 45) { // Check if the value is negative
+      weight = -weight;
+    }
+
+    RemoteScales::setWeight(weight * 0.01f); // Convert to floating point
+  }
+  else if (productNumber == 0x03 && messageType == WeighMyBrewMessageType::SYSTEM) {
+    WeighMyBrewScales::tare();
+  }
+  else {
+    RemoteScales::log("Unknown message type %02X: %s\n", messageType, RemoteScales::byteArrayToHexString(dataBuffer.data(), messageLength).c_str());
+  }
+
+    // Remove processed message from the buffer
+  dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + messageLength);
+
+    // Return whether there's more data to process
+  return dataBuffer.size() >= RECEIVE_PROTOCOL_LENGTH;
+}
+
+bool WeighMyBrewScales::performConnectionHandshake() {
+  RemoteScales::log("Performing handshake\n");
+
+  service = RemoteScales::clientGetService(serviceUUID);
+  if (service != nullptr) {
+    RemoteScales::log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  if (weightCharacteristic == nullptr || commandCharacteristic == nullptr) {
+    clientCleanup();
+    return false;
+  }
+  RemoteScales::log("Got weightCharacteristic and commandCharacteristic\n");
+
+  // Subscribe
+  NimBLERemoteDescriptor* notifyDescriptor = weightCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+  RemoteScales::log("Got notifyDescriptor\n");
+  if (notifyDescriptor != nullptr) {
+    uint8_t value[2] = { 0x00, 0x01 };
+    notifyDescriptor->writeValue(value, 2, true);
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  sendNotificationRequest();
+  RemoteScales::log("Sent notification request\n");
+  lastHeartbeat = millis();
+  return true;
+}
+
+void WeighMyBrewScales::sendNotificationRequest() {
+  uint8_t payload[] = { 0, 0, 0, 0, 0, 0 };
+  sendEvent(payload, 6);
+  RemoteScales::log("Sent event.\n");
+}
+
+void WeighMyBrewScales::sendEvent(const uint8_t* payload, size_t length) {
+  auto bytes = std::make_unique<uint8_t[]>(length + 1);
+  bytes[0] = static_cast<uint8_t>(length + 1);
+
+  for (size_t i = 0; i < length; ++i) {
+    bytes[i + 1] = payload[i] & 0xFF;
+  }
+
+  sendMessage(WeighMyBrewMessageType::SYSTEM, bytes.get(), length + 1);
+}
+
+void WeighMyBrewScales::sendHeartbeat() {
+  if (!isConnected()) {
+    return;
+  }
+
+  uint32_t now = millis();
+  if (now - lastHeartbeat < 2000) {
+    return;
+  }
+
+  uint8_t payload1[] = { 0x02,0x00 };
+  sendMessage(WeighMyBrewMessageType::SYSTEM, payload1, 2);
+  sendNotificationRequest();
+  uint8_t payload2[] = { 0x00 };
+  sendMessage(WeighMyBrewMessageType::SYSTEM, payload2, 1);
+  lastHeartbeat = now;
+}
+
+void WeighMyBrewScales::subscribeToNotifications() {
+  RemoteScales::log("subscribeToNotifications\n");
+
+  auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(characteristic, data, length, isNotify);
+    };
+
+  if (weightCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+
+  if (commandCharacteristic->canNotify()) {
+    RemoteScales::log("Registering callback for command characteristic\n");
+    commandCharacteristic->subscribe(true, callback);
+  }
+}
+
+void WeighMyBrewScales::sendMessage(WeighMyBrewMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse) {
+
+  auto bytes = std::make_unique<uint8_t[]>(length);
+
+  memcpy(bytes.get(), payload, length);
+
+  // Checksum Calculation (XOR of all bytes except checksum byte)
+  uint8_t checksum = bytes[0];
+  for (size_t i = 1; i < length - 1; i++) {
+    checksum ^= bytes[i];
+  }
+  bytes[length - 1] = checksum;
+
+  commandCharacteristic->writeValue(bytes.get(), length, waitResponse);
+}

--- a/lib/esp-arduino-ble-scales/src/scales/weighmybru.h
+++ b/lib/esp-arduino-ble-scales/src/scales/weighmybru.h
@@ -1,0 +1,67 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEScan.h>
+#include <vector>
+#include <memory>
+
+enum class WeighMyBrewMessageType : uint8_t {
+  SYSTEM = 0x0A,
+  WEIGHT = 0x0B
+};
+
+class WeighMyBrewScales : public RemoteScales {
+
+public:
+  WeighMyBrewScales(const DiscoveredDevice& device);
+  void update() override;
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  std::string weightUnits;
+  float time;
+  uint8_t battery;
+
+  uint32_t lastHeartbeat = 0;
+
+  bool markedForReconnection = false;
+
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  std::vector<uint8_t> dataBuffer;
+
+  bool performConnectionHandshake();
+  void subscribeToNotifications();
+
+  void sendMessage(WeighMyBrewMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void sendEvent(const uint8_t* payload, size_t length);
+  void sendHeartbeat();
+  void sendNotificationRequest();
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+  bool decodeAndHandleNotification();
+};
+
+class WeighMyBrewScalePlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-weighmybrew",
+      .handles = [](const DiscoveredDevice& device) { return WeighMyBrewScalePlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<WeighMyBrewScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() && (deviceName.find("WeighMyBru") == 0);
+  }
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,9 @@ lib_deps_default =
     https://github.com/ESP32Async/ESPAsyncWebServer.git#v3.9.1
     bblanchon/ArduinoJson@^7.2.1
     256dpi/MQTT@^2.5.2
-    https://github.com/gaggimate/esp-arduino-ble-scales
+    ; esp-arduino-ble-scales is vendored in lib/ (see that directory's README);
+    ; local copy is used instead of the remote registry entry while we iterate on
+    ; Bookoo-specific enhancements. Long-term these should be contributed upstream.
     homespan/HomeSpan@1.9.1
 
 [env:display]

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -364,6 +364,16 @@ bool Controller::isAutotuning() const { return autotuning; }
 bool Controller::isReady() const { return !isUpdating() && !isErrorState() && !isAutotuning(); }
 
 bool Controller::isVolumetricAvailable() const {
+    // Safety gate: if the BLE scale is physically toggled to ounces, its weight
+    // samples are ~28x off from grams -- volumetric stops would either fire
+    // immediately (target 36g reached at v=1.3 "oz" which is actually 36.8g) or
+    // never fire (target 36g but scale values never exceed a few units). Either
+    // way the shot would be silently wrong. Refuse volumetric routing when the
+    // unit is explicitly ounces. UNKNOWN (driver doesn't parse unit) is treated
+    // as GRAM for backwards compatibility with scales that don't report it.
+    if (BLEScales.hasWeightUnit() && BLEScales.getWeightUnit() == ScaleWeightUnit::OUNCE) {
+        return false;
+    }
 #ifdef NIGHTLY_BUILD
     return isBluetoothScaleHealthy() || systemInfo.capabilities.dimming;
 #else

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -25,23 +25,28 @@ BLEScalePlugin BLEScales;
 
 BLEScalePlugin::BLEScalePlugin() = default;
 
-BLEScalePlugin::~BLEScalePlugin() {
-    // Disable active flag first to stop processing
-    active = false;
+BLEScalePlugin::~BLEScalePlugin() noexcept {
+    try {
+        // Disable active flag first to stop processing
+        active = false;
 
-    // Give any running callbacks time to complete
-    delay(100);
+        // Give any running callbacks time to complete
+        delay(100);
 
-    // Ensure proper cleanup
-    disconnect();
+        // Ensure proper cleanup
+        disconnect();
 
-    if (scanner != nullptr) {
-        // Stop scanning first
-        scanner->stopAsyncScan();
-        // Give it time to actually stop
-        delay(50);
-        delete scanner;
-        scanner = nullptr;
+        if (scanner != nullptr) {
+            // Stop scanning first
+            scanner->stopAsyncScan();
+            // Give it time to actually stop
+            delay(50);
+            delete scanner;
+            scanner = nullptr;
+        }
+    } catch (...) {
+        // Swallow: destructors must not propagate exceptions.
+        // NimBLE + Arduino delay() calls don't throw in practice; belt-and-braces.
     }
 }
 

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -52,6 +52,7 @@ void BLEScalePlugin::setup(Controller *controller, PluginManager *manager) {
     }
 
     this->controller = controller;
+    this->pluginManager = manager;
     this->pluginRegistry = RemoteScalesPluginRegistry::getInstance();
 
     // Apply scale plugins with error checking
@@ -149,6 +150,10 @@ void BLEScalePlugin::update() {
                     scanner->initializeAsyncScan();
                 }
             }
+        } else {
+            // Poll slow-changing metadata (battery, unit). Flow rate is
+            // emitted inline with each weight measurement, not polled here.
+            pollScaleMetadata();
         }
     } else if (controller->getSettings().getSavedScale() != "" && scanner != nullptr) {
         // Protected scanner access with null checks
@@ -203,6 +208,10 @@ void BLEScalePlugin::disconnect() {
         uuid = "";
         doConnect = false;
         reconnectionTries = 0;
+        // Reset metadata caches so we re-emit change events when a new scale
+        // connects (possibly a different model with different capabilities).
+        lastBatteryLevel = REMOTE_SCALES_BATTERY_UNKNOWN;
+        lastWeightUnit = ScaleWeightUnit::UNKNOWN;
     }
 }
 
@@ -319,6 +328,44 @@ void BLEScalePlugin::onMeasurement(float value) const {
 
     // Safe to call controller method
     controller->onVolumetricMeasurement(value, VolumetricMeasurementSource::BLUETOOTH);
+
+    // If the scale driver also provides native flow rate (e.g. Bookoo), emit
+    // it on the same tick so consumers get it at the scale's native cadence
+    // (~10 Hz) without having to poll. Controller.onVolumetricMeasurement
+    // updates lastBluetoothMeasurement timestamps as a side effect; we reuse
+    // a lighter path here since flow is not gating shot state.
+    if (scale != nullptr && scale->hasFlowRate() && pluginManager != nullptr) {
+        pluginManager->trigger(
+            "controller:volumetric-measurement:scale-flow:change",
+            "value", scale->getFlowRate());
+    }
+}
+
+void BLEScalePlugin::pollScaleMetadata() {
+    if (scale == nullptr || !scale->isConnected() || pluginManager == nullptr) {
+        return;
+    }
+    auto *pm = pluginManager;
+
+    // Battery % -- fire event only on change so consumers can subscribe without
+    // being hammered at 1 Hz with duplicate values.
+    if (scale->hasBatteryLevel()) {
+        const uint8_t pct = scale->getBatteryLevel();
+        if (pct != lastBatteryLevel && pct != REMOTE_SCALES_BATTERY_UNKNOWN) {
+            lastBatteryLevel = pct;
+            pm->trigger("scale:battery:change", "value", static_cast<int>(pct));
+        }
+    }
+
+    // Weight unit -- fire once when we first learn the unit, then only when
+    // the user switches unit on the scale physically (rare).
+    if (scale->hasWeightUnit()) {
+        const ScaleWeightUnit u = scale->getWeightUnit();
+        if (u != lastWeightUnit && u != ScaleWeightUnit::UNKNOWN) {
+            lastWeightUnit = u;
+            pm->trigger("scale:weight-unit:change", "value", static_cast<int>(u));
+        }
+    }
 }
 
 std::vector<DiscoveredDevice> BLEScalePlugin::getDiscoveredScales() const {

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -89,6 +89,11 @@ void BLEScalePlugin::setup(Controller *controller, PluginManager *manager) {
         scanner->stopAsyncScan();
     });
     manager->on("controller:brew:prestart", [this](Event const &) { onProcessStart(); });
+    manager->on("controller:brew:end", [this](Event const &) {
+        if (scale != nullptr && scale->isConnected() && scale->hasTimerControl()) {
+            scale->stopTimer();
+        }
+    });
     manager->on("controller:grind:start", [this](Event const &) { onProcessStart(); });
     manager->on("controller:mode:change", [this](Event const &event) {
         if (event.getInt("value") != MODE_STANDBY) {

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -212,6 +212,7 @@ void BLEScalePlugin::disconnect() {
         // connects (possibly a different model with different capabilities).
         lastBatteryLevel = REMOTE_SCALES_BATTERY_UNKNOWN;
         lastWeightUnit = ScaleWeightUnit::UNKNOWN;
+        warnedOunceMidBrew = false;
     }
 }
 
@@ -324,6 +325,26 @@ void BLEScalePlugin::onMeasurement(float value) const {
     if (!isfinite(value) || value < -1000.0f || value > 10000.0f) {
         ESP_LOGW("BLEScalePlugin", "Invalid measurement value: %f, ignoring", value);
         return;
+    }
+
+    // Mid-shot unit-flip guard: the shot-start guard in
+    // Controller::isVolumetricAvailable() only covers entry into the shot.
+    // If the user physically toggles the scale to ounces *during* a brew,
+    // weight samples drop ~28x and the volumetric target is never hit --
+    // shot would then run until the time-safety cutoff. Detect oz per-sample
+    // and disable volumetric routing so the remainder of the shot falls
+    // through to time-based stop.
+    if (scale != nullptr && scale->hasWeightUnit() && scale->getWeightUnit() == ScaleWeightUnit::OUNCE) {
+        if (controller->isActive() && !warnedOunceMidBrew) {
+            ESP_LOGW("BLEScalePlugin",
+                     "Scale switched to oz mid-brew -- aborting volumetric, falling back to time stop");
+            warnedOunceMidBrew = true;
+        }
+        controller->setVolumetricOverride(false);
+    } else {
+        // Unit returned to grams (or is unknown again) -- re-arm the latch
+        // so a subsequent flip back to oz warns again.
+        warnedOunceMidBrew = false;
     }
 
     // Safe to call controller method

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -81,6 +81,11 @@ class BLEScalePlugin : public Plugin {
     uint8_t lastBatteryLevel = REMOTE_SCALES_BATTERY_UNKNOWN;
     ScaleWeightUnit lastWeightUnit = ScaleWeightUnit::UNKNOWN;
 
+    // Latch so the mid-brew oz warning + volumetric abort fires once per
+    // transition into ounces, not once per sample at ~10 Hz. Reset on
+    // disconnect and when the unit returns to grams.
+    mutable bool warnedOunceMidBrew = false;
+
     // Rate limiting for callbacks
     mutable unsigned long lastMeasurementTime = 0;
     static constexpr unsigned long MIN_MEASUREMENT_INTERVAL_MS = 10; // Max 100 measurements per second

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -12,7 +12,7 @@ constexpr unsigned int RECONNECTION_TRIES = 15;
 class BLEScalePlugin : public Plugin {
   public:
     BLEScalePlugin();
-    ~BLEScalePlugin();
+    ~BLEScalePlugin() noexcept;
 
     void setup(Controller *controller, PluginManager *pluginManager) override;
     void loop() override;

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -45,9 +45,25 @@ class BLEScalePlugin : public Plugin {
     std::vector<DiscoveredDevice> getDiscoveredScales() const;
     void tare() const;
 
+    // Accessors for the native scale fields that drivers optionally expose
+    // (see RemoteScales). Each returns a sentinel value if not supported.
+    float getFlowRate() const { return scale != nullptr && scale->hasFlowRate() ? scale->getFlowRate() : 0.0f; }
+    bool hasFlowRate() const { return scale != nullptr && scale->hasFlowRate(); }
+    uint8_t getBatteryLevel() const {
+        return scale != nullptr && scale->hasBatteryLevel() ? scale->getBatteryLevel() : REMOTE_SCALES_BATTERY_UNKNOWN;
+    }
+    bool hasBatteryLevel() const { return scale != nullptr && scale->hasBatteryLevel(); }
+    ScaleWeightUnit getWeightUnit() const {
+        return scale != nullptr && scale->hasWeightUnit() ? scale->getWeightUnit() : ScaleWeightUnit::UNKNOWN;
+    }
+    uint32_t getScaleTimerMs() const {
+        return scale != nullptr && scale->hasScaleTimer() ? scale->getScaleTimerMs() : 0;
+    }
+
   private:
     void update();
     void onProcessStart() const;
+    void pollScaleMetadata();
 
     void establishConnection();
 
@@ -58,11 +74,17 @@ class BLEScalePlugin : public Plugin {
     unsigned long lastUpdate = 0;
     unsigned int reconnectionTries = 0;
 
+    // Cached scale-metadata values used to avoid firing an event for each
+    // unchanged poll tick. Reset when the scale disconnects.
+    uint8_t lastBatteryLevel = REMOTE_SCALES_BATTERY_UNKNOWN;
+    ScaleWeightUnit lastWeightUnit = ScaleWeightUnit::UNKNOWN;
+
     // Rate limiting for callbacks
     mutable unsigned long lastMeasurementTime = 0;
     static constexpr unsigned long MIN_MEASUREMENT_INTERVAL_MS = 10; // Max 100 measurements per second
 
     Controller *controller = nullptr;
+    PluginManager *pluginManager = nullptr;
     RemoteScalesPluginRegistry *pluginRegistry = nullptr;
     RemoteScalesScanner *scanner = nullptr;
     std::unique_ptr<RemoteScales> scale = nullptr;

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -61,6 +61,10 @@ class BLEScalePlugin : public Plugin {
         return scale != nullptr && scale->hasScaleTimer() ? scale->getScaleTimerMs() : 0;
     }
     bool hasScaleTimer() const { return scale != nullptr && scale->hasScaleTimer(); }
+    // Surface the scale's reported flow-smoothing state so the debug endpoint
+    // can verify our disableScaleSmoothing() command took. Drivers that don't
+    // track this return false by default (RemoteScales base impl).
+    bool isFlowSmoothingOn() const { return scale != nullptr && scale->isFlowSmoothingOn(); }
 
   private:
     void update();

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -56,9 +56,11 @@ class BLEScalePlugin : public Plugin {
     ScaleWeightUnit getWeightUnit() const {
         return scale != nullptr && scale->hasWeightUnit() ? scale->getWeightUnit() : ScaleWeightUnit::UNKNOWN;
     }
+    bool hasWeightUnit() const { return scale != nullptr && scale->hasWeightUnit(); }
     uint32_t getScaleTimerMs() const {
         return scale != nullptr && scale->hasScaleTimer() ? scale->getScaleTimerMs() : 0;
     }
+    bool hasScaleTimer() const { return scale != nullptr && scale->hasScaleTimer(); }
 
   private:
     void update();


### PR DESCRIPTION
Was debugging an unrelated brew-by-weight issue and dug into the Bookoo protocol spec ([mini](https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md), [ultra](https://github.com/BooKooCode/OpenSource/blob/main/bookoo_ultra_scale/protocols.md)) — realized the driver was throwing away ~80% of each 20-byte weight notification. This PR parses the rest and wires the useful fields through to the firmware.

> **Status (2026-04-19):** driver changes now upstream as [gaggimate/esp-arduino-ble-scales#29](https://github.com/gaggimate/esp-arduino-ble-scales/pull/29). This firmware PR will be rebased to consume the upstream library once that merges; the vendored copy here is transitional. Bug fixes from [@salekseev](https://github.com/salekseev)'s review are mirrored into both PRs. See the updated commit list below.

## What the Bookoo packet actually contains

Bytes 0-1 are the `0x03 0x0B` header. Bytes 2-4 are a scale-internal timer (ms). Byte 5 is weight unit (`0x01`=oz, `0x02`=g). Bytes 6-9 are the signed weight × 100. **Bytes 10-12 are signed flow rate × 100 (g/s) — scale computes it natively.** Byte 13 is battery %. 14-15 standby timer, 16 buzzer, 17 flow-smoothing-enabled. Byte 18 is "auto-mode stop condition" on Ultra, reserved on Mini. 19 is the XOR checksum.

Before this PR: only weight sign + weight were used. Everything else on the floor.

## Commands changed

- Tare: switched from `0x01` (plain tare) to **`0x07` (Tare + Start Timer)** — Bookoo's recommended command. It atomically resets weight AND marks the scale as "shot in progress", which prevents auto-sleep mid-brew. Firmware semantics unchanged (we don't consume scale timer yet).
- New `disableScaleSmoothing()` sends `0x08 0x00` on connect. The scale runs its own EMA on flow; `ShotHistoryPlugin` runs another EMA (α=0.25) on top of that. Double-smoothing is strictly worse than either alone — turning off the scale-side filter gives the firmware access to raw per-sample flow.

## Firmware plumbing

`RemoteScales` grows five optional accessors (`getFlowRate`, `getBatteryLevel`, `getScaleTimerMs`, `getWeightUnit`, `getAutoModeStopCondition`), each with a `hasX()` capability flag defaulting to false. Non-Bookoo drivers (Acaia, Decent, Felicita, Timemore, Varia, WeighMyBrew, MyScale, Difluid, Eclair, Eureka) compile unchanged — they just don't opt in.

`BLEScalePlugin` proxies the getters, emits `controller:volumetric-measurement:scale-flow:change` alongside each weight measurement (~10 Hz), and polls battery/unit at 1 Hz, firing `scale:battery:change` / `scale:weight-unit:change` only on value transitions.

`Controller::isVolumetricAvailable()` now returns false if the scale reports ounces. Raw values in oz mode are ~28× off — the volumetric stop would fire either immediately or never, and the shot would be silently wrong. `UNKNOWN` (driver doesn't parse unit) is treated as grams for backwards compat. `BLEScalePlugin::onMeasurement` also checks the unit per sample and aborts volumetric mid-shot if the user physically flips the scale to oz while brewing, falling through to time-based stop.

I deliberately left `hasAutoModeStopCondition()` returning false because byte 18 is reserved=0x00 on Mini but meaningful on Ultra, and there's no clean discovery path to tell them apart. Parsed into the accessor anyway so an Ultra-specific subclass could surface it later.

## Why the library is vendored (transitional)

The vendored copy under `lib/esp-arduino-ble-scales/` lets the driver changes be reviewed in the same diff as the firmware consumers that need them. The driver changes are now open upstream as [gaggimate/esp-arduino-ble-scales#29](https://github.com/gaggimate/esp-arduino-ble-scales/pull/29); once that merges, the vendored tree will be deleted and `platformio.ini` restored to use the upstream library. See `lib/esp-arduino-ble-scales/VENDORING.md` for details.

## Commits

**Original (landing the feature):**
- `d383301b` vendor the library
- `7d40345b` extend `RemoteScales` abstraction
- `59d84705` Bookoo driver: parse full notification + `0x07` tare + disable scale smoothing
- `fa4898c0` `BLEScalePlugin` exposes native fields and broadcasts events
- `3308c011` `Controller` refuses volumetric when scale is in ounce mode

**Review fixes ([@salekseev](https://github.com/salekseev) on 2026-04-19):**
- `56181186` `fix(bookoo): frame per call + erase processed + flip decode loop sentinel` (bug 1 + risk 4)
- `903eb31a` `fix(bookoo): ignore inbound SYSTEM instead of re-taring` (bug 2)
- `521f3d57` `refactor(bookoo): drop dead msgType param from sendMessage` (risk 6)
- `1d1413cb` `fix(remote_scales): virtual destructor for polymorphic unique_ptr` (bug 3)
- `7361a5c6` `fix(ble-scale): mid-shot ounce-mode abort via per-sample guard` (risk 5)
- `41b99e84` `docs(vendoring): reference upstream PR + correct stale commit hash`

**Scale-timer sync (follow-up feature from the same thread):**
- `f900e871` `feat(scales): add timer-control abstraction on RemoteScales base`
- `33fcae6f` `feat(scales/bookoo): implement startTimer/stopTimer/resetTimer`
- `dbab99c5` `feat(ble-scale): stop scale timer on brew end`

The timer wiring uses the existing `tare()` (0x07 = tare + start timer) at brew-prestart to start the scale's stopwatch, then calls `stopTimer()` (0x05) on `controller:brew:end` to freeze the final shot time on the scale's display. On Bookoo Ultra this requires the scale to be physically set to timing-mode (no BLE mode-switch command exists); Mini has no such restriction. Other drivers' `hasTimerControl()` defaults to false so they're unaffected.

## Hardware verification

Flashed on Gaggia Classic + GaggiMate Pro + Bookoo Themis Ultra. Shot #61 pulled **35.8g on a 36g target** (Decaf v5 profile, 1:2 ratio, 51.9s total). Volumetric routing triggers correctly, 5-phase profile runs clean, all the new `hasX()` capability flags report true, scale flow/battery/unit events emit as expected.

One gotcha worth flagging for anyone else touching the vendored library: `pio run -e display` is incremental and only rebuilds the files that changed. When the header's struct layout changes (new fields in `RemoteScales`), the library's `remote_scales.cpp.o` isn't rebuilt and still has the old layout — writes to the new fields then clobber unrelated memory, and BLE weight notifications silently stop reaching the display. **Always `pio run -e display -t clean` once after editing `remote_scales.h`** or you'll chase a ghost.

## Out of scope that I noted while writing this

- Shot log binary format bump for `svf` (scale-native flow) — touches the web UI decoder, better as its own PR.
- Web UI consumers for `scale:battery:change` etc. — events exist, hookup is future work.
- `UltraBookooScales` subclass to surface auto-mode stop condition safely.
- Three nits from the external review deferred to a follow-up PR: flow/unit events emitting at 10 Hz regardless of change, metadata getters polled at 10 Hz instead of 1 Hz, `disableScaleSmoothing` not resent after reconnect.
