### PR TITLE
feat(scales): expose battery in /api/scales/info, evt:status, and Scales UI

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -120,6 +120,16 @@ void WebUIPlugin::loop() {
         doc["bw"] = bleConnected ? this->currentBluetoothWeight : 0; // current bluetooth weight
         doc["cw"] = bleConnected ? this->currentBluetoothWeight : 0; // Use 'currentWeight' for forward compatbility
         doc["bc"] = bleConnected;                                    // bluetooth scale connected status
+        // Scale battery — only surfaced when the driver reports one and the
+        // value isn't the UNKNOWN sentinel (255). UI omits the battery pill
+        // entirely when `sbat` is absent, so disconnected/unknown scales don't
+        // render a stale stub.
+        if (bleConnected && BLEScales.hasBatteryLevel()) {
+            const uint8_t pct = BLEScales.getBatteryLevel();
+            if (pct != REMOTE_SCALES_BATTERY_UNKNOWN) {
+                doc["sbat"] = pct;
+            }
+        }
 
         Process *process = controller->getProcess();
         if (process == nullptr) {
@@ -711,6 +721,15 @@ void WebUIPlugin::handleBLEScaleInfo(AsyncWebServerRequest *request) {
     doc["name"] = BLEScales.getName();
     doc["uuid"] = BLEScales.getUUID();
     doc["rssi"] = BLEScales.getRSSI();
+    doc["hasBattery"] = BLEScales.hasBatteryLevel();
+    // Only surface the numeric when the scale reports one — a 255 sentinel
+    // (REMOTE_SCALES_BATTERY_UNKNOWN) would otherwise render as a fake "255%".
+    if (BLEScales.hasBatteryLevel()) {
+        const uint8_t pct = BLEScales.getBatteryLevel();
+        if (pct != REMOTE_SCALES_BATTERY_UNKNOWN) {
+            doc["battery"] = pct;
+        }
+    }
     AsyncResponseStream *response = request->beginResponseStream("application/json");
     serializeJson(doc, *response);
     request->send(response);

--- a/web/src/pages/Scales/index.jsx
+++ b/web/src/pages/Scales/index.jsx
@@ -7,6 +7,28 @@ import { machine } from '../../services/ApiService.js';
 import { Spinner } from '../../components/Spinner.jsx';
 import { faSignal } from '@fortawesome/free-solid-svg-icons/faSignal';
 import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
+import { faBatteryFull } from '@fortawesome/free-solid-svg-icons/faBatteryFull';
+import { faBatteryThreeQuarters } from '@fortawesome/free-solid-svg-icons/faBatteryThreeQuarters';
+import { faBatteryHalf } from '@fortawesome/free-solid-svg-icons/faBatteryHalf';
+import { faBatteryQuarter } from '@fortawesome/free-solid-svg-icons/faBatteryQuarter';
+import { faBatteryEmpty } from '@fortawesome/free-solid-svg-icons/faBatteryEmpty';
+
+// Pick an icon that roughly matches the fill level for a richer at-a-glance
+// read on the Scales page. The thresholds here are visual-only; the color
+// below is what actually conveys "pay attention" (≤9% red, ≤29% yellow).
+function batteryIcon(pct) {
+  if (pct >= 87) return faBatteryFull;
+  if (pct >= 62) return faBatteryThreeQuarters;
+  if (pct >= 37) return faBatteryHalf;
+  if (pct >= 12) return faBatteryQuarter;
+  return faBatteryEmpty;
+}
+
+function batteryColorClass(pct) {
+  if (pct <= 9) return 'text-error';       // critical — user must charge soon
+  if (pct <= 29) return 'text-warning';    // heads-up
+  return 'text-base-content/60';           // everyday — same tone as RSSI
+}
 
 export function Scales() {
   const [key, setKey] = useState(0);
@@ -156,6 +178,14 @@ function ScaleList(props) {
                   <span
                     className={`indicator-item status ml-2 ${scale.rssi < -90 ? 'status-error' : scale.rssi < -80 ? 'status-warning' : 'status-success'}`}
                   ></span>
+                  {scale.connected && scale.hasBattery && typeof scale.battery === 'number' && (
+                    <>
+                      <span className='mx-2'></span>
+                      <span className={batteryColorClass(scale.battery)}>
+                        <FontAwesomeIcon icon={batteryIcon(scale.battery)} /> {scale.battery}%
+                      </span>
+                    </>
+                  )}
                 </p>
               </div>
               <div className='flex items-center space-x-3'>


### PR DESCRIPTION
Surface the BLE scale's battery percentage to consumers — small, standalone, Bookoo-agnostic.

## Backend

- `/api/scales/info` gains `hasBattery` (bool) and `battery` (uint8 %, 0–100), gated on `BLEScales.hasBatteryLevel()`. `battery` is omitted when the driver reports the `REMOTE_SCALES_BATTERY_UNKNOWN` sentinel (`0xFF`) so consumers never render a fake \"255%\".
- `evt:status` WebSocket broadcast gains `sbat` with the same semantics, conditional on `bleConnected && hasBatteryLevel && not-UNKNOWN`.
- No driver-layer changes — uses `RemoteScales::hasBatteryLevel()` / `getBatteryLevel()` which already exist and which any driver that wants to opt in can override.

## Web UI (Scales page)

- Per connected scale, shows a FontAwesome battery glyph (full / 3/4 / half / 1/4 / empty picked by fill level) inline with the existing RSSI/UUID row.
- Colour thresholds: red ≤ 9%, amber ≤ 29%, otherwise the same muted tone as RSSI — quiet when healthy, pops when the user needs to charge.
- Hidden entirely when scale disconnected or `hasBattery` false.

## Motivation

Bookoo Themis Ultra already emits battery in byte 13 of every weight notification; the Bookoo driver has parsed and stored it for a while but no user-facing path exposed it. Useful standalone diagnostic regardless of any other Bookoo/driver work in flight. Takes ~50 lines across 2 files.

## Testing

- `curl http://<display>/api/scales/info` → now returns `hasBattery` + `battery`.
- `/ws` subscription: `evt:status` ticks (~2 s cadence) carry `sbat` when a scale is connected and reporting.
- Visual: Scales page renders a battery pill that updates live as the scale's reported % changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Bluetooth scale battery levels are now displayed in the scales interface alongside connectivity information with color-coded health indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->