### PR TITLE
fix(predictive): evict samples older than windowDuration

### DIFF
--- a/src/display/core/predictive.h
+++ b/src/display/core/predictive.h
@@ -2,14 +2,22 @@
 #define PREDICTIVE_H
 
 #include <Arduino.h>
+#include <deque>
 
 class VolumetricRateCalculator {
   public:
     explicit VolumetricRateCalculator(double window_duration) : windowDuration(window_duration) {}
 
     void addMeasurement(double volume) {
+        const unsigned long now = millis();
         measurements.emplace_back(volume);
-        measurementTimes.emplace_back(millis());
+        measurementTimes.emplace_back(now);
+
+        const double cutoff = static_cast<double>(now) - windowDuration;
+        while (!measurementTimes.empty() && measurementTimes.front() <= cutoff) {
+            measurements.pop_front();
+            measurementTimes.pop_front();
+        }
     }
 
     double getRate(double time = 0) const {
@@ -78,8 +86,8 @@ class VolumetricRateCalculator {
     }
 
   private:
-    std::vector<double> measurements;
-    std::vector<double> measurementTimes;
+    std::deque<double> measurements;
+    std::deque<double> measurementTimes;
     const double windowDuration;
 };
 

--- a/src/display/core/predictive.h
+++ b/src/display/core/predictive.h
@@ -13,14 +13,15 @@ class VolumetricRateCalculator {
         measurements.emplace_back(volume);
         measurementTimes.emplace_back(now);
 
-        const double cutoff = static_cast<double>(now) - windowDuration;
-        while (!measurementTimes.empty() && measurementTimes.front() <= cutoff) {
+        // Unsigned subtraction is wrap-safe across the ~49d millis() rollover.
+        while (!measurementTimes.empty() &&
+               static_cast<double>(now - measurementTimes.front()) >= windowDuration) {
             measurements.pop_front();
             measurementTimes.pop_front();
         }
     }
 
-    double getRate(double time = 0) const {
+    double getRate(unsigned long time = 0) const {
         if (time == 0) {
             time = millis();
         }
@@ -29,8 +30,8 @@ class VolumetricRateCalculator {
             return 0.0;
 
         size_t i = measurementTimes.size();
-        double cutoff = time - windowDuration;
-        while (i > 0 && measurementTimes[i - 1] > cutoff) { // check from the most recent time
+        // Walk backward over in-window entries; stop at the first out-of-window one.
+        while (i > 0 && static_cast<double>(time - measurementTimes[i - 1]) < windowDuration) {
             i--;
         }
         // i is the index of the first entry after the cutoff
@@ -87,7 +88,7 @@ class VolumetricRateCalculator {
 
   private:
     std::deque<double> measurements;
-    std::deque<double> measurementTimes;
+    std::deque<unsigned long> measurementTimes;
     const double windowDuration;
 };
 


### PR DESCRIPTION
## What

`VolumetricRateCalculator` stored every `addMeasurement()` sample in two `std::vector<double>`s that were never pruned. `getRate()` ignores anything older than `windowDuration` (`PREDICTIVE_TIME = 4000 ms`), so the old entries are unreachable — but they kept accumulating every ~100 ms during brew/grind and fragmenting the heap on long or stuck shots.

## Fix

Prune at the source inside `addMeasurement`:

\`\`\`cpp
const double cutoff = static_cast<double>(now) - windowDuration;
while (!measurementTimes.empty() && measurementTimes.front() <= cutoff) {
    measurements.pop_front();
    measurementTimes.pop_front();
}
\`\`\`

Same cutoff boundary `getRate` already uses (`measurementTimes[j] > cutoff` → keep, `<= cutoff` → drop), mirrored on the producer side.

Switched the two members from `std::vector<double>` to `std::deque<double>` for O(1) front-pop. Rest of the class — `operator[]` and `size()` in the linear-fit loop — is unchanged (deque supports both with the same semantics).

## Why this is safe

- `getRate()` reads only entries with `timestamp > (time - windowDuration)`, where `time` defaults to `millis()` and the only non-default caller is `getOvershootAdjustMillis` passing `measurementTimes.back()`. Either way, anything popped here would have been filtered by the existing cutoff.
- `BrewProcess.h` and `GrindProcess.h` are the only consumers (`addMeasurement`, `getRate`, `getOvershootAdjustMillis`) — none iterate the container directly.
- Working set is now bounded at roughly `windowDuration / sampleInterval` ≈ 40 entries for the current 10 Hz path.

## Motivation

Directly relevant to **#658** ("Brew mode gets stuck after partial heating") — if the brew state machine hangs, `addMeasurement` keeps firing; before this change, the two vectors would grow without bound and fragment the heap, making recovery from the stuck state even more fragile.

## Testing

- `pio run -e display` passes cleanly in a fresh Codespace (5:07, firmware.bin produced).
- Flash impact: +576 bytes (~0.009% of partition) vs. master; deque internal layout overhead.
- Not yet flashed to hardware. Would appreciate a smoke test of a normal brew + grind before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of rate calculations by capturing a single timestamp per measurement and using wrap-safe time comparisons to handle timer rollover.
* **Performance**
  * More efficient removal of stale measurements for lower memory use and faster historical-data operations, improving overall rate-calculation performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->