### PR TITLE
Add HomeKit Bridge mode and configurable accessories (Rework of homekit pr 527)

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -15,7 +15,8 @@
 #include <display/plugins/AutoWakeupPlugin.h>
 #include <display/plugins/BLEScalePlugin.h>
 #include <display/plugins/BoilerFillPlugin.h>
-#include <display/plugins/HomekitPlugin.h>
+#include <display/plugins/HomekitThermostatPlugin.h>
+#include <display/plugins/HomekitBridgePlugin.h>
 #include <display/plugins/LedControlPlugin.h>
 #include <display/plugins/MQTTPlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
@@ -43,7 +44,6 @@ void Controller::setup() {
 
     pluginManager = new PluginManager();
 #ifndef GAGGIMATE_HEADLESS
-    ui = new DefaultUI(this, driver, pluginManager);
     if (driver->supportsSDCard() && driver->installSDCard()) {
         sdcard = true;
         ESP_LOGI(LOG_TAG, "SD Card detected and mounted");
@@ -56,10 +56,15 @@ void Controller::setup() {
     }
     profileManager = new ProfileManager(fs, "/p", settings, pluginManager);
     profileManager->setup();
-    if (settings.isHomekit())
-        pluginManager->registerPlugin(new HomekitPlugin(settings.getWifiSsid(), settings.getWifiPassword()));
-    else
+    if (settings.getHomekitMode() == HOMEKIT_MODE_THERMOSTAT) {
+        pluginManager->registerPlugin(new HomekitThermostatPlugin(settings.getWifiSsid(), settings.getWifiPassword()));
         pluginManager->registerPlugin(new mDNSPlugin());
+    } else if (settings.getHomekitMode() == HOMEKIT_MODE_BRIDGE) {
+        pluginManager->registerPlugin(new HomekitBridgePlugin(settings.getWifiSsid(), settings.getWifiPassword()));
+        pluginManager->registerPlugin(new mDNSPlugin());
+    } else {
+        pluginManager->registerPlugin(new mDNSPlugin());
+    }
     if (settings.isBoilerFillActive()) {
         pluginManager->registerPlugin(new BoilerFillPlugin());
     }

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -44,6 +44,7 @@ void Controller::setup() {
 
     pluginManager = new PluginManager();
 #ifndef GAGGIMATE_HEADLESS
+    ui = new DefaultUI(this, driver, pluginManager);
     if (driver->supportsSDCard() && driver->installSDCard()) {
         sdcard = true;
         ESP_LOGI(LOG_TAG, "SD Card detected and mounted");

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -57,9 +57,9 @@ void Controller::setup() {
     }
     profileManager = new ProfileManager(fs, "/p", settings, pluginManager);
     profileManager->setup();
-    if (settings.getHomekitMode() == HOMEKIT_MODE_THERMOSTAT) {
+    if (settings.getHomekitMode() == HomeKitMode::Thermostat) {
         pluginManager->registerPlugin(new HomekitThermostatPlugin(settings.getWifiSsid(), settings.getWifiPassword()));
-    } else if (settings.getHomekitMode() == HOMEKIT_MODE_BRIDGE) {
+    } else if (settings.getHomekitMode() == HomeKitMode::Bridge) {
         pluginManager->registerPlugin(new HomekitBridgePlugin(settings.getWifiSsid(), settings.getWifiPassword()));
     }
     pluginManager->registerPlugin(new mDNSPlugin());

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -59,13 +59,10 @@ void Controller::setup() {
     profileManager->setup();
     if (settings.getHomekitMode() == HOMEKIT_MODE_THERMOSTAT) {
         pluginManager->registerPlugin(new HomekitThermostatPlugin(settings.getWifiSsid(), settings.getWifiPassword()));
-        pluginManager->registerPlugin(new mDNSPlugin());
     } else if (settings.getHomekitMode() == HOMEKIT_MODE_BRIDGE) {
         pluginManager->registerPlugin(new HomekitBridgePlugin(settings.getWifiSsid(), settings.getWifiPassword()));
-        pluginManager->registerPlugin(new mDNSPlugin());
-    } else {
-        pluginManager->registerPlugin(new mDNSPlugin());
     }
+    pluginManager->registerPlugin(new mDNSPlugin());
     if (settings.isBoilerFillActive()) {
         pluginManager->registerPlugin(new BoilerFillPlugin());
     }

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -2,8 +2,35 @@
 
 #include <algorithm>
 #include <utility>
+#include <esp32-hal-log.h>
 
 Settings::Settings() {
+    // Phase 1: HomeKit Migration (Read-Write Mode)
+    preferences.begin(PREFERENCES_KEY, false);
+
+    // Check if the old boolean key "hk" exists
+    if (preferences.isKey("hk")) {
+        ESP_LOGW("Settings", "Migrating old HomeKit bool setting 'hk' to new int setting 'hkm'.");
+        bool old_homekit_bool = preferences.getBool("hk", false);
+
+        // Map old boolean to new integer modes
+        if (old_homekit_bool) {
+            homekitMode = HOMEKIT_MODE_THERMOSTAT;
+        } else {
+            homekitMode = HOMEKIT_MODE_DISABLED;
+        }
+
+        // Save the new mode and remove the obsolete boolean key
+        preferences.putInt("hkm", homekitMode);
+        preferences.remove("hk");
+        ESP_LOGI("Settings", "HomeKit migration complete. New mode: %d", homekitMode);
+    } else {
+        // If no old key exists, just load the current mode or default to disabled
+        homekitMode = preferences.getInt("hkm", HOMEKIT_MODE_DISABLED);
+    }
+    preferences.end(); // Close write access
+
+    // Phase 2: Standard Initialization (Read-Only Mode)
     preferences.begin(PREFERENCES_KEY, true);
     startupMode = preferences.getInt("sm", MODE_STANDBY);
     targetSteamTemp = preferences.getInt("ts", 145);
@@ -20,7 +47,11 @@ Settings::Settings() {
     wifiSsid = preferences.getString("ws", "");
     wifiPassword = preferences.getString("wp", "");
     mdnsName = preferences.getString("mn", DEFAULT_MDNS_NAME);
-    homekit = preferences.getBool("hk", false);
+    //homekitMode = preferences.getInt("hkm", HOMEKIT_MODE_DISABLED); // homekitMode handled at start
+    // Load new HomeKit sub-device toggles (default true)
+    hkPowerEnabled = preferences.getBool("hk_pe", true);
+    hkSteamEnabled = preferences.getBool("hk_se", true);
+    hkSensorEnabled = preferences.getBool("hk_he", true);
     volumetricTarget = preferences.getBool("vt", false);
     otaChannel = preferences.getString("oc", DEFAULT_OTA_CHANNEL);
     savedScale = preferences.getString("ssc", "");
@@ -203,8 +234,29 @@ void Settings::setMdnsName(const String &mdnsName) {
     save();
 }
 
-void Settings::setHomekit(const bool homekit) {
-    this->homekit = homekit;
+// Homekit mode
+void Settings::setHomekitMode(const int mode) {
+    int clampedMode = std::clamp(mode, (int)HOMEKIT_MODE_DISABLED, (int)HOMEKIT_MODE_BRIDGE);
+    // check save
+    if (this->homekitMode != clampedMode) {
+        this->homekitMode = clampedMode;
+        save();
+    }
+}
+
+// HomeKit Device Setters
+void Settings::setHkPowerEnabled(bool enabled) {
+    hkPowerEnabled = enabled;
+    save();
+}
+
+void Settings::setHkSteamEnabled(bool enabled) {
+    hkSteamEnabled = enabled;
+    save();
+}
+
+void Settings::setHkSensorEnabled(bool enabled) {
+    hkSensorEnabled = enabled;
     save();
 }
 
@@ -443,7 +495,13 @@ void Settings::doSave() {
     preferences.putString("ws", wifiSsid);
     preferences.putString("wp", wifiPassword);
     preferences.putString("mn", mdnsName);
-    preferences.putBool("hk", homekit);
+    preferences.putInt("hkm", homekitMode);
+
+    // Save new HomeKit toggles
+    preferences.putBool("hk_pe", hkPowerEnabled);
+    preferences.putBool("hk_se", hkSteamEnabled);
+    preferences.putBool("hk_he", hkSensorEnabled);
+
     preferences.putBool("vt", volumetricTarget);
     preferences.putString("oc", otaChannel);
     preferences.putString("ssc", savedScale);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -5,32 +5,27 @@
 #include <esp32-hal-log.h>
 
 Settings::Settings() {
-    // Phase 1: HomeKit Migration (Read-Write Mode)
+    // Migrate the legacy HomeKit boolean before opening settings read-only.
     preferences.begin(PREFERENCES_KEY, false);
 
-    // Check if the old boolean key "hk" exists
     if (preferences.isKey("hk")) {
         ESP_LOGW("Settings", "Migrating old HomeKit bool setting 'hk' to new int setting 'hkm'.");
-        bool old_homekit_bool = preferences.getBool("hk", false);
+        bool oldHomekitBool = preferences.getBool("hk", false);
 
-        // Map old boolean to new integer modes
-        if (old_homekit_bool) {
+        if (oldHomekitBool) {
             homekitMode = HOMEKIT_MODE_THERMOSTAT;
         } else {
             homekitMode = HOMEKIT_MODE_DISABLED;
         }
 
-        // Save the new mode and remove the obsolete boolean key
         preferences.putInt("hkm", homekitMode);
         preferences.remove("hk");
         ESP_LOGI("Settings", "HomeKit migration complete. New mode: %d", homekitMode);
     } else {
-        // If no old key exists, just load the current mode or default to disabled
         homekitMode = preferences.getInt("hkm", HOMEKIT_MODE_DISABLED);
     }
-    preferences.end(); // Close write access
+    preferences.end();
 
-    // Phase 2: Standard Initialization (Read-Only Mode)
     preferences.begin(PREFERENCES_KEY, true);
     startupMode = preferences.getInt("sm", MODE_STANDBY);
     targetSteamTemp = preferences.getInt("ts", 145);
@@ -47,8 +42,6 @@ Settings::Settings() {
     wifiSsid = preferences.getString("ws", "");
     wifiPassword = preferences.getString("wp", "");
     mdnsName = preferences.getString("mn", DEFAULT_MDNS_NAME);
-    //homekitMode = preferences.getInt("hkm", HOMEKIT_MODE_DISABLED); // homekitMode handled at start
-    // Load new HomeKit sub-device toggles (default true)
     hkPowerEnabled = preferences.getBool("hk_pe", true);
     hkSteamEnabled = preferences.getBool("hk_se", true);
     hkSensorEnabled = preferences.getBool("hk_he", true);
@@ -234,17 +227,14 @@ void Settings::setMdnsName(const String &mdnsName) {
     save();
 }
 
-// Homekit mode
 void Settings::setHomekitMode(const int mode) {
     int clampedMode = std::clamp(mode, (int)HOMEKIT_MODE_DISABLED, (int)HOMEKIT_MODE_BRIDGE);
-    // check save
     if (this->homekitMode != clampedMode) {
         this->homekitMode = clampedMode;
         save();
     }
 }
 
-// HomeKit Device Setters
 void Settings::setHkPowerEnabled(bool enabled) {
     hkPowerEnabled = enabled;
     save();
@@ -496,8 +486,6 @@ void Settings::doSave() {
     preferences.putString("wp", wifiPassword);
     preferences.putString("mn", mdnsName);
     preferences.putInt("hkm", homekitMode);
-
-    // Save new HomeKit toggles
     preferences.putBool("hk_pe", hkPowerEnabled);
     preferences.putBool("hk_se", hkSteamEnabled);
     preferences.putBool("hk_he", hkSensorEnabled);

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -5,26 +5,7 @@
 #include <esp32-hal-log.h>
 
 Settings::Settings() {
-    // Migrate the legacy HomeKit boolean before opening settings read-only.
-    preferences.begin(PREFERENCES_KEY, false);
-
-    if (preferences.isKey("hk")) {
-        ESP_LOGW("Settings", "Migrating old HomeKit bool setting 'hk' to new int setting 'hkm'.");
-        bool oldHomekitBool = preferences.getBool("hk", false);
-
-        if (oldHomekitBool) {
-            homekitMode = HOMEKIT_MODE_THERMOSTAT;
-        } else {
-            homekitMode = HOMEKIT_MODE_DISABLED;
-        }
-
-        preferences.putInt("hkm", homekitMode);
-        preferences.remove("hk");
-        ESP_LOGI("Settings", "HomeKit migration complete. New mode: %d", homekitMode);
-    } else {
-        homekitMode = preferences.getInt("hkm", HOMEKIT_MODE_DISABLED);
-    }
-    preferences.end();
+    migrateHomekitSettings();
 
     preferences.begin(PREFERENCES_KEY, true);
     startupMode = preferences.getInt("sm", MODE_STANDBY);
@@ -228,7 +209,7 @@ void Settings::setMdnsName(const String &mdnsName) {
 }
 
 void Settings::setHomekitMode(const int mode) {
-    int clampedMode = std::clamp(mode, (int)HOMEKIT_MODE_DISABLED, (int)HOMEKIT_MODE_BRIDGE);
+    HomeKitMode clampedMode = parseHomekitMode(mode);
     if (this->homekitMode != clampedMode) {
         this->homekitMode = clampedMode;
         save();
@@ -485,7 +466,7 @@ void Settings::doSave() {
     preferences.putString("ws", wifiSsid);
     preferences.putString("wp", wifiPassword);
     preferences.putString("mn", mdnsName);
-    preferences.putInt("hkm", homekitMode);
+    preferences.putInt("hkm", static_cast<int>(homekitMode));
     preferences.putBool("hk_pe", hkPowerEnabled);
     preferences.putBool("hk_se", hkSteamEnabled);
     preferences.putBool("hk_he", hkSensorEnabled);
@@ -550,6 +531,29 @@ void Settings::doSave() {
     preferences.putInt("alt_relay", altRelayFunction);
 
     preferences.end();
+}
+
+void Settings::migrateHomekitSettings() {
+    preferences.begin(PREFERENCES_KEY, false);
+
+    if (preferences.isKey("hk")) {
+        ESP_LOGW("Settings", "Migrating old HomeKit bool setting 'hk' to new int setting 'hkm'.");
+        bool oldHomekitBool = preferences.getBool("hk", false);
+        homekitMode = oldHomekitBool ? HomeKitMode::Thermostat : HomeKitMode::Disabled;
+
+        preferences.putInt("hkm", static_cast<int>(homekitMode));
+        preferences.remove("hk");
+        ESP_LOGI("Settings", "HomeKit migration complete. New mode: %d", static_cast<int>(homekitMode));
+    } else {
+        homekitMode = parseHomekitMode(preferences.getInt("hkm", static_cast<int>(HomeKitMode::Disabled)));
+    }
+
+    preferences.end();
+}
+
+HomeKitMode Settings::parseHomekitMode(int mode) {
+    int clampedMode = std::clamp(mode, static_cast<int>(HomeKitMode::Disabled), static_cast<int>(HomeKitMode::Bridge));
+    return static_cast<HomeKitMode>(clampedMode);
 }
 
 [[noreturn]] void Settings::loopTask(void *arg) {

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -76,7 +76,6 @@ class Settings {
     String getWifiSsid() const { return wifiSsid; }
     String getWifiPassword() const { return wifiPassword; }
     String getMdnsName() const { return mdnsName; }
-    // HomeKit Settings
     int getHomekitMode() const { return homekitMode; }
     bool isHkPowerEnabled() const { return hkPowerEnabled; }
     bool isHkSteamEnabled() const { return hkSteamEnabled; }
@@ -136,7 +135,6 @@ class Settings {
     void setWifiSsid(const String &wifiSsid);
     void setWifiPassword(const String &wifiPassword);
     void setMdnsName(const String &mdnsName);
-    // HomeKit Setters
     void setHomekitMode(int homekitMode);
     void setHkPowerEnabled(bool enabled);
     void setHkSteamEnabled(bool enabled);
@@ -208,7 +206,6 @@ class Settings {
     String wifiPassword = "";
     String mdnsName = DEFAULT_MDNS_NAME;
     String savedScale = "";
-    // HomeKit Variables
     int homekitMode = HOMEKIT_MODE_DISABLED;
     bool hkPowerEnabled = true;
     bool hkSteamEnabled = true;

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -10,6 +10,12 @@
 
 #define PREFERENCES_KEY "controller"
 
+enum HomeKitMode {
+    HOMEKIT_MODE_DISABLED = 0,    // Default, HomeKit disabled
+    HOMEKIT_MODE_THERMOSTAT = 1,  // Thermostat
+    HOMEKIT_MODE_BRIDGE = 2       // Bridge
+};
+
 struct AutoWakeupSchedule {
     String time;    // HH:MM format
     bool days[7]{}; // [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
@@ -70,7 +76,11 @@ class Settings {
     String getWifiSsid() const { return wifiSsid; }
     String getWifiPassword() const { return wifiPassword; }
     String getMdnsName() const { return mdnsName; }
-    bool isHomekit() const { return homekit; }
+    // HomeKit Settings
+    int getHomekitMode() const { return homekitMode; }
+    bool isHkPowerEnabled() const { return hkPowerEnabled; }
+    bool isHkSteamEnabled() const { return hkSteamEnabled; }
+    bool isHkSensorEnabled() const { return hkSensorEnabled; }
     bool isVolumetricTarget() const { return volumetricTarget; }
     String getOTAChannel() const { return otaChannel; }
     String getSavedScale() const { return savedScale; }
@@ -126,7 +136,12 @@ class Settings {
     void setWifiSsid(const String &wifiSsid);
     void setWifiPassword(const String &wifiPassword);
     void setMdnsName(const String &mdnsName);
-    void setHomekit(bool homekit);
+    // HomeKit Setters
+    void setHomekitMode(int homekitMode);
+    void setHkPowerEnabled(bool enabled);
+    void setHkSteamEnabled(bool enabled);
+    void setHkSensorEnabled(bool enabled);
+    bool isHomekitEnabled() const { return homekitMode != HOMEKIT_MODE_DISABLED; }
     void setVolumetricTarget(bool volumetric_target);
     void setOTAChannel(const String &otaChannel);
     void setSavedScale(const String &savedScale);
@@ -193,7 +208,11 @@ class Settings {
     String wifiPassword = "";
     String mdnsName = DEFAULT_MDNS_NAME;
     String savedScale = "";
-    bool homekit = false;
+    // HomeKit Variables
+    int homekitMode = HOMEKIT_MODE_DISABLED;
+    bool hkPowerEnabled = true;
+    bool hkSteamEnabled = true;
+    bool hkSensorEnabled = true;
     bool volumetricTarget = false;
     bool boilerFillActive = false;
     int startupFillTime = 0;

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -10,10 +10,10 @@
 
 #define PREFERENCES_KEY "controller"
 
-enum HomeKitMode {
-    HOMEKIT_MODE_DISABLED = 0,    // Default, HomeKit disabled
-    HOMEKIT_MODE_THERMOSTAT = 1,  // Thermostat
-    HOMEKIT_MODE_BRIDGE = 2       // Bridge
+enum class HomeKitMode : int {
+    Disabled = 0,
+    Thermostat = 1,
+    Bridge = 2
 };
 
 struct AutoWakeupSchedule {
@@ -76,7 +76,7 @@ class Settings {
     String getWifiSsid() const { return wifiSsid; }
     String getWifiPassword() const { return wifiPassword; }
     String getMdnsName() const { return mdnsName; }
-    int getHomekitMode() const { return homekitMode; }
+    HomeKitMode getHomekitMode() const { return homekitMode; }
     bool isHkPowerEnabled() const { return hkPowerEnabled; }
     bool isHkSteamEnabled() const { return hkSteamEnabled; }
     bool isHkSensorEnabled() const { return hkSensorEnabled; }
@@ -139,7 +139,7 @@ class Settings {
     void setHkPowerEnabled(bool enabled);
     void setHkSteamEnabled(bool enabled);
     void setHkSensorEnabled(bool enabled);
-    bool isHomekitEnabled() const { return homekitMode != HOMEKIT_MODE_DISABLED; }
+    bool isHomekitEnabled() const { return homekitMode != HomeKitMode::Disabled; }
     void setVolumetricTarget(bool volumetric_target);
     void setOTAChannel(const String &otaChannel);
     void setSavedScale(const String &savedScale);
@@ -206,7 +206,7 @@ class Settings {
     String wifiPassword = "";
     String mdnsName = DEFAULT_MDNS_NAME;
     String savedScale = "";
-    int homekitMode = HOMEKIT_MODE_DISABLED;
+    HomeKitMode homekitMode = HomeKitMode::Disabled;
     bool hkPowerEnabled = true;
     bool hkSteamEnabled = true;
     bool hkSensorEnabled = true;
@@ -252,6 +252,8 @@ class Settings {
     int altRelayFunction = ALT_RELAY_GRIND; // Default to grind
 
     void doSave();
+    void migrateHomekitSettings();
+    static HomeKitMode parseHomekitMode(int mode);
     xTaskHandle taskHandle;
     static void loopTask(void *arg);
 };

--- a/src/display/plugins/HomekitBridgePlugin.cpp
+++ b/src/display/plugins/HomekitBridgePlugin.cpp
@@ -80,13 +80,12 @@ HomekitBridgePlugin::HomekitBridgePlugin(String wifiSsid, String wifiPassword)
     isHeatingStable.store(false);
 }
 
-void HomekitBridgePlugin::setup(Controller *controller, PluginManager *pluginManager) {
-    this->controller = controller;
+void HomekitBridgePlugin::setup(Controller *pluginController, PluginManager *pluginManager) {
+    this->controller = pluginController;
 
-    // Load configuration from Settings
-    bool enablePower = controller->getSettings().isHkPowerEnabled();
-    bool enableSteam = controller->getSettings().isHkSteamEnabled();
-    bool enableSensor = controller->getSettings().isHkSensorEnabled();
+    bool enablePower = pluginController->getSettings().isHkPowerEnabled();
+    bool enableSteam = pluginController->getSettings().isHkSteamEnabled();
+    bool enableSensor = pluginController->getSettings().isHkSensorEnabled();
 
     // Callback HomeKit -> Controller
     auto callback = [this](HomekitAction action, bool state) {
@@ -101,47 +100,12 @@ void HomekitBridgePlugin::setup(Controller *controller, PluginManager *pluginMan
 
     if (pluginManager == nullptr) return;
 
-    pluginManager->on("controller:wifi:connect", [this, enablePower, enableSteam, enableSensor, callback](Event &event) {
+    pluginManager->on("controller:wifi:connect", [this, enablePower, enableSteam, enableSensor, callback](Event const &event) {
         int apMode = event.getInt("AP");
         if (apMode) return;
         if (homekitStarted) return;
 
-        homekitStarted = true;
-        homeSpan.setHostNameSuffix("");
-        homeSpan.setPortNum(HOMESPAN_PORT);
-
-        homeSpan.begin(Category::Bridges, DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());
-        homeSpan.setWifiCredentials(wifiSsid.c_str(), wifiPassword.c_str());
-
-        new SpanAccessory(1);
-        new Service::AccessoryInformation();
-        new Characteristic::Identify();
-
-        if (enablePower) {
-            new SpanAccessory(2);
-            new Service::AccessoryInformation();
-            new Characteristic::Identify();
-            new Characteristic::Name("GaggiMate Power");
-            powerSwitch = new GaggiMatePowerSwitch(callback);
-        }
-
-        if (enableSteam) {
-            new SpanAccessory(3);
-            new Service::AccessoryInformation();
-            new Characteristic::Identify();
-            new Characteristic::Name("GaggiMate Steam");
-            steamSwitch = new GaggiMateSteamSwitch(callback);
-        }
-
-        if (enableSensor) {
-            new SpanAccessory(4);
-            new Service::AccessoryInformation();
-            new Characteristic::Identify();
-            new Characteristic::Name("GaggiMate Heating Status");
-            this->heatingSensor = new GaggiMateHeatingSensor();
-        }
-
-        homeSpan.autoPoll();
+        startHomekitBridge(enablePower, enableSteam, enableSensor, callback);
     });
 
     pluginManager->on("controller:mode:change", [this](Event const &e) {
@@ -149,10 +113,63 @@ void HomekitBridgePlugin::setup(Controller *controller, PluginManager *pluginMan
         this->statusUpdateRequired.store(true);
     });
 
-    pluginManager->on("boiler:heating:stable", [this](Event &e) {
+    pluginManager->on("boiler:heating:stable", [this](Event const &e) {
         this->isHeatingStable.store(e.getInt("isStable") == 1);
         this->heatingUpdateRequired.store(true);
     });
+}
+
+void HomekitBridgePlugin::startHomekitBridge(bool enablePower, bool enableSteam, bool enableSensor,
+                                             const bridge_callback_t &callback) {
+    homekitStarted = true;
+    homeSpan.setHostNameSuffix("");
+    homeSpan.setPortNum(HOMEKIT_BRIDGE_HOMESPAN_PORT);
+
+    homeSpan.begin(Category::Bridges, HOMEKIT_BRIDGE_DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());
+    homeSpan.setWifiCredentials(wifiSsid.c_str(), wifiPassword.c_str());
+
+    createBridgeAccessory();
+    if (enablePower) {
+        createPowerAccessory(callback);
+    }
+    if (enableSteam) {
+        createSteamAccessory(callback);
+    }
+    if (enableSensor) {
+        createHeatingSensorAccessory();
+    }
+
+    homeSpan.autoPoll();
+}
+
+void HomekitBridgePlugin::createBridgeAccessory() {
+    new SpanAccessory(1);
+    new Service::AccessoryInformation();
+    new Characteristic::Identify();
+}
+
+void HomekitBridgePlugin::createPowerAccessory(const bridge_callback_t &callback) {
+    new SpanAccessory(2);
+    new Service::AccessoryInformation();
+    new Characteristic::Identify();
+    new Characteristic::Name("GaggiMate Power");
+    powerSwitch = std::make_unique<GaggiMatePowerSwitch>(callback);
+}
+
+void HomekitBridgePlugin::createSteamAccessory(const bridge_callback_t &callback) {
+    new SpanAccessory(3);
+    new Service::AccessoryInformation();
+    new Characteristic::Identify();
+    new Characteristic::Name("GaggiMate Steam");
+    steamSwitch = std::make_unique<GaggiMateSteamSwitch>(callback);
+}
+
+void HomekitBridgePlugin::createHeatingSensorAccessory() {
+    new SpanAccessory(4);
+    new Service::AccessoryInformation();
+    new Characteristic::Identify();
+    new Characteristic::Name("GaggiMate Heating Status");
+    this->heatingSensor = std::make_unique<GaggiMateHeatingSensor>();
 }
 
 void HomekitBridgePlugin::loop() {

--- a/src/display/plugins/HomekitBridgePlugin.cpp
+++ b/src/display/plugins/HomekitBridgePlugin.cpp
@@ -1,0 +1,215 @@
+#include "HomekitBridgePlugin.h"
+#include "../core/Controller.h"
+#include "../core/PluginManager.h"
+#include "../core/constants.h"
+#include <utility>
+#include <Arduino.h>
+
+// ==========================================
+// Helper Classes Implementation
+// ==========================================
+
+// GaggiMatePowerSwitch
+GaggiMatePowerSwitch::GaggiMatePowerSwitch(bridge_callback_t callback)
+    : callback(std::move(callback)) {
+    power = new Characteristic::On();
+}
+
+boolean GaggiMatePowerSwitch::update() {
+    if (power->getVal() != power->getNewVal()) {
+        bool newState = power->getNewVal();
+        this->callback(HomekitAction::SWITCH_1_TOGGLE, newState);
+        return true;
+    }
+    return false;
+}
+
+void GaggiMatePowerSwitch::setState(bool active) {
+    if (power) power->setVal(active, true);
+}
+
+// GaggiMateSteamSwitch
+GaggiMateSteamSwitch::GaggiMateSteamSwitch(bridge_callback_t callback)
+    : callback(std::move(callback)) {
+    power = new Characteristic::On();
+}
+
+boolean GaggiMateSteamSwitch::update() {
+    if (power->getVal() != power->getNewVal()) {
+        bool newState = power->getNewVal();
+        this->callback(HomekitAction::SWITCH_2_TOGGLE, newState);
+        return true;
+    }
+    return false;
+}
+
+void GaggiMateSteamSwitch::setState(bool active) {
+    if (power) power->setVal(active, true);
+}
+
+// GaggiMateHeatingSensor
+GaggiMateHeatingSensor::GaggiMateHeatingSensor() : Service::ContactSensor() {
+    contactState = new Characteristic::ContactSensorState(0);
+}
+
+void GaggiMateHeatingSensor::setStability(bool isStable) {
+    int targetVal = isStable ? 1 : 0; // 0 = Contact Detected (Closed/Ready), 1 = Open
+
+    if (contactState && contactState->getVal() != targetVal) {
+        contactState->setVal(targetVal, true);
+    }
+}
+
+
+// ==========================================
+// Main Plugin Implementation
+// ==========================================
+
+HomekitBridgePlugin::HomekitBridgePlugin(String wifiSsid, String wifiPassword)
+    : wifiSsid(std::move(wifiSsid)), wifiPassword(std::move(wifiPassword)) {
+    // Init Atomics
+    actionRequired.store(false);
+    lastAction.store(HomekitAction::NONE);
+    actionSwitch1State.store(false);
+    actionSwitch2State.store(false);
+
+    statusUpdateRequired.store(false);
+    currentMachineMode.store(0);
+
+    heatingUpdateRequired.store(false);
+    isHeatingStable.store(false);
+}
+
+void HomekitBridgePlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+
+    // Load configuration from Settings
+    bool enablePower = controller->getSettings().isHkPowerEnabled();
+    bool enableSteam = controller->getSettings().isHkSteamEnabled();
+    bool enableSensor = controller->getSettings().isHkSensorEnabled();
+
+    // Callback HomeKit -> Controller
+    auto callback = [this](HomekitAction action, bool state) {
+        if (action == HomekitAction::SWITCH_1_TOGGLE) {
+            this->actionSwitch1State.store(state);
+        } else if (action == HomekitAction::SWITCH_2_TOGGLE) {
+            this->actionSwitch2State.store(state);
+        }
+        this->lastAction.store(action);
+        this->actionRequired.store(true);
+    };
+
+    homeSpan.setHostNameSuffix("");
+    homeSpan.setPortNum(HOMESPAN_PORT);
+
+    homeSpan.begin(Category::Bridges, DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());
+    homeSpan.setWifiCredentials(wifiSsid.c_str(), wifiPassword.c_str());
+
+    // ---------------------------------------------------------
+    // 1. The Bridge Accessory (ID = 1)
+    // ---------------------------------------------------------
+    new SpanAccessory(1); // Explicitly set ID 1
+    new Service::AccessoryInformation();
+    new Characteristic::Identify();
+
+    // ---------------------------------------------------------
+    // 2. Power Accessory (ID = 2)
+    // ---------------------------------------------------------
+    if (enablePower) {
+        new SpanAccessory(2); // Explicitly set ID 2
+        new Service::AccessoryInformation();
+        new Characteristic::Identify();
+        new Characteristic::Name("GaggiMate Power");
+        powerSwitch = new GaggiMatePowerSwitch(callback);
+    }
+
+    // ---------------------------------------------------------
+    // 3. Steam Accessory (ID = 3)
+    // ---------------------------------------------------------
+    if (enableSteam) {
+        new SpanAccessory(3); // Explicitly set ID 3
+        new Service::AccessoryInformation();
+        new Characteristic::Identify();
+        new Characteristic::Name("GaggiMate Steam");
+        steamSwitch = new GaggiMateSteamSwitch(callback);
+    }
+
+    // ---------------------------------------------------------
+    // 4. Sensor Accessory (ID = 4)
+    // ---------------------------------------------------------
+    if (enableSensor) {
+        new SpanAccessory(4); // Explicitly set ID 4
+        new Service::AccessoryInformation();
+        new Characteristic::Identify();
+        new Characteristic::Name("GaggiMate Heating Status");
+        this->heatingSensor = new GaggiMateHeatingSensor();
+    }
+
+    if (pluginManager != nullptr) {
+        // Thread-safe: Mode changes (Machine -> HomeKit)
+        pluginManager->on("controller:mode:change", [this](Event const &e) {
+            this->currentMachineMode.store(e.getInt("value"));
+            this->statusUpdateRequired.store(true);
+        });
+
+        // Thread-safe: Heating Status (Machine -> HomeKit)
+        pluginManager->on("boiler:heating:stable", [this](Event &e) {
+             this->isHeatingStable.store(e.getInt("isStable") == 1);
+             this->heatingUpdateRequired.store(true);
+        });
+    }
+
+    homeSpan.autoPoll();
+}
+
+void HomekitBridgePlugin::loop() {
+    if (controller == nullptr) return;
+
+    // Thread-Safe Sync: Machine -> HomeKit
+
+    // A) Update Power / Steam Switches
+    if (statusUpdateRequired.exchange(false)) {
+        int newMode = currentMachineMode.load();
+
+        // Only update if the object exists
+        if (this->powerSwitch) {
+            this->powerSwitch->setState(newMode != MODE_STANDBY);
+        }
+        if (this->steamSwitch) {
+            this->steamSwitch->setState(newMode == MODE_STEAM);
+        }
+    }
+
+    // B) Update Heating Sensor
+    if (heatingUpdateRequired.exchange(false)) {
+        bool stable = isHeatingStable.load();
+        // Only update if the object exists
+        if (this->heatingSensor) {
+            this->heatingSensor->setStability(stable);
+        }
+    }
+
+    // Action: HomeKit -> Controller
+    if (actionRequired.load()) {
+        HomekitAction currentAction = lastAction.load();
+        bool s1 = actionSwitch1State.load();
+        bool s2 = actionSwitch2State.load();
+
+        if (currentAction == HomekitAction::SWITCH_1_TOGGLE) {
+            if (s1) controller->deactivateStandby();
+            else controller->activateStandby();
+        } else if (currentAction == HomekitAction::SWITCH_2_TOGGLE) {
+            if (s2) controller->setMode(MODE_STEAM);
+            else {
+                controller->deactivate();
+                controller->setMode(MODE_BREW);
+            }
+        }
+        this->clearAction();
+    }
+}
+
+void HomekitBridgePlugin::clearAction() {
+    actionRequired.store(false);
+    lastAction.store(HomekitAction::NONE);
+}

--- a/src/display/plugins/HomekitBridgePlugin.cpp
+++ b/src/display/plugins/HomekitBridgePlugin.cpp
@@ -53,7 +53,7 @@ GaggiMateHeatingSensor::GaggiMateHeatingSensor() : Service::ContactSensor() {
 }
 
 void GaggiMateHeatingSensor::setStability(bool isStable) {
-    int targetVal = isStable ? 1 : 0; // 0 = Contact Detected (Closed/Ready), 1 = Open
+    int targetVal = isStable ? 1 : 0; // 0 = contact detected/heating, 1 = open/ready
 
     if (contactState && contactState->getVal() != targetVal) {
         contactState->setVal(targetVal, true);
@@ -99,73 +99,66 @@ void HomekitBridgePlugin::setup(Controller *controller, PluginManager *pluginMan
         this->actionRequired.store(true);
     };
 
-    homeSpan.setHostNameSuffix("");
-    homeSpan.setPortNum(HOMESPAN_PORT);
+    if (pluginManager == nullptr) return;
 
-    homeSpan.begin(Category::Bridges, DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());
-    homeSpan.setWifiCredentials(wifiSsid.c_str(), wifiPassword.c_str());
+    pluginManager->on("controller:wifi:connect", [this, enablePower, enableSteam, enableSensor, callback](Event &event) {
+        int apMode = event.getInt("AP");
+        if (apMode) return;
+        if (homekitStarted) return;
 
-    // ---------------------------------------------------------
-    // 1. The Bridge Accessory (ID = 1)
-    // ---------------------------------------------------------
-    new SpanAccessory(1); // Explicitly set ID 1
-    new Service::AccessoryInformation();
-    new Characteristic::Identify();
+        homekitStarted = true;
+        homeSpan.setHostNameSuffix("");
+        homeSpan.setPortNum(HOMESPAN_PORT);
 
-    // ---------------------------------------------------------
-    // 2. Power Accessory (ID = 2)
-    // ---------------------------------------------------------
-    if (enablePower) {
-        new SpanAccessory(2); // Explicitly set ID 2
+        homeSpan.begin(Category::Bridges, DEVICE_NAME, this->controller->getSettings().getMdnsName().c_str());
+        homeSpan.setWifiCredentials(wifiSsid.c_str(), wifiPassword.c_str());
+
+        new SpanAccessory(1);
         new Service::AccessoryInformation();
         new Characteristic::Identify();
-        new Characteristic::Name("GaggiMate Power");
-        powerSwitch = new GaggiMatePowerSwitch(callback);
-    }
 
-    // ---------------------------------------------------------
-    // 3. Steam Accessory (ID = 3)
-    // ---------------------------------------------------------
-    if (enableSteam) {
-        new SpanAccessory(3); // Explicitly set ID 3
-        new Service::AccessoryInformation();
-        new Characteristic::Identify();
-        new Characteristic::Name("GaggiMate Steam");
-        steamSwitch = new GaggiMateSteamSwitch(callback);
-    }
+        if (enablePower) {
+            new SpanAccessory(2);
+            new Service::AccessoryInformation();
+            new Characteristic::Identify();
+            new Characteristic::Name("GaggiMate Power");
+            powerSwitch = new GaggiMatePowerSwitch(callback);
+        }
 
-    // ---------------------------------------------------------
-    // 4. Sensor Accessory (ID = 4)
-    // ---------------------------------------------------------
-    if (enableSensor) {
-        new SpanAccessory(4); // Explicitly set ID 4
-        new Service::AccessoryInformation();
-        new Characteristic::Identify();
-        new Characteristic::Name("GaggiMate Heating Status");
-        this->heatingSensor = new GaggiMateHeatingSensor();
-    }
+        if (enableSteam) {
+            new SpanAccessory(3);
+            new Service::AccessoryInformation();
+            new Characteristic::Identify();
+            new Characteristic::Name("GaggiMate Steam");
+            steamSwitch = new GaggiMateSteamSwitch(callback);
+        }
 
-    if (pluginManager != nullptr) {
-        // Thread-safe: Mode changes (Machine -> HomeKit)
-        pluginManager->on("controller:mode:change", [this](Event const &e) {
-            this->currentMachineMode.store(e.getInt("value"));
-            this->statusUpdateRequired.store(true);
-        });
+        if (enableSensor) {
+            new SpanAccessory(4);
+            new Service::AccessoryInformation();
+            new Characteristic::Identify();
+            new Characteristic::Name("GaggiMate Heating Status");
+            this->heatingSensor = new GaggiMateHeatingSensor();
+        }
 
-        // Thread-safe: Heating Status (Machine -> HomeKit)
-        pluginManager->on("boiler:heating:stable", [this](Event &e) {
-             this->isHeatingStable.store(e.getInt("isStable") == 1);
-             this->heatingUpdateRequired.store(true);
-        });
-    }
+        homeSpan.autoPoll();
+    });
 
-    homeSpan.autoPoll();
+    pluginManager->on("controller:mode:change", [this](Event const &e) {
+        this->currentMachineMode.store(e.getInt("value"));
+        this->statusUpdateRequired.store(true);
+    });
+
+    pluginManager->on("boiler:heating:stable", [this](Event &e) {
+        this->isHeatingStable.store(e.getInt("isStable") == 1);
+        this->heatingUpdateRequired.store(true);
+    });
 }
 
 void HomekitBridgePlugin::loop() {
     if (controller == nullptr) return;
 
-    // Thread-Safe Sync: Machine -> HomeKit
+    // Thread-safe sync: Machine -> HomeKit
 
     // A) Update Power / Steam Switches
     if (statusUpdateRequired.exchange(false)) {

--- a/src/display/plugins/HomekitBridgePlugin.h
+++ b/src/display/plugins/HomekitBridgePlugin.h
@@ -1,0 +1,102 @@
+#pragma once
+#ifndef HOMEKITBRIDGEPLUGIN_H
+#define HOMEKITBRIDGEPLUGIN_H
+
+#include "../core/Plugin.h"
+#include "HomeSpan.h"
+#include <functional>
+#include <utility>
+#include <atomic>
+
+#include "../core/Event.h"
+
+#define HOMESPAN_PORT 8080
+#define DEVICE_NAME "GaggiMate"
+
+enum class HomekitAction {
+    NONE,
+    SWITCH_1_TOGGLE,
+    SWITCH_2_TOGGLE,
+};
+
+// Callback-Type def
+typedef std::function<void(HomekitAction, bool)> bridge_callback_t;
+
+// Accessoires:
+
+// Switch 1: Power
+class GaggiMatePowerSwitch : public Service::Switch {
+  public:
+    GaggiMatePowerSwitch(bridge_callback_t callback);
+    boolean update() override;
+    void setState(bool active);
+
+  private:
+    bridge_callback_t callback;
+    SpanCharacteristic *power;
+};
+
+// Switch 2: Steam
+class GaggiMateSteamSwitch : public Service::Switch {
+  public:
+    GaggiMateSteamSwitch(bridge_callback_t callback);
+    boolean update() override;
+    void setState(bool active);
+
+  private:
+    bridge_callback_t callback;
+    SpanCharacteristic *power;
+};
+
+
+// Contact Sensor (Heating Status)
+class GaggiMateHeatingSensor : public Service::ContactSensor {
+  public:
+    GaggiMateHeatingSensor();
+    // true = Ready, false = Heating
+    void setStability(bool isStable);
+  private:
+    SpanCharacteristic *contactState;
+};
+
+// Plugin Class
+
+class HomekitBridgePlugin : public Plugin {
+  public:
+    HomekitBridgePlugin(String wifiSsid, String wifiPassword);
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+    // Helper
+    void clearAction();
+
+    const char *getName() const { return "HomekitBridgePlugin"; }
+
+  private:
+    Controller *controller = nullptr;
+    String wifiSsid;
+    String wifiPassword;
+
+    // Bridged Accessoires
+    GaggiMatePowerSwitch *powerSwitch = nullptr;
+    GaggiMateSteamSwitch *steamSwitch = nullptr;
+    GaggiMateHeatingSensor *heatingSensor = nullptr;
+
+    // Thread-Safe variables (Atomic), fixing race condition
+
+    // HomeKit -> Maschine
+    std::atomic<HomekitAction> lastAction{HomekitAction::NONE};
+    std::atomic<bool> actionSwitch1State{false};
+    std::atomic<bool> actionSwitch2State{false};
+    std::atomic<bool> actionRequired{false};
+
+    // Maschine -> HomeKit (Mode)
+    std::atomic<bool> statusUpdateRequired{false};
+    std::atomic<int> currentMachineMode{0}; // 0 = Standby default
+
+    // Maschine -> HomeKit (Heating) - DIESE HABEN GEFEHLT
+    std::atomic<bool> heatingUpdateRequired{false};
+    std::atomic<bool> isHeatingStable{false};
+};
+
+#endif // HOMEKITBRIDGEPLUGIN_H

--- a/src/display/plugins/HomekitBridgePlugin.h
+++ b/src/display/plugins/HomekitBridgePlugin.h
@@ -5,13 +5,14 @@
 #include "../core/Plugin.h"
 #include "HomeSpan.h"
 #include <functional>
+#include <memory>
 #include <utility>
 #include <atomic>
 
 #include "../core/Event.h"
 
-#define HOMESPAN_PORT 8080
-#define DEVICE_NAME "GaggiMate"
+static constexpr uint16_t HOMEKIT_BRIDGE_HOMESPAN_PORT = 8080;
+static constexpr const char *HOMEKIT_BRIDGE_DEVICE_NAME = "GaggiMate";
 
 enum class HomekitAction {
     NONE,
@@ -20,14 +21,14 @@ enum class HomekitAction {
 };
 
 // Callback type
-typedef std::function<void(HomekitAction, bool)> bridge_callback_t;
+using bridge_callback_t = std::function<void(HomekitAction, bool)>;
 
 // Accessories
 
 // Switch 1: Power
 class GaggiMatePowerSwitch : public Service::Switch {
   public:
-    GaggiMatePowerSwitch(bridge_callback_t callback);
+    explicit GaggiMatePowerSwitch(bridge_callback_t callback);
     boolean update() override;
     void setState(bool active);
 
@@ -39,7 +40,7 @@ class GaggiMatePowerSwitch : public Service::Switch {
 // Switch 2: Steam
 class GaggiMateSteamSwitch : public Service::Switch {
   public:
-    GaggiMateSteamSwitch(bridge_callback_t callback);
+    explicit GaggiMateSteamSwitch(bridge_callback_t callback);
     boolean update() override;
     void setState(bool active);
 
@@ -63,7 +64,7 @@ class GaggiMateHeatingSensor : public Service::ContactSensor {
 class HomekitBridgePlugin : public Plugin {
   public:
     HomekitBridgePlugin(String wifiSsid, String wifiPassword);
-    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void setup(Controller *pluginController, PluginManager *pluginManager) override;
     void loop() override;
 
     // Helper
@@ -72,15 +73,21 @@ class HomekitBridgePlugin : public Plugin {
     const char *getName() const { return "HomekitBridgePlugin"; }
 
   private:
+    void startHomekitBridge(bool enablePower, bool enableSteam, bool enableSensor, const bridge_callback_t &callback);
+    void createBridgeAccessory();
+    void createPowerAccessory(const bridge_callback_t &callback);
+    void createSteamAccessory(const bridge_callback_t &callback);
+    void createHeatingSensorAccessory();
+
     Controller *controller = nullptr;
     String wifiSsid;
     String wifiPassword;
     bool homekitStarted = false;
 
     // Bridged accessories
-    GaggiMatePowerSwitch *powerSwitch = nullptr;
-    GaggiMateSteamSwitch *steamSwitch = nullptr;
-    GaggiMateHeatingSensor *heatingSensor = nullptr;
+    std::unique_ptr<GaggiMatePowerSwitch> powerSwitch = nullptr;
+    std::unique_ptr<GaggiMateSteamSwitch> steamSwitch = nullptr;
+    std::unique_ptr<GaggiMateHeatingSensor> heatingSensor = nullptr;
 
     // Thread-safe variables
 

--- a/src/display/plugins/HomekitBridgePlugin.h
+++ b/src/display/plugins/HomekitBridgePlugin.h
@@ -19,10 +19,10 @@ enum class HomekitAction {
     SWITCH_2_TOGGLE,
 };
 
-// Callback-Type def
+// Callback type
 typedef std::function<void(HomekitAction, bool)> bridge_callback_t;
 
-// Accessoires:
+// Accessories
 
 // Switch 1: Power
 class GaggiMatePowerSwitch : public Service::Switch {
@@ -53,7 +53,6 @@ class GaggiMateSteamSwitch : public Service::Switch {
 class GaggiMateHeatingSensor : public Service::ContactSensor {
   public:
     GaggiMateHeatingSensor();
-    // true = Ready, false = Heating
     void setStability(bool isStable);
   private:
     SpanCharacteristic *contactState;
@@ -76,25 +75,26 @@ class HomekitBridgePlugin : public Plugin {
     Controller *controller = nullptr;
     String wifiSsid;
     String wifiPassword;
+    bool homekitStarted = false;
 
-    // Bridged Accessoires
+    // Bridged accessories
     GaggiMatePowerSwitch *powerSwitch = nullptr;
     GaggiMateSteamSwitch *steamSwitch = nullptr;
     GaggiMateHeatingSensor *heatingSensor = nullptr;
 
-    // Thread-Safe variables (Atomic), fixing race condition
+    // Thread-safe variables
 
-    // HomeKit -> Maschine
+    // HomeKit -> machine
     std::atomic<HomekitAction> lastAction{HomekitAction::NONE};
     std::atomic<bool> actionSwitch1State{false};
     std::atomic<bool> actionSwitch2State{false};
     std::atomic<bool> actionRequired{false};
 
-    // Maschine -> HomeKit (Mode)
+    // Machine -> HomeKit (mode)
     std::atomic<bool> statusUpdateRequired{false};
     std::atomic<int> currentMachineMode{0}; // 0 = Standby default
 
-    // Maschine -> HomeKit (Heating) - DIESE HABEN GEFEHLT
+    // Machine -> HomeKit (heating)
     std::atomic<bool> heatingUpdateRequired{false};
     std::atomic<bool> isHeatingStable{false};
 };

--- a/src/display/plugins/HomekitThermostatPlugin.cpp
+++ b/src/display/plugins/HomekitThermostatPlugin.cpp
@@ -1,4 +1,4 @@
-#include "HomekitPlugin.h"
+#include "HomekitThermostatPlugin.h"
 #include "../core/Controller.h"
 #include "../core/constants.h"
 #include <utility>
@@ -42,17 +42,17 @@ void HomekitAccessory::setTargetTemperature(float temperatureValue) const { targ
 
 float HomekitAccessory::getTargetTemperature() const { return targetTemperature->getVal(); }
 
-HomekitPlugin::HomekitPlugin(String wifiSsid, String wifiPassword)
+HomekitThermostatPlugin::HomekitThermostatPlugin(String wifiSsid, String wifiPassword)
     : spanAccessory(nullptr), accessoryInformation(nullptr), identify(nullptr), accessory(nullptr), controller(nullptr) {
     this->wifiSsid = std::move(wifiSsid);
     this->wifiPassword = std::move(wifiPassword);
 }
 
-bool HomekitPlugin::hasAction() const { return actionRequired; }
+bool HomekitThermostatPlugin::hasAction() const { return actionRequired; }
 
-void HomekitPlugin::clearAction() { actionRequired = false; }
+void HomekitThermostatPlugin::clearAction() { actionRequired = false; }
 
-void HomekitPlugin::setup(Controller *controller, PluginManager *pluginManager) {
+void HomekitThermostatPlugin::setup(Controller *controller, PluginManager *pluginManager) {
     this->controller = controller;
 
     pluginManager->on("controller:wifi:connect", [this](Event &event) {
@@ -91,7 +91,7 @@ void HomekitPlugin::setup(Controller *controller, PluginManager *pluginManager) 
     });
 }
 
-void HomekitPlugin::loop() {
+void HomekitThermostatPlugin::loop() {
     if (!actionRequired || controller == nullptr || accessory == nullptr)
         return;
     if (accessory->getState() && controller->getMode() == MODE_STANDBY) {

--- a/src/display/plugins/HomekitThermostatPlugin.cpp
+++ b/src/display/plugins/HomekitThermostatPlugin.cpp
@@ -52,8 +52,8 @@ bool HomekitThermostatPlugin::hasAction() const { return actionRequired; }
 
 void HomekitThermostatPlugin::clearAction() { actionRequired = false; }
 
-void HomekitThermostatPlugin::setup(Controller *controller, PluginManager *pluginManager) {
-    this->controller = controller;
+void HomekitThermostatPlugin::setup(Controller *pluginController, PluginManager *pluginManager) {
+    this->controller = pluginController;
 
     pluginManager->on("controller:wifi:connect", [this](Event &event) {
         int apMode = event.getInt("AP");

--- a/src/display/plugins/HomekitThermostatPlugin.h
+++ b/src/display/plugins/HomekitThermostatPlugin.h
@@ -1,5 +1,6 @@
-#ifndef HOMEKITPLUGIN_H
-#define HOMEKITPLUGIN_H
+#pragma once
+#ifndef HOMEKITTHERMOSTATPLUGIN_H
+#define HOMEKITTHERMOSTATPLUGIN_H
 #include "../core/Plugin.h"
 #include "HomeSpan.h"
 
@@ -26,9 +27,9 @@ class HomekitAccessory : public Service::Thermostat {
     SpanCharacteristic *displayUnits;
 };
 
-class HomekitPlugin : public Plugin {
+class HomekitThermostatPlugin : public Plugin {
   public:
-    HomekitPlugin(String wifiSsid, String wifiPassword);
+    HomekitThermostatPlugin(String wifiSsid, String wifiPassword);
     void setup(Controller *controller, PluginManager *pluginManager) override;
     void loop() override;
 
@@ -46,4 +47,4 @@ class HomekitPlugin : public Plugin {
     Controller *controller;
 };
 
-#endif // HOMEKITPLUGIN_H
+#endif // HOMEKITTHERMOSTATPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -607,7 +607,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["startupMode"] = settings.getStartupMode() == MODE_BREW ? "brew" : "standby";
     doc["targetSteamTemp"] = settings.getTargetSteamTemp();
     doc["targetWaterTemp"] = settings.getTargetWaterTemp();
-    doc["homekitMode"] = settings.getHomekitMode();
+    doc["homekitMode"] = static_cast<int>(settings.getHomekitMode());
     doc["hkPowerEnabled"] = settings.isHkPowerEnabled();
     doc["hkSteamEnabled"] = settings.isHkSteamEnabled();
     doc["hkSensorEnabled"] = settings.isHkSensorEnabled();

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -484,7 +484,13 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setMdnsName(request->arg("mdnsName"));
             if (request->hasArg("wifiPassword") && request->arg("wifiPassword") != "---unchanged---")
                 settings->setWifiPassword(request->arg("wifiPassword"));
-            settings->setHomekit(request->hasArg("homekit"));
+            if (request->hasArg("homekitMode")) {
+                settings->setHomekitMode(request->arg("homekitMode").toInt());
+            }
+            // Handle HomeKit Toggle Settings
+            settings->setHkPowerEnabled(request->hasArg("hkPowerEnabled"));
+            settings->setHkSteamEnabled(request->hasArg("hkSteamEnabled"));
+            settings->setHkSensorEnabled(request->hasArg("hkSensorEnabled"));
             settings->setBoilerFillActive(request->hasArg("boilerFillActive"));
             if (request->hasArg("startupFillTime"))
                 settings->setStartupFillTime(request->arg("startupFillTime").toInt() * 1000);
@@ -601,7 +607,10 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["startupMode"] = settings.getStartupMode() == MODE_BREW ? "brew" : "standby";
     doc["targetSteamTemp"] = settings.getTargetSteamTemp();
     doc["targetWaterTemp"] = settings.getTargetWaterTemp();
-    doc["homekit"] = settings.isHomekit();
+    doc["homekitMode"] = settings.getHomekitMode();
+    doc["hkPowerEnabled"] = settings.isHkPowerEnabled();
+    doc["hkSteamEnabled"] = settings.isHkSteamEnabled();
+    doc["hkSensorEnabled"] = settings.isHkSensorEnabled();
     doc["homeAssistant"] = settings.isHomeAssistant();
     doc["haUser"] = settings.getHomeAssistantUser();
     doc["haPassword"] = settings.getHomeAssistantPassword();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -41,6 +41,8 @@ void DefaultUI::updateTempHistory() {
 }
 
 void DefaultUI::updateTempStableFlag() {
+    int oldIsStable = isTemperatureStable; // Saves state before calculation
+
     if (isTempHistoryInitialized) {
         float totalError = 0.0f;
         float maxError = 0.0f;
@@ -62,6 +64,11 @@ void DefaultUI::updateTempStableFlag() {
     }
 
     prevTargetTemp = targetTemp;
+
+    // Event Broadcasting: only send event if stability status has changed
+    if (isTemperatureStable != oldIsStable) {
+        pluginManager->trigger("boiler:heating:stable", "isStable", isTemperatureStable);
+    }
 }
 
 void DefaultUI::adjustHeatingIndicator(lv_obj_t *dials) {

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -41,7 +41,7 @@ void DefaultUI::updateTempHistory() {
 }
 
 void DefaultUI::updateTempStableFlag() {
-    int oldIsStable = isTemperatureStable; // Saves state before calculation
+    int oldIsStable = isTemperatureStable;
 
     if (isTempHistoryInitialized) {
         float totalError = 0.0f;
@@ -65,7 +65,6 @@ void DefaultUI::updateTempStableFlag() {
 
     prevTargetTemp = targetTemp;
 
-    // Event Broadcasting: only send event if stability status has changed
     if (isTemperatureStable != oldIsStable) {
         pluginManager->trigger("boiler:heating:stable", "isStable", isTemperatureStable);
     }

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -77,9 +77,6 @@ class DefaultUI {
     int isTemperatureStable = false;
     unsigned long lastTempLog = 0;
 
-    // recognize status change for plugins
-    int prevIsTemperatureStable = false;
-
     void updateTempHistory();
     void updateTempStableFlag();
     void adjustHeatingIndicator(lv_obj_t *contentPanel);

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -77,6 +77,9 @@ class DefaultUI {
     int isTemperatureStable = false;
     unsigned long lastTempLog = 0;
 
+    // recognize status change for plugins
+    int prevIsTemperatureStable = false;
+
     void updateTempHistory();
     void updateTempStableFlag();
     void adjustHeatingIndicator(lv_obj_t *contentPanel);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -77,6 +77,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -934,6 +935,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
       "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.0.0"
       },
@@ -1918,6 +1920,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2223,6 +2226,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -2306,6 +2310,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
       "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -2483,7 +2488,8 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -2884,6 +2890,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4711,6 +4718,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4747,6 +4755,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4766,6 +4775,7 @@
       "version": "10.25.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.0.tgz",
       "integrity": "sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4793,6 +4803,7 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.13.tgz",
       "integrity": "sha512-iGPd+hKPMFKsfpR2vL4kJ6ZPcFIoWZEcBf0Dpm3zOpdVvj77aY8RlLiQji5OMrngEyaxGogeakTb54uS2FvA6w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -4812,6 +4823,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5636,6 +5648,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5885,6 +5898,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -6359,6 +6373,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
       "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "7.0.0"
       }
@@ -6968,7 +6983,8 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -7167,6 +7183,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
       "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -7213,6 +7230,7 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
       "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "peer": true,
       "requires": {
         "@kurkle/color": "^0.3.0"
       }
@@ -7333,7 +7351,8 @@
     "dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "peer": true
     },
     "debug": {
       "version": "4.3.7",
@@ -7629,6 +7648,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8828,7 +8848,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "possible-typed-array-names": {
       "version": "1.0.0",
@@ -8841,6 +8862,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8856,7 +8878,8 @@
     "preact": {
       "version": "10.25.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.0.tgz",
-      "integrity": "sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg=="
+      "integrity": "sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg==",
+      "peer": true
     },
     "preact-fetching": {
       "version": "1.0.0",
@@ -8874,6 +8897,7 @@
       "version": "6.5.13",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.13.tgz",
       "integrity": "sha512-iGPd+hKPMFKsfpR2vL4kJ6ZPcFIoWZEcBf0Dpm3zOpdVvj77aY8RlLiQji5OMrngEyaxGogeakTb54uS2FvA6w==",
+      "peer": true,
       "requires": {}
     },
     "prelude-ls": {
@@ -8886,7 +8910,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-plugin-tailwindcss": {
       "version": "0.6.14",
@@ -9390,6 +9415,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -1,16 +1,41 @@
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import homekitImage from '../../assets/homekit.png';
+import { useState, useEffect } from 'preact/hooks';
 
 export function PluginCard({
   formData,
   onChange,
+  updateHomekitMode,
   autowakeupSchedules,
   addAutoWakeupSchedule,
   removeAutoWakeupSchedule,
   updateAutoWakeupTime,
   updateAutoWakeupDay,
 }) {
+
+ const homekitMode = parseInt(formData.homekitMode, 10) || 0;
+
+  // state exposing
+  const [isHomekitOpen, setIsHomekitOpen] = useState(homekitMode > 0);
+
+  // sync
+  useEffect(() => {
+    if (homekitMode > 0) {
+      setIsHomekitOpen(true);
+    }
+  }, [homekitMode]);
+
+  const handleHomekitToggle = () => {
+    const nextState = !isHomekitOpen;
+    setIsHomekitOpen(nextState);
+    if (!nextState) {
+      updateHomekitMode(0);
+    } else if (homekitMode === 0) {
+      updateHomekitMode(1);
+    }
+  };
+
   return (
     <div className='space-y-4'>
       <div className='bg-base-200 rounded-lg p-4'>
@@ -121,27 +146,193 @@ export function PluginCard({
         )}
       </div>
 
+      {/*homekit*/}
       <div className='bg-base-200 rounded-lg p-4'>
         <div className='flex items-center justify-between'>
-          <span className='text-xl font-medium'>HomeKit</span>
+          <span className='text-xl font-medium'>HomeKit Integration</span>
           <input
-            id='homekit'
-            name='homekit'
-            value='homekit'
             type='checkbox'
             className='toggle toggle-primary'
-            checked={!!formData.homekit}
-            onChange={onChange('homekit')}
-            aria-label='Enable HomeKit'
+            checked={isHomekitOpen}
+            onChange={handleHomekitToggle}
           />
         </div>
-        {formData.homekit && (
-          <div className='border-base-300 mt-4 flex flex-col items-center justify-center gap-4 border-t pt-4'>
-            <img src={homekitImage} alt='HomeKit Setup Code' />
-            <p className='text-center'>
-              Open the Home app on your iOS device, select Add Accessory, and enter the setup code
-              shown above.
+
+        {isHomekitOpen && (
+          <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
+
+            <p className='text-sm opacity-70'>
+              Control your machine via Apple Home.
             </p>
+
+            <div className='form-control'>
+              <label className='mb-2 block text-sm font-medium opacity-70'>Select Integration Mode</label>
+              <div className='grid grid-cols-2 gap-2'>
+                <button
+                  type='button'
+                  className={`btn btn-sm ${homekitMode === 1 ? 'btn-primary' : 'btn-outline'}`}
+                  onClick={() => updateHomekitMode(1)}
+                >
+                  Thermostat
+                </button>
+                <button
+                  type='button'
+                  className={`btn btn-sm ${homekitMode === 2 ? 'btn-primary' : 'btn-outline'}`}
+                  onClick={() => updateHomekitMode(2)}
+                >
+                  Bridge
+                </button>
+              </div>
+            </div>
+
+            {/* Descriptions & Device Selection */}
+            <div className='text-sm bg-base-100 p-4 rounded-md shadow-sm border border-base-300'>
+              {homekitMode === 1 && (
+                <p><strong>Thermostat Mode:</strong> Emulates a thermostat for direct temperature control (as before).</p>
+              )}
+              {homekitMode === 2 && (
+                <div>
+                  <strong>Bridge Mode:</strong> Exposes the machine capabilities as separate HomeKit accessories.
+
+                  {/* Accessory Toggles */}
+                  <div className="mt-4 pt-4 border-t border-base-300">
+                    <p className="text-sm font-medium opacity-70 mb-3">Enabled Accessories</p>
+
+                    <div className="space-y-4">
+                      {/* Power Switch */}
+                      <div className='form-control'>
+                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                          <input
+                            id='hkPowerEnabled'
+                            name='hkPowerEnabled'
+                            type="checkbox"
+                            className="toggle toggle-sm toggle-primary mt-1"
+                            checked={formData.hkPowerEnabled !== false}
+                            onChange={onChange('hkPowerEnabled')}
+                          />
+                          <div className='flex flex-col flex-1 min-w-0'>
+                            <span className='label-text font-medium'>Power Switch</span>
+                            <span className='text-xs opacity-70 block whitespace-normal'>
+                              Controls the main machine state (Standby / Brew).
+                            </span>
+                          </div>
+                        </label>
+                      </div>
+
+                      {/* Steam Switch */}
+                      <div className='form-control'>
+                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                          <input
+                            id='hkSteamEnabled'
+                            name='hkSteamEnabled'
+                            type="checkbox"
+                            className="toggle toggle-sm toggle-primary mt-1"
+                            checked={formData.hkSteamEnabled !== false}
+                            onChange={onChange('hkSteamEnabled')}
+                          />
+                          <div className='flex flex-col flex-1 min-w-0'>
+                             <span className='label-text font-medium'>Steam Switch</span>
+                             <span className='text-xs opacity-70 block whitespace-normal'>
+                               Toggles the Steam Mode.
+                             </span>
+                          </div>
+                        </label>
+                      </div>
+
+                      {/* Heating Sensor */}
+                      <div className='form-control'>
+                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                          <input
+                            id='hkSensorEnabled'
+                            name='hkSensorEnabled'
+                            type="checkbox"
+                            className="toggle toggle-sm toggle-primary mt-1"
+                            checked={formData.hkSensorEnabled !== false}
+                            onChange={onChange('hkSensorEnabled')}
+                          />
+                           <div className='flex flex-col flex-1 min-w-0'>
+                            <span className='label-text font-medium'>Heating Sensor</span>
+                            <span className='text-xs opacity-70 block whitespace-normal'>
+                              A contact sensor indicating boiler stability (Closed = Heating, Open = Ready).
+                            </span>
+                          </div>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+
+                </div>
+              )}
+            </div>
+
+            {/* Pairing Code */}
+            <div className='flex flex-col items-center justify-center gap-4 pt-4 border-t border-base-300'>
+              <img
+                src={homekitImage}
+                alt='Homekit Setup Code'
+                className='h-auto w-auto max-w-full object-contain'
+                style={{ maxHeight: '150px' }}
+              />
+
+              <div className='text-center space-y-2 max-w-md'>
+                 <p className='text-sm font-medium'>
+                  Open the Home app, select Add Accessory, and scan the code above.
+                </p>
+              </div>
+            </div>
+
+            {/* 3. COLLAPSIBLE TROUBLESHOOTING */}
+            <details className="collapse collapse-arrow bg-base-100 border border-base-300 rounded-box">
+                <summary className="collapse-title text-sm font-medium">
+                    Troubleshooting
+                </summary>
+                <div className="collapse-content text-xs text-base-content/70 space-y-3 pt-2">
+
+                    {/* No Connection / Update */}
+                    <div>
+                        <p className="font-bold mb-1">Devices not updating, connecting or other problems:</p>
+                        <ul className="list-disc list-inside ml-1 space-y-1">
+                            <li>
+                                <b>Cycle the modes:</b> Switch mode &rarr; Save & Restart &rarr; Wait for Apple Home to update GaggiMate devices
+                                (speed it up by tapping on one of the devices in the Home App and give it some time)
+                                &rarr; Switch back &rarr; Save & Restart.
+                            </li>
+                        </ul>
+                    </div>
+
+                    {/* Pairing Issues */}
+                    <div>
+                        <p className="font-bold mb-1">GaggiMate does not appear for pairing:</p>
+                        <ul className="list-disc list-inside ml-1 space-y-1">
+                            <li>
+                                Ensure no stale GaggiMate accessories remain in the Home App (check <i>Home Settings &rarr; Home Hubs & Bridges</i>).
+                                If unsure, try cycling the modes as described above.
+                            </li>
+
+                            {/* Console Reset Instructions */}
+                            <li className="mt-2 mb-1">
+                                <span className="font-semibold">Reset the HomeKit plugin via the console:</span>
+                                <ol className="list-decimal list-inside ml-2 mt-1 space-y-1">
+                                    <li>Connect your GaggiMate to the flashing web interface and open <b>Logs & Console</b>.</li>
+                                    <li>In the console, send <code>?</code> to list available HomeKit commands.</li>
+                                    <li>Send <code>H</code> to perform a HomeKit reset (this clears pairing info and restarts the accessory).</li>
+                                    <li>Re-add GaggiMate in the Home app using the setup code.</li>
+                                </ol>
+                                <div className="mt-1 ml-2 opacity-90">
+                                    If <code>H</code> is not available, check the console help (<code>?</code>). If this doesn’t resolve your issue, you may need to do a full reset with <code>E</code>.
+                                </div>
+                            </li>
+
+                            <li className="text-error font-bold mt-2">
+                                If GaggiMate still does not appear, you must reset the display.
+                                To do this, re-flash the display via USB (just like the initial installation).
+                                Don't forget to backup your profiles and settings first!
+                            </li>
+                        </ul>
+                    </div>
+
+                </div>
+            </details>
           </div>
         )}
       </div>

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -149,10 +149,10 @@ export function PluginCard({
           <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
             <p className='text-sm opacity-70'>Control GaggiMate from the Apple Home app.</p>
 
-            <div className='form-control' role='group' aria-labelledby='homekit-mode-label'>
-              <span id='homekit-mode-label' className='mb-2 block text-sm font-medium opacity-70'>
+            <fieldset className='form-control'>
+              <legend className='mb-2 block text-sm font-medium opacity-70'>
                 Integration mode
-              </span>
+              </legend>
               <div className='grid grid-cols-2 gap-2'>
                 <button
                   type='button'
@@ -171,7 +171,7 @@ export function PluginCard({
                   Bridge
                 </button>
               </div>
-            </div>
+            </fieldset>
 
             <div className='bg-base-100 border-base-300 rounded-md border p-4 text-sm'>
               {homekitMode === 1 && (

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -15,7 +15,7 @@ export function PluginCard({
   updateAutoWakeupTime,
   updateAutoWakeupDay,
 }) {
-  const homekitMode = parseInt(formData.homekitMode, 10) || 0;
+  const homekitMode = Number.parseInt(formData.homekitMode, 10) || 0;
   const homekitEnabled = homekitMode > 0;
   const [troubleshootingExpanded, setTroubleshootingExpanded] = useState(false);
 
@@ -149,8 +149,10 @@ export function PluginCard({
           <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
             <p className='text-sm opacity-70'>Control GaggiMate from the Apple Home app.</p>
 
-            <div className='form-control'>
-              <label className='mb-2 block text-sm font-medium opacity-70'>Integration mode</label>
+            <div className='form-control' role='group' aria-labelledby='homekit-mode-label'>
+              <span id='homekit-mode-label' className='mb-2 block text-sm font-medium opacity-70'>
+                Integration mode
+              </span>
               <div className='grid grid-cols-2 gap-2'>
                 <button
                   type='button'
@@ -187,7 +189,7 @@ export function PluginCard({
 
                     <div className='space-y-4'>
                       <div className='form-control'>
-                        <label className='label cursor-pointer items-start justify-start gap-4'>
+                        <div className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkPowerEnabled'
                             name='hkPowerEnabled'
@@ -195,18 +197,25 @@ export function PluginCard({
                             className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkPowerEnabled !== false}
                             onChange={onChange('hkPowerEnabled')}
+                            aria-labelledby='hk-power-enabled-label'
+                            aria-describedby='hk-power-enabled-description'
                           />
                           <div className='flex min-w-0 flex-1 flex-col'>
-                            <span className='label-text font-medium'>Power Switch</span>
-                            <span className='block text-xs whitespace-normal opacity-70'>
+                            <span id='hk-power-enabled-label' className='label-text font-medium'>
+                              Power Switch
+                            </span>
+                            <span
+                              id='hk-power-enabled-description'
+                              className='block text-xs whitespace-normal opacity-70'
+                            >
                               Controls the main machine state (Standby / Brew).
                             </span>
                           </div>
-                        </label>
+                        </div>
                       </div>
 
                       <div className='form-control'>
-                        <label className='label cursor-pointer items-start justify-start gap-4'>
+                        <div className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkSteamEnabled'
                             name='hkSteamEnabled'
@@ -214,18 +223,25 @@ export function PluginCard({
                             className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkSteamEnabled !== false}
                             onChange={onChange('hkSteamEnabled')}
+                            aria-labelledby='hk-steam-enabled-label'
+                            aria-describedby='hk-steam-enabled-description'
                           />
                           <div className='flex min-w-0 flex-1 flex-col'>
-                            <span className='label-text font-medium'>Steam Switch</span>
-                            <span className='block text-xs whitespace-normal opacity-70'>
+                            <span id='hk-steam-enabled-label' className='label-text font-medium'>
+                              Steam Switch
+                            </span>
+                            <span
+                              id='hk-steam-enabled-description'
+                              className='block text-xs whitespace-normal opacity-70'
+                            >
                               Toggles the Steam Mode.
                             </span>
                           </div>
-                        </label>
+                        </div>
                       </div>
 
                       <div className='form-control'>
-                        <label className='label cursor-pointer items-start justify-start gap-4'>
+                        <div className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkSensorEnabled'
                             name='hkSensorEnabled'
@@ -233,15 +249,22 @@ export function PluginCard({
                             className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkSensorEnabled !== false}
                             onChange={onChange('hkSensorEnabled')}
+                            aria-labelledby='hk-sensor-enabled-label'
+                            aria-describedby='hk-sensor-enabled-description'
                           />
                           <div className='flex min-w-0 flex-1 flex-col'>
-                            <span className='label-text font-medium'>Heating Sensor</span>
-                            <span className='block text-xs whitespace-normal opacity-70'>
+                            <span id='hk-sensor-enabled-label' className='label-text font-medium'>
+                              Heating Sensor
+                            </span>
+                            <span
+                              id='hk-sensor-enabled-description'
+                              className='block text-xs whitespace-normal opacity-70'
+                            >
                               A contact sensor indicating boiler stability (Closed = Heating, Open =
                               Ready).
                             </span>
                           </div>
-                        </label>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -322,9 +345,9 @@ export function PluginCard({
                           <li>Re-add GaggiMate in the Home app using the setup code.</li>
                         </ol>
                         <div className='mt-1 ml-2 opacity-90'>
-                          If <code>H</code> is not available, check the console help (<code>?</code>
-                          ). If this does not resolve your issue, you may need to do a full reset
-                          with <code>E</code>.
+                          If <code>H</code> is not available, send <code>?</code> again and check
+                          the console help. If this does not resolve your issue, you may need to do
+                          a full reset with <code>E</code>.
                         </div>
                       </li>
                       <li className='text-error mt-2 font-bold'>

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -1,7 +1,9 @@
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import homekitImage from '../../assets/homekit.png';
-import { useState, useEffect } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 
 export function PluginCard({
   formData,
@@ -13,27 +15,12 @@ export function PluginCard({
   updateAutoWakeupTime,
   updateAutoWakeupDay,
 }) {
-
- const homekitMode = parseInt(formData.homekitMode, 10) || 0;
-
-  // state exposing
-  const [isHomekitOpen, setIsHomekitOpen] = useState(homekitMode > 0);
-
-  // sync
-  useEffect(() => {
-    if (homekitMode > 0) {
-      setIsHomekitOpen(true);
-    }
-  }, [homekitMode]);
+  const homekitMode = parseInt(formData.homekitMode, 10) || 0;
+  const homekitEnabled = homekitMode > 0;
+  const [troubleshootingExpanded, setTroubleshootingExpanded] = useState(false);
 
   const handleHomekitToggle = () => {
-    const nextState = !isHomekitOpen;
-    setIsHomekitOpen(nextState);
-    if (!nextState) {
-      updateHomekitMode(0);
-    } else if (homekitMode === 0) {
-      updateHomekitMode(1);
-    }
+    updateHomekitMode(homekitEnabled ? 0 : 1);
   };
 
   return (
@@ -146,32 +133,30 @@ export function PluginCard({
         )}
       </div>
 
-      {/*homekit*/}
       <div className='bg-base-200 rounded-lg p-4'>
         <div className='flex items-center justify-between'>
           <span className='text-xl font-medium'>HomeKit Integration</span>
           <input
             type='checkbox'
             className='toggle toggle-primary'
-            checked={isHomekitOpen}
+            checked={homekitEnabled}
             onChange={handleHomekitToggle}
+            aria-label='Enable HomeKit'
           />
         </div>
 
-        {isHomekitOpen && (
+        {homekitEnabled && (
           <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
-
-            <p className='text-sm opacity-70'>
-              Control your machine via Apple Home.
-            </p>
+            <p className='text-sm opacity-70'>Control GaggiMate from the Apple Home app.</p>
 
             <div className='form-control'>
-              <label className='mb-2 block text-sm font-medium opacity-70'>Select Integration Mode</label>
+              <label className='mb-2 block text-sm font-medium opacity-70'>Integration mode</label>
               <div className='grid grid-cols-2 gap-2'>
                 <button
                   type='button'
                   className={`btn btn-sm ${homekitMode === 1 ? 'btn-primary' : 'btn-outline'}`}
                   onClick={() => updateHomekitMode(1)}
+                  aria-pressed={homekitMode === 1}
                 >
                   Thermostat
                 </button>
@@ -179,160 +164,179 @@ export function PluginCard({
                   type='button'
                   className={`btn btn-sm ${homekitMode === 2 ? 'btn-primary' : 'btn-outline'}`}
                   onClick={() => updateHomekitMode(2)}
+                  aria-pressed={homekitMode === 2}
                 >
                   Bridge
                 </button>
               </div>
             </div>
 
-            {/* Descriptions & Device Selection */}
-            <div className='text-sm bg-base-100 p-4 rounded-md shadow-sm border border-base-300'>
+            <div className='bg-base-100 border-base-300 rounded-md border p-4 text-sm'>
               {homekitMode === 1 && (
-                <p><strong>Thermostat Mode:</strong> Emulates a thermostat for direct temperature control (as before).</p>
+                <p>
+                  <strong>Thermostat mode:</strong> Emulates a thermostat for direct temperature
+                  control.
+                </p>
               )}
               {homekitMode === 2 && (
                 <div>
-                  <strong>Bridge Mode:</strong> Exposes the machine capabilities as separate HomeKit accessories.
+                  <strong>Bridge mode:</strong> Exposes the machine capabilities as separate HomeKit
+                  accessories.
+                  <div className='border-base-300 mt-4 border-t pt-4'>
+                    <p className='mb-3 text-sm font-medium opacity-70'>Enabled Accessories</p>
 
-                  {/* Accessory Toggles */}
-                  <div className="mt-4 pt-4 border-t border-base-300">
-                    <p className="text-sm font-medium opacity-70 mb-3">Enabled Accessories</p>
-
-                    <div className="space-y-4">
-                      {/* Power Switch */}
+                    <div className='space-y-4'>
                       <div className='form-control'>
-                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                        <label className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkPowerEnabled'
                             name='hkPowerEnabled'
-                            type="checkbox"
-                            className="toggle toggle-sm toggle-primary mt-1"
+                            type='checkbox'
+                            className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkPowerEnabled !== false}
                             onChange={onChange('hkPowerEnabled')}
                           />
-                          <div className='flex flex-col flex-1 min-w-0'>
+                          <div className='flex min-w-0 flex-1 flex-col'>
                             <span className='label-text font-medium'>Power Switch</span>
-                            <span className='text-xs opacity-70 block whitespace-normal'>
+                            <span className='block text-xs whitespace-normal opacity-70'>
                               Controls the main machine state (Standby / Brew).
                             </span>
                           </div>
                         </label>
                       </div>
 
-                      {/* Steam Switch */}
                       <div className='form-control'>
-                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                        <label className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkSteamEnabled'
                             name='hkSteamEnabled'
-                            type="checkbox"
-                            className="toggle toggle-sm toggle-primary mt-1"
+                            type='checkbox'
+                            className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkSteamEnabled !== false}
                             onChange={onChange('hkSteamEnabled')}
                           />
-                          <div className='flex flex-col flex-1 min-w-0'>
-                             <span className='label-text font-medium'>Steam Switch</span>
-                             <span className='text-xs opacity-70 block whitespace-normal'>
-                               Toggles the Steam Mode.
-                             </span>
+                          <div className='flex min-w-0 flex-1 flex-col'>
+                            <span className='label-text font-medium'>Steam Switch</span>
+                            <span className='block text-xs whitespace-normal opacity-70'>
+                              Toggles the Steam Mode.
+                            </span>
                           </div>
                         </label>
                       </div>
 
-                      {/* Heating Sensor */}
                       <div className='form-control'>
-                        <label className='label cursor-pointer justify-start gap-4 items-start'>
+                        <label className='label cursor-pointer items-start justify-start gap-4'>
                           <input
                             id='hkSensorEnabled'
                             name='hkSensorEnabled'
-                            type="checkbox"
-                            className="toggle toggle-sm toggle-primary mt-1"
+                            type='checkbox'
+                            className='toggle toggle-primary toggle-sm mt-1'
                             checked={formData.hkSensorEnabled !== false}
                             onChange={onChange('hkSensorEnabled')}
                           />
-                           <div className='flex flex-col flex-1 min-w-0'>
+                          <div className='flex min-w-0 flex-1 flex-col'>
                             <span className='label-text font-medium'>Heating Sensor</span>
-                            <span className='text-xs opacity-70 block whitespace-normal'>
-                              A contact sensor indicating boiler stability (Closed = Heating, Open = Ready).
+                            <span className='block text-xs whitespace-normal opacity-70'>
+                              A contact sensor indicating boiler stability (Closed = Heating, Open =
+                              Ready).
                             </span>
                           </div>
                         </label>
                       </div>
                     </div>
                   </div>
-
                 </div>
               )}
             </div>
 
-            {/* Pairing Code */}
-            <div className='flex flex-col items-center justify-center gap-4 pt-4 border-t border-base-300'>
+            <div className='border-base-300 flex flex-col items-center justify-center gap-4 border-t pt-4'>
               <img
                 src={homekitImage}
-                alt='Homekit Setup Code'
-                className='h-auto w-auto max-w-full object-contain'
-                style={{ maxHeight: '150px' }}
+                alt='HomeKit Setup Code'
+                className='h-auto max-h-[150px] w-auto max-w-full object-contain'
               />
 
-              <div className='text-center space-y-2 max-w-md'>
-                 <p className='text-sm font-medium'>
+              <div className='max-w-md space-y-2 text-center'>
+                <p className='text-sm font-medium'>
                   Open the Home app, select Add Accessory, and scan the code above.
                 </p>
               </div>
             </div>
 
-            {/* 3. COLLAPSIBLE TROUBLESHOOTING */}
-            <details className="collapse collapse-arrow bg-base-100 border border-base-300 rounded-box">
-                <summary className="collapse-title text-sm font-medium">
-                    Troubleshooting
-                </summary>
-                <div className="collapse-content text-xs text-base-content/70 space-y-3 pt-2">
+            <div className='bg-base-100 border-base-300 rounded-box border'>
+              <button
+                type='button'
+                className='flex w-full items-center gap-3 p-4 text-left text-sm font-medium'
+                onClick={() => setTroubleshootingExpanded(expanded => !expanded)}
+                aria-expanded={troubleshootingExpanded}
+                aria-controls='homekit-troubleshooting'
+              >
+                <span className='border-base-content/20 text-base-content/60 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border'>
+                  <FontAwesomeIcon
+                    icon={troubleshootingExpanded ? faMinus : faPlus}
+                    className='h-3 w-3'
+                  />
+                </span>
+                <span>Troubleshooting</span>
+              </button>
+              {troubleshootingExpanded && (
+                <div
+                  id='homekit-troubleshooting'
+                  className='text-base-content/70 space-y-3 px-4 pb-4 text-xs'
+                >
+                  <div>
+                    <p className='mb-1 font-bold'>Devices do not update or connect:</p>
+                    <ul className='ml-1 list-inside list-disc space-y-1'>
+                      <li>
+                        <b>Cycle the modes:</b> Switch mode &rarr; Save & Restart &rarr; Wait for
+                        the Home app to refresh the GaggiMate devices &rarr; Switch back &rarr; Save
+                        & Restart.
+                      </li>
+                    </ul>
+                  </div>
 
-                    {/* No Connection / Update */}
-                    <div>
-                        <p className="font-bold mb-1">Devices not updating, connecting or other problems:</p>
-                        <ul className="list-disc list-inside ml-1 space-y-1">
-                            <li>
-                                <b>Cycle the modes:</b> Switch mode &rarr; Save & Restart &rarr; Wait for Apple Home to update GaggiMate devices
-                                (speed it up by tapping on one of the devices in the Home App and give it some time)
-                                &rarr; Switch back &rarr; Save & Restart.
-                            </li>
-                        </ul>
-                    </div>
-
-                    {/* Pairing Issues */}
-                    <div>
-                        <p className="font-bold mb-1">GaggiMate does not appear for pairing:</p>
-                        <ul className="list-disc list-inside ml-1 space-y-1">
-                            <li>
-                                Ensure no stale GaggiMate accessories remain in the Home App (check <i>Home Settings &rarr; Home Hubs & Bridges</i>).
-                                If unsure, try cycling the modes as described above.
-                            </li>
-
-                            {/* Console Reset Instructions */}
-                            <li className="mt-2 mb-1">
-                                <span className="font-semibold">Reset the HomeKit plugin via the console:</span>
-                                <ol className="list-decimal list-inside ml-2 mt-1 space-y-1">
-                                    <li>Connect your GaggiMate to the flashing web interface and open <b>Logs & Console</b>.</li>
-                                    <li>In the console, send <code>?</code> to list available HomeKit commands.</li>
-                                    <li>Send <code>H</code> to perform a HomeKit reset (this clears pairing info and restarts the accessory).</li>
-                                    <li>Re-add GaggiMate in the Home app using the setup code.</li>
-                                </ol>
-                                <div className="mt-1 ml-2 opacity-90">
-                                    If <code>H</code> is not available, check the console help (<code>?</code>). If this doesn’t resolve your issue, you may need to do a full reset with <code>E</code>.
-                                </div>
-                            </li>
-
-                            <li className="text-error font-bold mt-2">
-                                If GaggiMate still does not appear, you must reset the display.
-                                To do this, re-flash the display via USB (just like the initial installation).
-                                Don't forget to backup your profiles and settings first!
-                            </li>
-                        </ul>
-                    </div>
-
+                  <div>
+                    <p className='mb-1 font-bold'>GaggiMate does not appear for pairing:</p>
+                    <ul className='ml-1 list-inside list-disc space-y-1'>
+                      <li>
+                        Ensure no stale GaggiMate accessories remain in the Home app (check{' '}
+                        <i>Home Settings &rarr; Home Hubs & Bridges</i>). If unsure, try cycling the
+                        modes as described above.
+                      </li>
+                      <li className='mt-2 mb-1'>
+                        <span className='font-semibold'>
+                          Reset the HomeKit plugin via the console:
+                        </span>
+                        <ol className='mt-1 ml-2 list-inside list-decimal space-y-1'>
+                          <li>
+                            Connect your GaggiMate to the flashing web interface and open{' '}
+                            <b>Logs & Console</b>.
+                          </li>
+                          <li>
+                            In the console, send <code>?</code> to list available HomeKit commands.
+                          </li>
+                          <li>
+                            Send <code>H</code> to perform a HomeKit reset (this clears pairing info
+                            and restarts the accessory).
+                          </li>
+                          <li>Re-add GaggiMate in the Home app using the setup code.</li>
+                        </ol>
+                        <div className='mt-1 ml-2 opacity-90'>
+                          If <code>H</code> is not available, check the console help (<code>?</code>
+                          ). If this does not resolve your issue, you may need to do a full reset
+                          with <code>E</code>.
+                        </div>
+                      </li>
+                      <li className='text-error mt-2 font-bold'>
+                        If GaggiMate still does not appear, perform a full display reset by
+                        re-flashing the display via USB, as you would during the initial
+                        installation. Back up your profiles and settings before continuing.
+                      </li>
+                    </ul>
+                  </div>
                 </div>
-            </details>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -75,6 +75,10 @@ export function Settings() {
             ? fetchedSettings.standbyDisplayEnabled
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
+        // Initialize HomeKit toggles (Default to true if undefined/new)
+        hkPowerEnabled: fetchedSettings.hkPowerEnabled !== undefined ? fetchedSettings.hkPowerEnabled : true,
+        hkSteamEnabled: fetchedSettings.hkSteamEnabled !== undefined ? fetchedSettings.hkSteamEnabled : true,
+        hkSensorEnabled: fetchedSettings.hkSensorEnabled !== undefined ? fetchedSettings.hkSensorEnabled : true,
       };
 
       // Extract Kf from PID string and separate them. Mirrors the same
@@ -128,9 +132,7 @@ export function Settings() {
   const onChange = key => {
     return e => {
       let value = e.currentTarget.value;
-      if (key === 'homekit') {
-        value = !formData.homekit;
-      }
+
       if (key === 'boilerFillActive') {
         value = !formData.boilerFillActive;
       }
@@ -139,6 +141,12 @@ export function Settings() {
       }
       if (key === 'smartGrindToggle') {
         value = !formData.smartGrindToggle;
+      }
+      if (key === 'homekitMode') {
+        value = parseInt(value, 10);
+      }
+      if (['hkPowerEnabled', 'hkSteamEnabled', 'hkSensorEnabled'].includes(key)) {
+        value = !formData[key];
       }
       if (key === 'homeAssistant') {
         value = !formData.homeAssistant;
@@ -188,6 +196,13 @@ export function Settings() {
     ]);
   };
 
+  const updateHomekitMode = (mode) => {
+    setFormData({
+      ...formData,
+      homekitMode: parseInt(mode, 10),
+    });
+  };
+
   const removeAutoWakeupSchedule = index => {
     if (autowakeupSchedules.length > 1) {
       const newSchedules = autowakeupSchedules.filter((_, i) => i !== index);
@@ -235,6 +250,8 @@ export function Settings() {
       if (!formData.standbyDisplayEnabled) {
         formDataToSubmit.set('standbyBrightness', '0');
       }
+
+      formDataToSubmit.set('homekitMode', formData.homekitMode !== undefined ? formData.homekitMode : 0);
 
       if (restart) {
         formDataToSubmit.append('restart', '1');
@@ -1038,6 +1055,7 @@ export function Settings() {
             <PluginCard
               formData={formData}
               onChange={onChange}
+              updateHomekitMode={updateHomekitMode}
               autowakeupSchedules={autowakeupSchedules}
               addAutoWakeupSchedule={addAutoWakeupSchedule}
               removeAutoWakeupSchedule={removeAutoWakeupSchedule}

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -75,10 +75,12 @@ export function Settings() {
             ? fetchedSettings.standbyDisplayEnabled
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
-        // Initialize HomeKit toggles (Default to true if undefined/new)
-        hkPowerEnabled: fetchedSettings.hkPowerEnabled !== undefined ? fetchedSettings.hkPowerEnabled : true,
-        hkSteamEnabled: fetchedSettings.hkSteamEnabled !== undefined ? fetchedSettings.hkSteamEnabled : true,
-        hkSensorEnabled: fetchedSettings.hkSensorEnabled !== undefined ? fetchedSettings.hkSensorEnabled : true,
+        hkPowerEnabled:
+          fetchedSettings.hkPowerEnabled !== undefined ? fetchedSettings.hkPowerEnabled : true,
+        hkSteamEnabled:
+          fetchedSettings.hkSteamEnabled !== undefined ? fetchedSettings.hkSteamEnabled : true,
+        hkSensorEnabled:
+          fetchedSettings.hkSensorEnabled !== undefined ? fetchedSettings.hkSensorEnabled : true,
       };
 
       // Extract Kf from PID string and separate them. Mirrors the same
@@ -196,7 +198,7 @@ export function Settings() {
     ]);
   };
 
-  const updateHomekitMode = (mode) => {
+  const updateHomekitMode = mode => {
     setFormData({
       ...formData,
       homekitMode: parseInt(mode, 10),
@@ -251,7 +253,17 @@ export function Settings() {
         formDataToSubmit.set('standbyBrightness', '0');
       }
 
-      formDataToSubmit.set('homekitMode', formData.homekitMode !== undefined ? formData.homekitMode : 0);
+      formDataToSubmit.set(
+        'homekitMode',
+        formData.homekitMode !== undefined ? formData.homekitMode : 0,
+      );
+      ['hkPowerEnabled', 'hkSteamEnabled', 'hkSensorEnabled'].forEach(key => {
+        if (formData[key] !== false) {
+          formDataToSubmit.set(key, 'on');
+        } else {
+          formDataToSubmit.delete(key);
+        }
+      });
 
       if (restart) {
         formDataToSubmit.append('restart', '1');

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -75,12 +75,9 @@ export function Settings() {
             ? fetchedSettings.standbyDisplayEnabled
             : fetchedSettings.standbyBrightness > 0,
         dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
-        hkPowerEnabled:
-          fetchedSettings.hkPowerEnabled !== undefined ? fetchedSettings.hkPowerEnabled : true,
-        hkSteamEnabled:
-          fetchedSettings.hkSteamEnabled !== undefined ? fetchedSettings.hkSteamEnabled : true,
-        hkSensorEnabled:
-          fetchedSettings.hkSensorEnabled !== undefined ? fetchedSettings.hkSensorEnabled : true,
+        hkPowerEnabled: fetchedSettings.hkPowerEnabled ?? true,
+        hkSteamEnabled: fetchedSettings.hkSteamEnabled ?? true,
+        hkSensorEnabled: fetchedSettings.hkSensorEnabled ?? true,
       };
 
       // Extract Kf from PID string and separate them. Mirrors the same
@@ -145,7 +142,7 @@ export function Settings() {
         value = !formData.smartGrindToggle;
       }
       if (key === 'homekitMode') {
-        value = parseInt(value, 10);
+        value = Number.parseInt(value, 10);
       }
       if (['hkPowerEnabled', 'hkSteamEnabled', 'hkSensorEnabled'].includes(key)) {
         value = !formData[key];
@@ -201,7 +198,7 @@ export function Settings() {
   const updateHomekitMode = mode => {
     setFormData({
       ...formData,
-      homekitMode: parseInt(mode, 10),
+      homekitMode: Number.parseInt(mode, 10),
     });
   };
 
@@ -253,15 +250,12 @@ export function Settings() {
         formDataToSubmit.set('standbyBrightness', '0');
       }
 
-      formDataToSubmit.set(
-        'homekitMode',
-        formData.homekitMode !== undefined ? formData.homekitMode : 0,
-      );
+      formDataToSubmit.set('homekitMode', formData.homekitMode ?? 0);
       ['hkPowerEnabled', 'hkSteamEnabled', 'hkSensorEnabled'].forEach(key => {
-        if (formData[key] !== false) {
-          formDataToSubmit.set(key, 'on');
-        } else {
+        if (formData[key] === false) {
           formDataToSubmit.delete(key);
+        } else {
+          formDataToSubmit.set(key, 'on');
         }
       });
 


### PR DESCRIPTION
Adds an optional HomeKit Bridge mode alongside the existing Thermostat mode. Bridge mode exposes GaggiMate controls as separate HomeKit accessories for power, steam, and heating status, with configurable accessory toggles in the Web UI.

Also includes migration from the previous HomeKit boolean setting to the new mode-based setting, keeps compatibility with HomeSpan 1.9.1, and updates the HomeKit settings UI with setup and troubleshooting guidance.

<img width="1267" height="475" alt="SCR-20260513-mgqb" src="https://github.com/user-attachments/assets/93132da6-7252-4cd5-a647-08f29388ddb9" />
<img width="1247" height="897" alt="SCR-20260513-mgub" src="https://github.com/user-attachments/assets/abec1e83-4cac-4c2a-9293-0117d6b8460b" />
<img width="1260" height="958" alt="SCR-20260513-mgvm" src="https://github.com/user-attachments/assets/d9010f27-6ea4-4fdc-b753-2dfb32be892d" />
<img width="1232" height="954" alt="SCR-20260513-mgym" src="https://github.com/user-attachments/assets/a9e84898-aca6-48a5-b6d7-18999782e757" />
<img width="563" height="1218" alt="Bildschirmfoto 2026-05-13 um 13 46 52" src="https://github.com/user-attachments/assets/adb15ef4-285c-4f16-ba17-9a0b78ef15c2" />
<img width="563" height="1218" alt="Bildschirmfoto 2026-05-13 um 13 45 44" src="https://github.com/user-attachments/assets/9c028b02-6b13-4263-9536-f062fd3c23ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HomeKit now supports two modes: Thermostat or Bridge.
  * Bridge mode exposes three accessories: power switch, steam switch, and a heating/contact sensor.
  * Per-feature toggles to enable/disable power, steam, and sensor integration.
  * Settings UI: “HomeKit Integration” toggle, mode chooser, accessory checkboxes, and a Troubleshooting accordion with reset/pairing instructions.

* **Bug Fixes**
  * Heating-stable notifications only fire when the stability state actually changes.

* **Chores**
  * Settings migrated from a single HomeKit flag to a numeric mode plus separate feature flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/697)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->