### PR TITLE
fix: assorted reliability fixes

### DIFF
--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -112,7 +112,7 @@ bool NimBLEClientController::connectToServer() {
     // Obtain the remote notify characteristic and subscribe to it
 
     errorChar = pRemoteService->getCharacteristic(NimBLEUUID(ERROR_CHAR_UUID));
-    if (errorChar->canNotify()) {
+    if (errorChar != nullptr && errorChar->canNotify()) {
         errorChar->subscribe(true, std::bind(&NimBLEClientController::notifyCallback, this, std::placeholders::_1,
                                              std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     }

--- a/lib/OTA/src/ControllerOTA.cpp
+++ b/lib/OTA/src/ControllerOTA.cpp
@@ -39,7 +39,8 @@ bool ControllerOTA::downloadFile(WiFiClientSecure &wifi_client, const String &re
     }
 
     http.useHTTP10(true);
-    http.setTimeout(1800);
+    http.setTimeout(300000);
+    http.setConnectTimeout(10000);
     http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     http.setUserAgent("ESP32-http-Update");
     http.addHeader("Cache-Control", "no-cache");

--- a/lib/OTA/src/semver_extensions.cpp
+++ b/lib/OTA/src/semver_extensions.cpp
@@ -34,8 +34,11 @@ semver_t from_string(const string &version) {
     if (split_at != string::npos) {
         patch = atoi(numbers.at(2).substr(0, split_at).c_str());
         auto prerelease = numbers.at(2).substr(split_at + 1);
-        prerelease_ptr = (char *)malloc(prerelease.length());
-        prerelease.copy(prerelease_ptr, prerelease.length());
+        prerelease_ptr = (char *)malloc(prerelease.length() + 1);
+        if (prerelease_ptr != nullptr) {
+            prerelease.copy(prerelease_ptr, prerelease.length());
+            prerelease_ptr[prerelease.length()] = '\0';
+        }
     } else {
         patch = atoi(numbers.at(2).c_str());
     }

--- a/src/display/plugins/HomekitPlugin.cpp
+++ b/src/display/plugins/HomekitPlugin.cpp
@@ -59,6 +59,8 @@ void HomekitPlugin::setup(Controller *controller, PluginManager *pluginManager) 
         int apMode = event.getInt("AP");
         if (apMode)
             return;
+        if (accessory != nullptr)
+            return;
         homeSpan.setHostNameSuffix("");
         homeSpan.setPortNum(HOMESPAN_PORT);
         homeSpan.begin(Category::Thermostats, DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -26,13 +26,12 @@ int16_t calculate_angle(int set_temp, int range, int offset) {
 
 void DefaultUI::updateTempHistory() {
     if (currentTemp > 0) {
+        if (tempHistoryIndex >= TEMP_HISTORY_LENGTH) {
+            tempHistoryIndex = 0;
+            isTempHistoryInitialized = true;
+        }
         tempHistory[tempHistoryIndex] = currentTemp;
         tempHistoryIndex += 1;
-    }
-
-    if (tempHistoryIndex > TEMP_HISTORY_LENGTH) {
-        tempHistoryIndex = 0;
-        isTempHistoryInitialized = true;
     }
 
     if (tempHistoryIndex % 4 == 0) {


### PR DESCRIPTION
Five small, low-risk reliability fixes found by auditing `src/` and `lib/` against the set of open issues labeled for crashes, freezes, reboots, and memory problems. Each is independently motivated and landable in isolation — bundled only because they're all one-liners.

### 1. `lib/OTA/src/ControllerOTA.cpp` — OTA download timeout

`http.setTimeout(1800)` with Arduino `HTTPClient` is **milliseconds**, so the download times out after ~1.8s. That's shorter than many TLS handshakes and will truncate almost every firmware download on anything but a fast LAN — leaves the board half-flashed.

Bumped to 300000 (5 min) and added `setConnectTimeout(10000)` so a slow DNS/handshake can't hang the controller loop indefinitely either.

### 2. `lib/NimBLEComm/src/NimBLEClientController.cpp` — `errorChar` null guard

`errorChar = pRemoteService->getCharacteristic(ERROR_CHAR_UUID); if (errorChar->canNotify()) { ... }`

Every sibling characteristic in the same function (`brewBtnChar`, `steamBtnChar`, `autotuneResultChar`, `sensorChar`, `volumetricMeasurementChar`) has an `errorChar != nullptr &&` guard. This one was missed. If the connected controller firmware ever omits that UUID (version skew, partial service), the display crashes on BLE connect.

### 3. `src/display/ui/default/DefaultUI.cpp` — `tempHistory` off-by-one

```cpp
tempHistory[tempHistoryIndex] = currentTemp;
tempHistoryIndex += 1;

if (tempHistoryIndex > TEMP_HISTORY_LENGTH) {  // <- off by one
    tempHistoryIndex = 0;
    ...
}
```

`tempHistory` is sized `TEMP_HISTORY_LENGTH`, so valid indices are `0..LENGTH-1`. The guard was `>`, meaning `tempHistoryIndex` reached `LENGTH`, we wrote at `tempHistory[LENGTH]` (one past end), then reset. That silently corrupts whatever class member follows `tempHistory` every time the buffer wraps. Moved the bounds check above the write and changed to `>=`.

### 4. `src/display/plugins/HomekitPlugin.cpp` — re-init leak on WiFi reconnect

The `controller:wifi:connect` handler calls `homeSpan.begin()` and does `spanAccessory = new SpanAccessory()` (plus 3 more `new`s) every time the event fires — which is on every WiFi reconnect. Each reconnect leaks 4 HomeSpan/Characteristic objects. Added an `if (accessory != nullptr) return;` so init only runs once.

### 5. `lib/OTA/src/semver_extensions.cpp` — missing null terminator + malloc null check

```cpp
prerelease_ptr = (char *)malloc(prerelease.length());
prerelease.copy(prerelease_ptr, prerelease.length());
```

Allocates exactly `length` bytes with no room for `'\0'`, and `std::string::copy` does not null-terminate. The buffer is later rendered as a C string (`String(version.prerelease)`), so this reads past the heap. Allocate `length + 1`, null-terminate explicitly, and null-check the malloc.

---

## Testing

- Inspected each change against the code it touches.
- Partial local PlatformIO build of `display` and `display-headless` (cc1 OOM'd on LVGL components, unrelated to these changes) — `HomekitPlugin.cpp.o` and `DefaultUI.cpp.o` built clean before the kill; the 3 library changes are trivially-safe (integer literal, sibling-matching null check, standard-C malloc-size + null-terminator).
- Not yet tested on hardware. Would appreciate a flash-and-smoke on any of the display targets before merging.

## Splitting

Happy to split any of these into separate PRs if that's preferred — they're independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential null pointer crash in Bluetooth connectivity setup
  * Enhanced OTA firmware update stability with increased timeout values and connection handling
  * Resolved memory allocation and string handling issues in version parsing
  * Prevented redundant Homekit accessory reinitialization on WiFi reconnection
  * Corrected circular buffer boundary condition in temperature history tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->