### PR TITLE
Fix: flush pending settings to NVS before restart

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -458,6 +458,27 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
     ws.text(clientId, buffer);
 }
 
+/**
+ * Handle the `/api/settings` HTTP endpoint (GET and POST).
+ *
+ * On `GET`, serializes the current `Settings` object to JSON and writes it
+ * to the response. The serialized payload includes auto-wakeup schedules
+ * encoded as the `"time1|days1;time2|days2"` string the web UI expects.
+ *
+ * On `POST`, applies any provided form arguments to `Settings` via a
+ * single `batchUpdate` call (so partial writes don't see intermediate
+ * state), then echoes the updated settings back as JSON.
+ *
+ * On `POST` with the `restart` argument present, the handler explicitly
+ * flushes any pending writes to NVS (`Settings::save(true)`) before
+ * calling `ESP.restart()`. Without the explicit flush, settings written
+ * inside `batchUpdate` may still be queued behind the debounced write
+ * timer when `ESP.restart()` fires, and the device boots with stale
+ * values.
+ *
+ * @param request The incoming HTTP request. Method must be GET or POST.
+ *   Arguments accepted are documented inline in the `batchUpdate` body.
+ */
 void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     if (request->method() == HTTP_POST) {
         controller->getSettings().batchUpdate([request](Settings *settings) {
@@ -659,8 +680,10 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     serializeJson(doc, *response);
     request->send(response);
 
-    if (request->method() == HTTP_POST && request->hasArg("restart"))
+    if (request->method() == HTTP_POST && request->hasArg("restart")) {
+        controller->getSettings().save(true);
         ESP.restart();
+    }
 }
 
 void WebUIPlugin::handleBLEScaleList(AsyncWebServerRequest *request) {


### PR DESCRIPTION
Save() defers writes by up to 5 seconds via a background task. When the settings form is submitted with the restart flag, ESP.restart() fires immediately after the response is sent, so any setting changed in that POST is lost if the 5-second flush window hasn't elapsed.

This PR forces a synchronous save before restarting so requested changes survive the reboot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings are now saved to persistent storage before triggering a restart from the web interface, preventing loss of configuration.

* **Documentation**
  * Clarified web settings endpoint behavior and restart/save semantics in inline documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->