### PR TITLE
feat: add water mode via simultaneous brew+steam button press

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ data/w
 .codebuddy
 src/version.h
 src/display/ui/default/lvgl/project.info
+Gaggimate.code-workspace

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -38,8 +38,7 @@ void GaggiMateController::setup() {
     } else {
         pump = new SimplePump(_config.pumpPin, _config.pumpOn, _config.capabilites.ssrPump ? 1000.0f : 5000.0f);
     }
-    this->brewBtn = new DigitalInput(_config.brewButtonPin, [this](const bool state) { _ble.sendBrewBtnState(state); });
-    this->steamBtn = new DigitalInput(_config.steamButtonPin, [this](const bool state) { _ble.sendSteamBtnState(state); });
+    this->buttonsInput = new DigitalInput(_config.brewButtonPin,_config.steamButtonPin,[this](const uint8_t buttonsStatus) { _ble.sendButtonsState(buttonsStatus); });
 
     // 4-Pin peripheral port
     if (!Wire.begin(_config.sunriseSdaPin, _config.sunriseSclPin, 400000)) {
@@ -69,8 +68,7 @@ void GaggiMateController::setup() {
     this->valve->setup();
     this->alt->setup();
     this->pump->setup();
-    this->brewBtn->setup();
-    this->steamBtn->setup();
+    this->buttonsInput->setup();
     if (_config.capabilites.pressure) {
         pressureSensor->setup();
         _ble.registerPressureScaleCallback([this](float scale) { this->pressureSensor->setScale(scale); });

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -38,7 +38,8 @@ void GaggiMateController::setup() {
     } else {
         pump = new SimplePump(_config.pumpPin, _config.pumpOn, _config.capabilites.ssrPump ? 1000.0f : 5000.0f);
     }
-    this->buttonsInput = new DigitalInput(_config.brewButtonPin,_config.steamButtonPin,[this](const uint8_t buttonsStatus) { _ble.sendButtonsState(buttonsStatus); });
+    this->buttonsInput = new DigitalInput(_config.brewButtonPin, _config.steamButtonPin,
+                                          [this](const uint8_t buttonsStatus) { _ble.sendButtonsState(buttonsStatus); });
 
     // 4-Pin peripheral port
     if (!Wire.begin(_config.sunriseSdaPin, _config.sunriseSclPin, 400000)) {

--- a/lib/GaggiMateController/src/GaggiMateController.h
+++ b/lib/GaggiMateController/src/GaggiMateController.h
@@ -43,8 +43,7 @@ class GaggiMateController {
     SimpleRelay *valve = nullptr;
     SimpleRelay *alt = nullptr;
     Pump *pump = nullptr;
-    DigitalInput *brewBtn = nullptr;
-    DigitalInput *steamBtn = nullptr;
+    DigitalInput *buttonsInput = nullptr;
     PressureSensor *pressureSensor = nullptr;
     LedController *ledController = nullptr;
     DistanceSensor *distanceSensor = nullptr;

--- a/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
+++ b/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
@@ -1,23 +1,47 @@
 #include "DigitalInput.h"
 
-DigitalInput::DigitalInput(uint8_t pin, const input_callback_t &callback) : _pin(pin), _callback(callback) {}
+// Single pin constructor
+DigitalInput::DigitalInput(uint8_t pin, const input_callback_t &callback)
+    : _pin1(pin), _singleCallback(callback) {}
+
+// Dual pin constructor
+DigitalInput::DigitalInput(uint8_t pin1, uint8_t pin2, const combined_callback_t &callback)
+    : _pin1(pin1), _pin2(pin2), _combinedCallback(callback) {}
 
 void DigitalInput::setup() {
-    pinMode(_pin, INPUT_PULLUP);
+    pinMode(_pin1, INPUT_PULLUP);
+    if (_pin2 != 255) {
+        pinMode(_pin2, INPUT_PULLUP);
+    }
     xTaskCreate(loopTask, "DigitalInput::loop", configMINIMAL_STACK_SIZE * 4, this, 1, &taskHandle);
 }
 
-void DigitalInput::loop() {
-    if (digitalRead(_pin) != _last_state) {
-        _last_state = digitalRead(_pin);
-        _callback(!_last_state);
+void DigitalInput::loopSingle() {
+    uint8_t current = !digitalRead(_pin1);
+    if (current != _lastState) {
+        _lastState = current;
+        _singleCallback(current); // active low — invert
+    }
+}
+
+void DigitalInput::loopCombined() {
+    uint8_t brew  = !digitalRead(_pin1); // active low
+    uint8_t steam = !digitalRead(_pin2); // active low
+    uint8_t current = (brew << 1) | steam;
+    if (current != _lastState) {
+        _lastState = current;
+        _combinedCallback(current);
     }
 }
 
 void DigitalInput::loopTask(void *arg) {
     auto *input = static_cast<DigitalInput *>(arg);
     while (true) {
-        input->loop();
+        if (input->_pin2 == 255) {
+            input->loopSingle();
+        } else {
+            input->loopCombined();
+        }
         vTaskDelay(INPUT_CHECK_INTERVAL_MS / portTICK_PERIOD_MS);
     }
 }

--- a/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
+++ b/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
@@ -1,8 +1,7 @@
 #include "DigitalInput.h"
 
 // Single pin constructor
-DigitalInput::DigitalInput(uint8_t pin, const input_callback_t &callback)
-    : _pin1(pin), _singleCallback(callback) {}
+DigitalInput::DigitalInput(uint8_t pin, const input_callback_t &callback) : _pin1(pin), _singleCallback(callback) {}
 
 // Dual pin constructor
 DigitalInput::DigitalInput(uint8_t pin1, uint8_t pin2, const combined_callback_t &callback)
@@ -25,7 +24,7 @@ void DigitalInput::loopSingle() {
 }
 
 void DigitalInput::loopCombined() {
-    uint8_t brew  = !digitalRead(_pin1); // active low
+    uint8_t brew = !digitalRead(_pin1);  // active low
     uint8_t steam = !digitalRead(_pin2); // active low
     uint8_t current = (brew << 1) | steam;
     if (current != _lastState) {

--- a/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
+++ b/lib/GaggiMateController/src/peripherals/DigitalInput.cpp
@@ -9,7 +9,7 @@ DigitalInput::DigitalInput(uint8_t pin1, uint8_t pin2, const combined_callback_t
 
 void DigitalInput::setup() {
     pinMode(_pin1, INPUT_PULLUP);
-    if (_pin2 != 255) {
+    if (_pin2 != PIN_NOT_CONFIGURED) {
         pinMode(_pin2, INPUT_PULLUP);
     }
     xTaskCreate(loopTask, "DigitalInput::loop", configMINIMAL_STACK_SIZE * 4, this, 1, &taskHandle);
@@ -36,7 +36,7 @@ void DigitalInput::loopCombined() {
 void DigitalInput::loopTask(void *arg) {
     auto *input = static_cast<DigitalInput *>(arg);
     while (true) {
-        if (input->_pin2 == 255) {
+        if (input->_pin2 == PIN_NOT_CONFIGURED) {
             input->loopSingle();
         } else {
             input->loopCombined();

--- a/lib/GaggiMateController/src/peripherals/DigitalInput.h
+++ b/lib/GaggiMateController/src/peripherals/DigitalInput.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 
 constexpr int INPUT_CHECK_INTERVAL_MS = 100;
+static constexpr uint8_t PIN_NOT_CONFIGURED = 255;
 
 using input_callback_t = std::function<void(const bool state)>;
 using combined_callback_t = std::function<void(const uint8_t state)>;
@@ -21,7 +22,7 @@ class DigitalInput {
 
   private:
     uint8_t _pin1;
-    uint8_t _pin2 = 255; // 255 = not used (single pin mode)
+    uint8_t _pin2 = PIN_NOT_CONFIGURED;
     uint8_t _lastState = 0;
     input_callback_t _singleCallback;
     combined_callback_t _combinedCallback;

--- a/lib/GaggiMateController/src/peripherals/DigitalInput.h
+++ b/lib/GaggiMateController/src/peripherals/DigitalInput.h
@@ -6,20 +6,31 @@
 constexpr int INPUT_CHECK_INTERVAL_MS = 100;
 
 using input_callback_t = std::function<void(const bool state)>;
+using combined_callback_t = std::function<void(const uint8_t state)>;
 
 class DigitalInput {
   public:
+    // Single pin constructor — original behavior
     DigitalInput(uint8_t pin, const input_callback_t &callback);
+
+    // Dual pin constructor — combined state
+    // state: 0b00=both released, 0b01=steam, 0b10=brew, 0b11=both
+    DigitalInput(uint8_t pin1, uint8_t pin2, const combined_callback_t &callback);
+
     void setup();
-    void loop();
 
   private:
-    uint8_t _pin;
-    uint8_t _last_state = HIGH;
+    uint8_t _pin1;
+    uint8_t _pin2 = 255; // 255 = not used (single pin mode)
+    uint8_t _lastState = 0;
+    input_callback_t _singleCallback;
+    combined_callback_t _combinedCallback;
     xTaskHandle taskHandle;
-    input_callback_t _callback;
 
-    const char *LOG_TAG = "Heater";
+    void loopSingle();
+    void loopCombined();
+
+    const char *LOG_TAG = "DigitalInput";
     static void loopTask(void *arg);
 };
 

--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -43,8 +43,7 @@ void NimBLEClientController::tare() {
 void NimBLEClientController::registerRemoteErrorCallback(const remote_err_callback_t &callback) {
     remoteErrorCallback = callback;
 }
-void NimBLEClientController::registerBrewBtnCallback(const brew_callback_t &callback) { brewBtnCallback = callback; }
-void NimBLEClientController::registerSteamBtnCallback(const brew_callback_t &callback) { steamBtnCallback = callback; }
+void NimBLEClientController::registerButtonsCallback(const buttons_callback_t &callback) { buttonsCallback = callback; }
 
 void NimBLEClientController::registerSensorCallback(const sensor_read_callback_t &callback) { sensorCallback = callback; }
 
@@ -97,6 +96,8 @@ bool NimBLEClientController::connectToServer() {
         return false;
     }
 
+
+    
     // Obtain the remote write characteristics
     outputControlChar = pRemoteService->getCharacteristic(NimBLEUUID(OUTPUT_CONTROL_UUID));
     altControlChar = pRemoteService->getCharacteristic(NimBLEUUID(ALT_CONTROL_CHAR_UUID));
@@ -117,17 +118,14 @@ bool NimBLEClientController::connectToServer() {
                                              std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     }
 
-    brewBtnChar = pRemoteService->getCharacteristic(NimBLEUUID(BREW_BTN_UUID));
-    if (brewBtnChar != nullptr && brewBtnChar->canNotify()) {
-        brewBtnChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
-                                               std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
+     buttonsStateChar = pRemoteService->getCharacteristic(NimBLEUUID(BUTTONS_STATE_UUID));
+    if (buttonsStateChar != nullptr && buttonsStateChar->canNotify()) {
+        buttonsStateChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
+                                                    std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     }
 
-    steamBtnChar = pRemoteService->getCharacteristic(NimBLEUUID(STEAM_BTN_UUID));
-    if (steamBtnChar != nullptr && steamBtnChar->canNotify()) {
-        steamBtnChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
-                                                std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
-    }
+    autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
+
 
     autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
     if (autotuneResultChar != nullptr && autotuneResultChar->canNotify()) {
@@ -262,8 +260,7 @@ void NimBLEClientController::onDisconnect(NimBLEClient *pServer) {
     errorChar = nullptr;
     autotuneChar = nullptr;
     autotuneResultChar = nullptr;
-    brewBtnChar = nullptr;
-    steamBtnChar = nullptr;
+    buttonsStateChar = nullptr;
     infoChar = nullptr;
     sensorChar = nullptr;
     outputControlChar = nullptr;
@@ -293,18 +290,11 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
             remoteErrorCallback(errorCode);
         }
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(BREW_BTN_UUID))) {
-        int brewButtonStatus = atoi(rawData);
-        ESP_LOGV(LOG_TAG, "brew button: %d", brewButtonStatus);
-        if (brewBtnCallback != nullptr) {
-            brewBtnCallback(brewButtonStatus);
-        }
-    }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(STEAM_BTN_UUID))) {
-        int steamButtonStatus = atoi(rawData);
-        ESP_LOGV(LOG_TAG, "steam button: %d", steamButtonStatus);
-        if (steamBtnCallback != nullptr) {
-            steamBtnCallback(steamButtonStatus);
+    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(BUTTONS_STATE_UUID))) {
+    uint8_t buttonsStatus = atoi(rawData.c_str());
+    ESP_LOGV(LOG_TAG, "buttons state: %d", buttonsStatus);
+    if (buttonsCallback != nullptr) {
+        buttonsCallback(buttonsStatus);
         }
     }
     if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(SENSOR_DATA_UUID))) {

--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -123,8 +123,7 @@ bool NimBLEClientController::connectToServer() {
     }
 
     autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
-
-    autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
+    
     if (autotuneResultChar != nullptr && autotuneResultChar->canNotify()) {
         autotuneResultChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
                                                       std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
@@ -288,7 +287,7 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
         }
     }
     if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(BUTTONS_STATE_UUID))) {
-        uint8_t buttonsStatus = atoi(rawData.c_str());
+        uint8_t buttonsStatus = atoi(rawData);
         ESP_LOGV(LOG_TAG, "buttons state: %d", buttonsStatus);
         if (buttonsCallback != nullptr) {
             buttonsCallback(buttonsStatus);

--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -96,8 +96,6 @@ bool NimBLEClientController::connectToServer() {
         return false;
     }
 
-
-    
     // Obtain the remote write characteristics
     outputControlChar = pRemoteService->getCharacteristic(NimBLEUUID(OUTPUT_CONTROL_UUID));
     altControlChar = pRemoteService->getCharacteristic(NimBLEUUID(ALT_CONTROL_CHAR_UUID));
@@ -118,14 +116,13 @@ bool NimBLEClientController::connectToServer() {
                                              std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     }
 
-     buttonsStateChar = pRemoteService->getCharacteristic(NimBLEUUID(BUTTONS_STATE_UUID));
+    buttonsStateChar = pRemoteService->getCharacteristic(NimBLEUUID(BUTTONS_STATE_UUID));
     if (buttonsStateChar != nullptr && buttonsStateChar->canNotify()) {
         buttonsStateChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
                                                     std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     }
 
     autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
-
 
     autotuneResultChar = pRemoteService->getCharacteristic(NimBLEUUID(AUTOTUNE_RESULT_UUID));
     if (autotuneResultChar != nullptr && autotuneResultChar->canNotify()) {
@@ -291,10 +288,10 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
         }
     }
     if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(BUTTONS_STATE_UUID))) {
-    uint8_t buttonsStatus = atoi(rawData.c_str());
-    ESP_LOGV(LOG_TAG, "buttons state: %d", buttonsStatus);
-    if (buttonsCallback != nullptr) {
-        buttonsCallback(buttonsStatus);
+        uint8_t buttonsStatus = atoi(rawData.c_str());
+        ESP_LOGV(LOG_TAG, "buttons state: %d", buttonsStatus);
+        if (buttonsCallback != nullptr) {
+            buttonsCallback(buttonsStatus);
         }
     }
     if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(SENSOR_DATA_UUID))) {

--- a/lib/NimBLEComm/src/NimBLEClientController.h
+++ b/lib/NimBLEComm/src/NimBLEClientController.h
@@ -26,8 +26,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void scan();
     void tare();
     void registerRemoteErrorCallback(const remote_err_callback_t &callback);
-    void registerBrewBtnCallback(const brew_callback_t &callback);
-    void registerSteamBtnCallback(const steam_callback_t &callback);
+    void registerButtonsCallback(const buttons_callback_t &callback);
     void registerSensorCallback(const sensor_read_callback_t &callback);
     void registerAutotuneResultCallback(const pid_control_callback_t &callback);
     void registerVolumetricMeasurementCallback(const float_callback_t &callback);
@@ -51,8 +50,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     NimBLERemoteCharacteristic *errorChar = nullptr;
     NimBLERemoteCharacteristic *autotuneChar = nullptr;
     NimBLERemoteCharacteristic *autotuneResultChar = nullptr;
-    NimBLERemoteCharacteristic *brewBtnChar = nullptr;
-    NimBLERemoteCharacteristic *steamBtnChar = nullptr;
+    NimBLERemoteCharacteristic *buttonsStateChar = nullptr;
     NimBLERemoteCharacteristic *infoChar = nullptr;
     NimBLERemoteCharacteristic *sensorChar = nullptr;
     NimBLERemoteCharacteristic *outputControlChar = nullptr;
@@ -66,8 +64,7 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     xTaskHandle taskHandle;
 
     remote_err_callback_t remoteErrorCallback = nullptr;
-    brew_callback_t brewBtnCallback = nullptr;
-    steam_callback_t steamBtnCallback = nullptr;
+    buttons_callback_t buttonsCallback = nullptr;
     pid_control_callback_t autotuneResultCallback = nullptr;
     sensor_read_callback_t sensorCallback = nullptr;
     float_callback_t volumetricMeasurementCallback = nullptr;

--- a/lib/NimBLEComm/src/NimBLEComm.h
+++ b/lib/NimBLEComm/src/NimBLEComm.h
@@ -13,8 +13,7 @@
 #define AUTOTUNE_RESULT_UUID "7f61607a-2817-4354-9b94-d49c057fc879"
 #define PID_CONTROL_CHAR_UUID "d448c469-3e1d-4105-b5b8-75bf7d492fad"
 #define PUMP_MODEL_COEFFS_CHAR_UUID "e448c469-3e1d-4105-b5b8-75bf7d492fae"
-#define BREW_BTN_UUID "a29eb137-b33e-45a4-b1fc-15eb04e8ab39"
-#define STEAM_BTN_UUID "53750675-4839-421e-971e-cc6823507d8e"
+#define BUTTONS_STATE_UUID "b3c4d5e6-f7a8-4b9c-8d1e-2f3a4b5c6d7e"
 #define INFO_UUID "f8d7203b-e00c-48e2-83ba-37ff49cdba74"
 
 #define PRESSURE_SCALE_UUID "3aa65ab6-2dda-4c95-9cf3-58b2a0480623"
@@ -38,8 +37,7 @@ using pump_model_coeffs_callback_t = std::function<void(float a, float b, float 
 using ping_callback_t = std::function<void()>;
 using remote_err_callback_t = std::function<void(int errorCode)>;
 using autotune_callback_t = std::function<void(int testTime, int samples)>;
-using brew_callback_t = std::function<void(bool brewButtonStatus)>;
-using steam_callback_t = std::function<void(bool steamButtonStatus)>;
+using buttons_callback_t = std::function<void(const uint8_t buttonsStatus)>;
 using void_callback_t = std::function<void()>;
 
 // New combined callbacks

--- a/lib/NimBLEComm/src/NimBLEServerController.cpp
+++ b/lib/NimBLEComm/src/NimBLEServerController.cpp
@@ -44,11 +44,8 @@ void NimBLEServerController::initServer(const String infoString) {
     autotuneChar->setCallbacks(this); // Use this class as the callback handler
     autotuneResultChar = pService->createCharacteristic(AUTOTUNE_RESULT_UUID, NIMBLE_PROPERTY::NOTIFY);
 
-    // Brew button Characteristic (Server notifies client of brew button)
-    brewBtnChar = pService->createCharacteristic(BREW_BTN_UUID, NIMBLE_PROPERTY::NOTIFY);
-
-    // Steam button Characteristic (Server notifies client of steam button)
-    steamBtnChar = pService->createCharacteristic(STEAM_BTN_UUID, NIMBLE_PROPERTY::NOTIFY);
+    // Buttons state Characteristic (Server notifies client of combined button state)
+    buttonsStateChar = pService->createCharacteristic(BUTTONS_STATE_UUID, NIMBLE_PROPERTY::NOTIFY);
 
     infoChar = pService->createCharacteristic(INFO_UUID, NIMBLE_PROPERTY::READ);
     setInfo(infoString);
@@ -106,21 +103,10 @@ void NimBLEServerController::sendError(int errorCode) {
     }
 }
 
-void NimBLEServerController::sendBrewBtnState(bool brewButtonStatus) {
+void NimBLEServerController::sendButtonsState(uint8_t buttonsStatus) {
     if (deviceConnected) {
-        // Send brew notification to the client
-        snprintf(brewBtnBuffer, sizeof(brewBtnBuffer), "%d", static_cast<int>(brewButtonStatus));
-        brewBtnChar->setValue(brewBtnBuffer);
-        brewBtnChar->notify();
-    }
-}
-
-void NimBLEServerController::sendSteamBtnState(bool steamButtonStatus) {
-    if (deviceConnected) {
-        // Send steam notification to the client
-        snprintf(steamBtnBuffer, sizeof(steamBtnBuffer), "%d", static_cast<int>(steamButtonStatus));
-        steamBtnChar->setValue(steamBtnBuffer);
-        steamBtnChar->notify();
+        buttonsStateChar->setValue(std::to_string(static_cast<int>(buttonsStatus)));
+        buttonsStateChar->notify();
     }
 }
 

--- a/lib/NimBLEComm/src/NimBLEServerController.h
+++ b/lib/NimBLEComm/src/NimBLEServerController.h
@@ -64,8 +64,6 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     led_control_callback_t ledControlCallback = nullptr;
     char sensorDataBuffer[80]{};
     char errorBuffer[12]{};
-    char brewBtnBuffer[4]{};
-    char steamBtnBuffer[4]{};
     char autotuneResultBuffer[64]{};
     char tofBuffer[16]{};
     char volumetricBuffer[16]{};

--- a/lib/NimBLEComm/src/NimBLEServerController.h
+++ b/lib/NimBLEComm/src/NimBLEServerController.h
@@ -13,8 +13,7 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
 
     void sendSensorData(float temperature, float pressure, float puckFlow, float pumpFlow, float puckResistance);
     void sendError(int errorCode);
-    void sendBrewBtnState(bool brewButtonStatus);
-    void sendSteamBtnState(bool steamButtonStatus);
+    void sendButtonsState(uint8_t buttonsStatus);
     void sendAutotuneResult(float Kp, float Ki, float Kd);
     void sendVolumetricMeasurement(float value);
     void sendTofMeasurement(int value);
@@ -45,8 +44,7 @@ class NimBLEServerController : public NimBLEServerCallbacks, public NimBLECharac
     NimBLECharacteristic *errorChar = nullptr;
     NimBLECharacteristic *autotuneChar = nullptr;
     NimBLECharacteristic *autotuneResultChar = nullptr;
-    NimBLECharacteristic *brewBtnChar = nullptr;
-    NimBLECharacteristic *steamBtnChar = nullptr;
+    NimBLECharacteristic *buttonsStateChar = nullptr;
     NimBLECharacteristic *infoChar = nullptr;
     NimBLECharacteristic *sensorChar = nullptr;
     NimBLECharacteristic *volumetricMeasurementChar = nullptr;

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -745,7 +745,6 @@ void Controller::handleWaterPress() {
         setMode(MODE_WATER);
     }
     if (!isActive()) { activate(); return; }
-    if (settings.isMomentaryButtons()) { deactivate(); }
 }
 
 void Controller::handleRelease() {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -739,9 +739,8 @@ void Controller::onVolumetricDelete() {
     }
 }
 
-
 void Controller::handleButtonsState(uint8_t buttonsStatus) {
-    bool isBrewPressed  = (buttonsStatus >> 1) & 1;
+    bool isBrewPressed = (buttonsStatus >> 1) & 1;
     bool isSteamPressed = buttonsStatus & 1;
 
     if (isBrewPressed && isSteamPressed) {
@@ -750,14 +749,21 @@ void Controller::handleButtonsState(uint8_t buttonsStatus) {
             deactivateStandby();
             setMode(MODE_WATER);
         }
-        if (!isActive()) activate();
+        if (!isActive())
+            activate();
     } else if (!isBrewPressed && !isSteamPressed) {
         // Both released
         if (getMode() == MODE_WATER) {
-            if (isActive()) deactivate();
+            if (isActive())
+                deactivate();
         } else if (!settings.isMomentaryButtons()) {
             if (getMode() == MODE_BREW) {
-                if (isActive()) { deactivate(); clear(); } else { clear(); }
+                if (isActive()) {
+                    deactivate();
+                    clear();
+                } else {
+                    clear();
+                }
             } else if (getMode() == MODE_STEAM) {
                 deactivate();
                 setMode(MODE_BREW);
@@ -766,27 +772,37 @@ void Controller::handleButtonsState(uint8_t buttonsStatus) {
     } else if (isBrewPressed) {
         // Only brew
         if (getMode() == MODE_WATER || getMode() == MODE_STEAM) {
-            if (isActive()) deactivate();
+            if (isActive())
+                deactivate();
             setMode(MODE_BREW);
             return;
         }
         switch (getMode()) {
-            case MODE_STANDBY: deactivateStandby(); break;
-            case MODE_BREW:
-                if (!isActive()) { deactivateStandby(); clear(); activate(); }
-                else if (settings.isMomentaryButtons()) { deactivate(); clear(); }
-                break;
-            default: break;
+        case MODE_STANDBY:
+            deactivateStandby();
+            break;
+        case MODE_BREW:
+            if (!isActive()) {
+                deactivateStandby();
+                clear();
+                activate();
+            } else if (settings.isMomentaryButtons()) {
+                deactivate();
+                clear();
+            }
+            break;
+        default:
+            break;
         }
     } else if (isSteamPressed) {
         // Only steam
         if (getMode() == MODE_WATER || getMode() == MODE_BREW || getMode() == MODE_STANDBY) {
-            if (isActive()) deactivate();
+            if (isActive())
+                deactivate();
             setMode(MODE_STEAM);
         }
     }
 }
-
 
 void Controller::handleProfileUpdate() {
     pluginManager->trigger("boiler:targetTemperature:change", "value", profileManager->getSelectedProfile().temperature);

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -153,8 +153,7 @@ void Controller::setupBluetooth() {
             pluginManager->trigger("pump:flow:change", "value", pumpFlow);
             pluginManager->trigger("pump:puck-resistance:change", "value", puckResistance);
         });
-    clientController.registerBrewBtnCallback([this](const int brewButtonStatus) { handleBrewButton(brewButtonStatus); });
-    clientController.registerSteamBtnCallback([this](const int steamButtonStatus) { handleSteamButton(steamButtonStatus); });
+    clientController.registerButtonsCallback([this](const uint8_t buttonsStatus) { handleButtonsState(buttonsStatus); });
     clientController.registerRemoteErrorCallback([this](const int error) {
         if (error != ERROR_CODE_TIMEOUT && error != this->error) {
             this->error = error;
@@ -740,64 +739,54 @@ void Controller::onVolumetricDelete() {
     }
 }
 
-void Controller::handleBrewButton(int brewButtonStatus) {
-    printf("current screen %d, brew button %d\n", getMode(), brewButtonStatus);
-    if (brewButtonStatus) {
-        switch (getMode()) {
-        case MODE_STANDBY:
+
+void Controller::handleButtonsState(uint8_t buttonsStatus) {
+    bool isBrewPressed  = (buttonsStatus >> 1) & 1;
+    bool isSteamPressed = buttonsStatus & 1;
+
+    if (isBrewPressed && isSteamPressed) {
+        // Both pressed — water mode
+        if (getMode() != MODE_WATER) {
             deactivateStandby();
-            break;
-        case MODE_BREW:
-            if (!isActive()) {
-                deactivateStandby();
-                clear();
-                activate();
-            } else if (settings.isMomentaryButtons()) {
-                deactivate();
-                clear();
-            }
-            break;
-        case MODE_WATER:
-            activate();
-            break;
-        case MODE_STEAM:
-            deactivate();
-            setMode(MODE_BREW);
-        default:
-            break;
+            setMode(MODE_WATER);
         }
-    } else if (!settings.isMomentaryButtons()) {
-        if (getMode() == MODE_BREW) {
-            if (isActive()) {
+        if (!isActive()) activate();
+    } else if (!isBrewPressed && !isSteamPressed) {
+        // Both released
+        if (getMode() == MODE_WATER) {
+            if (isActive()) deactivate();
+        } else if (!settings.isMomentaryButtons()) {
+            if (getMode() == MODE_BREW) {
+                if (isActive()) { deactivate(); clear(); } else { clear(); }
+            } else if (getMode() == MODE_STEAM) {
                 deactivate();
-                clear();
-            } else {
-                clear();
+                setMode(MODE_BREW);
             }
-        } else if (getMode() == MODE_WATER) {
-            deactivate();
+        }
+    } else if (isBrewPressed) {
+        // Only brew
+        if (getMode() == MODE_WATER || getMode() == MODE_STEAM) {
+            if (isActive()) deactivate();
+            setMode(MODE_BREW);
+            return;
+        }
+        switch (getMode()) {
+            case MODE_STANDBY: deactivateStandby(); break;
+            case MODE_BREW:
+                if (!isActive()) { deactivateStandby(); clear(); activate(); }
+                else if (settings.isMomentaryButtons()) { deactivate(); clear(); }
+                break;
+            default: break;
+        }
+    } else if (isSteamPressed) {
+        // Only steam
+        if (getMode() == MODE_WATER || getMode() == MODE_BREW || getMode() == MODE_STANDBY) {
+            if (isActive()) deactivate();
+            setMode(MODE_STEAM);
         }
     }
 }
 
-void Controller::handleSteamButton(int steamButtonStatus) {
-    printf("current screen %d, steam button %d\n", getMode(), steamButtonStatus);
-    if (steamButtonStatus) {
-        switch (getMode()) {
-        case MODE_STANDBY:
-            setMode(MODE_STEAM);
-            break;
-        case MODE_BREW:
-            setMode(MODE_STEAM);
-            break;
-        default:
-            break;
-        }
-    } else if (!settings.isMomentaryButtons() && getMode() == MODE_STEAM) {
-        deactivate();
-        setMode(MODE_BREW);
-    }
-}
 
 void Controller::handleProfileUpdate() {
     pluginManager->trigger("boiler:targetTemperature:change", "value", profileManager->getSelectedProfile().temperature);

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -739,71 +739,81 @@ void Controller::onVolumetricDelete() {
     }
 }
 
+void Controller::handleWaterPress() {
+    if (getMode() != MODE_WATER) {
+        deactivate();
+        setMode(MODE_WATER);
+    }
+    if (!isActive()) { activate(); return; }
+    if (settings.isMomentaryButtons()) { deactivate(); }
+}
+
+void Controller::handleRelease() {
+    if (getMode() == MODE_WATER) {
+        if (isActive()) deactivate();
+        return;
+    }
+    if (settings.isMomentaryButtons()) return;
+    if (getMode() == MODE_BREW) {
+        if (isActive()) deactivate();
+        clear();
+        return;
+    }
+    if (getMode() == MODE_STEAM) {
+        deactivate();
+        setMode(MODE_BREW);
+    }
+}
+
+void Controller::handleBrewPress() {
+    if (getMode() == MODE_WATER || getMode() == MODE_STEAM) {
+        if (isActive()) deactivate();
+        setMode(MODE_BREW);
+        clear();
+        activate();
+        return;
+    }
+    if (getMode() == MODE_STANDBY) {
+        deactivateStandby();
+        return;
+    }
+    if (getMode() == MODE_BREW) {
+        if (!isActive()) { deactivateStandby(); clear(); activate(); return; }
+        if (settings.isMomentaryButtons()) { deactivate(); clear(); }
+    }
+}
+
+void Controller::handleSteamPress() {
+    if (getMode() == MODE_WATER || getMode() == MODE_BREW || getMode() == MODE_STANDBY) {
+        if (isActive()) deactivate();
+        setMode(MODE_STEAM);
+        return;
+    }
+    if (getMode() == MODE_STEAM) {
+        if (!isActive()) { activate(); return; }
+        if (settings.isMomentaryButtons()) { deactivate(); }
+    }
+}
+
 void Controller::handleButtonsState(uint8_t buttonsStatus) {
     bool isBrewPressed = (buttonsStatus >> 1) & 1;
     bool isSteamPressed = buttonsStatus & 1;
 
     if (isBrewPressed && isSteamPressed) {
-        // Both pressed — water mode
-        if (getMode() != MODE_WATER) {
-            deactivateStandby();
-            setMode(MODE_WATER);
-        }
-        if (!isActive())
-            activate();
-    } else if (!isBrewPressed && !isSteamPressed) {
-        // Both released
-        if (getMode() == MODE_WATER) {
-            if (isActive())
-                deactivate();
-        } else if (!settings.isMomentaryButtons()) {
-            if (getMode() == MODE_BREW) {
-                if (isActive()) {
-                    deactivate();
-                    clear();
-                } else {
-                    clear();
-                }
-            } else if (getMode() == MODE_STEAM) {
-                deactivate();
-                setMode(MODE_BREW);
-            }
-        }
-    } else if (isBrewPressed) {
-        // Only brew
-        if (getMode() == MODE_WATER || getMode() == MODE_STEAM) {
-            if (isActive())
-                deactivate();
-            setMode(MODE_BREW);
-            return;
-        }
-        switch (getMode()) {
-        case MODE_STANDBY:
-            deactivateStandby();
-            break;
-        case MODE_BREW:
-            if (!isActive()) {
-                deactivateStandby();
-                clear();
-                activate();
-            } else if (settings.isMomentaryButtons()) {
-                deactivate();
-                clear();
-            }
-            break;
-        default:
-            break;
-        }
-    } else if (isSteamPressed) {
-        // Only steam
-        if (getMode() == MODE_WATER || getMode() == MODE_BREW || getMode() == MODE_STANDBY) {
-            if (isActive())
-                deactivate();
-            setMode(MODE_STEAM);
-        }
+        wasWaterMode = true;
+        handleWaterPress();
+        return;
     }
+    if (!isBrewPressed && !isSteamPressed) {
+        wasWaterMode = false;
+        handleRelease();
+        return;
+    }
+    // Single button — only act if not transitioning out of combined press
+    if (wasWaterMode) return;
+    if (isBrewPressed) handleBrewPress();
+    else handleSteamPress();
 }
-
 void Controller::handleProfileUpdate() {
     pluginManager->trigger("boiler:targetTemperature:change", "value", profileManager->getSelectedProfile().temperature);
     pluginManager->trigger("controller:targetDuration:change", "value", profileManager->getSelectedProfile().getTotalDuration());

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -120,7 +120,7 @@ class Controller {
 
     void handleProfileUpdate();
 
-    //Steam, water, brew button
+    // Steam, water, brew button
     void handleButtonsState(uint8_t buttonsStatus);
 
     // Private Attributes

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -118,12 +118,10 @@ class Controller {
     // Event handlers
     void onTempRead(float temperature);
 
-    // brew button
-    void handleBrewButton(int brewButtonStatus);
-
-    // steam button
-    void handleSteamButton(int steamButtonStatus);
     void handleProfileUpdate();
+
+    //Steam, water, brew button
+    void handleButtonsState(uint8_t buttonsStatus);
 
     // Private Attributes
 #ifndef GAGGIMATE_HEADLESS

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -122,6 +122,10 @@ class Controller {
 
     // Steam, water, brew button
     void handleButtonsState(uint8_t buttonsStatus);
+    void handleWaterPress();
+    void handleBrewPress();
+    void handleSteamPress();
+    void handleRelease();
 
     // Private Attributes
 #ifndef GAGGIMATE_HEADLESS
@@ -159,6 +163,7 @@ class Controller {
     bool initialized = false;
     bool screenReady = false;
     bool waitingForController = false;
+    bool wasWaterMode = false;
     unsigned long connectStartTime = 0;
     bool volumetricOverride = false;
     bool processCompleted = false;


### PR DESCRIPTION
## Summary
Adds hardware water mode trigger for Gaggia Classic compatibility. 
Pressing both BREW (GPIO38) and STEAM (GPIO48) buttons simultaneously 
activates water mode, mirroring how a Gaggia Classic achieves hot water 
from the steam wand. On machines like the Rancilio Silvia which have a 
dedicated water button, this combination acts as that button.

## Behavior
- **Both pressed** → switch to water mode, start water flow
- **Both released** → stop water flow, stay in water mode (temperature 
  setpoint maintained for refilling)
- **Only brew pressed** (while in water mode) → exit to brew screen
- **Only steam pressed** (while in water mode) → exit to steam screen

## Changes

### Added
- `DigitalInput` — dual pin constructor reading both GPIOs simultaneously, eliminating race conditions between separate button callbacks
- `BUTTONS_STATE_UUID` — new BLE characteristic replacing separate brew/steam characteristics, sends combined state as single packet
- `buttons_callback_t` — new callback type for combined button state
- `sendButtonsState(uint8_t buttonsStatus)` — sends combined button state over BLE
- `registerButtonsCallback()` — registers combined button state callback on display side
- `handleButtonsState(uint8_t buttonsStatus)` — handles all three button cases in one place on display side
- Fixed `DigitalInput` LOG_TAG from "Heater" to "DigitalInput"

### Removed
- `BREW_BTN_UUID`, `STEAM_BTN_UUID` — replaced by `BUTTONS_STATE_UUID`
- `brew_callback_t`, `steam_callback_t` — replaced by `buttons_callback_t`
- `sendBrewBtnState`, `sendSteamBtnState` — replaced by `sendButtonsState`
- `brewBtnChar`, `steamBtnChar` — replaced by `buttonsStateChar`
- `registerBrewBtnCallback`, `registerSteamBtnCallback` — replaced by `registerButtonsCallback`
- `handleBrewButton`, `handleSteamButton` — replaced by `handleButtonsState`

## Testing
Tested on GaggiMate Pro hardware with GPIO38 (brew) and GPIO48 (steam).
Water mode correctly activates on simultaneous press, stops on release,
and exits to brew/steam on single button press.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified brew and steam button inputs into a single combined button-state flow
  * Switched Bluetooth communication to a single combined buttons-state channel
  * Updated controller logic to interpret combined vs single presses and handle water/brew/steam actions

* **Chores**
  * Added local workspace file to .gitignore to avoid tracking it in version control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->