### PR TITLE
Adjust button flex class for correct sizing on mobile

### DIFF
--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -985,12 +985,12 @@ export function Settings() {
             <span>Some options like Wi-Fi, NTP, and managing plugins require a restart.</span>
           </div>
           <div className='flex flex-col gap-2 pt-4 sm:flex-row'>
-            <a href='/' className='btn btn-outline flex-1 sm:flex-none'>
+            <a href='/' className='btn btn-outline'>
               Back
             </a>
             <button
               type='submit'
-              className='btn btn-primary flex-1 sm:flex-none'
+              className='btn btn-primary'
               disabled={submitting}
             >
               {submitting && <Spinner size={4} />} Save
@@ -998,7 +998,7 @@ export function Settings() {
             <button
               type='submit'
               name='restart'
-              className='btn btn-secondary flex-1 sm:flex-none'
+              className='btn btn-secondary'
               disabled={submitting}
               onClick={e => onSubmit(e, true)}
             >


### PR DESCRIPTION
- Updated button classes to not use flex instead of `flex-1 sm:flex-none`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Settings page bottom action controls’ responsive sizing so the Back, Save, and Save & Restart buttons no longer use the previous flexible width behavior. This refines their layout and alignment across screen sizes for a more consistent appearance and spacing in the page footer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->