### PR TITLE
Move BLE notification handling into main loop context

### DIFF
--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -5,6 +5,7 @@ constexpr size_t MAX_CONNECT_RETRIES = 3;
 
 NimBLEClientController::NimBLEClientController() : client(nullptr) {}
 
+// Create the event queue with the BLE client so callbacks can stay copy-only.
 void NimBLEClientController::initClient() {
     NimBLEDevice::init("GPBLC");
     NimBLEDevice::setPower(ESP_PWR_LVL_P9); // Set to maximum power
@@ -14,6 +15,14 @@ void NimBLEClientController::initClient() {
     if (client == nullptr) {
         ESP_LOGE(LOG_TAG, "Failed to create BLE client");
         return;
+    }
+
+    if (pendingEventQueue == nullptr) {
+        pendingEventQueue = xQueueCreate(PENDING_EVENT_QUEUE_LENGTH, sizeof(PendingEvent));
+        if (pendingEventQueue == nullptr) {
+            ESP_LOGE(LOG_TAG, "Failed to create BLE event queue");
+            return;
+        }
     }
     client->setClientCallbacks(this);
 
@@ -161,6 +170,21 @@ void NimBLEClientController::loop() {
     }
 }
 
+// Run queued notification and disconnect work outside NimBLE callback context.
+void NimBLEClientController::dispatchPendingEvents() {
+    if (pendingEventQueue == nullptr) {
+        return;
+    }
+
+    PendingEvent event;
+    for (size_t dispatched = 0; dispatched < MAX_PENDING_EVENTS_PER_DISPATCH; dispatched++) {
+        if (xQueueReceive(pendingEventQueue, &event, 0) != pdTRUE) {
+            break;
+        }
+        dispatchPendingEvent(event);
+    }
+}
+
 void NimBLEClientController::sendAdvancedOutputControl(bool valve, float boilerSetpoint, bool pressureTarget, float pressure,
                                                        float flow) {
     if (client->isConnected() && outputControlChar != nullptr) {
@@ -243,50 +267,94 @@ void NimBLEClientController::onResult(NimBLEAdvertisedDevice *advertisedDevice) 
     }
 }
 
+// Queue disconnect work so earlier notifications are replayed first.
 void NimBLEClientController::onDisconnect(NimBLEClient *pServer) {
     ESP_LOGI(LOG_TAG, "Disconnected from server, trying to reconnect...");
-    tempControlChar = nullptr;
-    pumpControlChar = nullptr;
-    valveControlChar = nullptr;
-    altControlChar = nullptr;
-    tempReadChar = nullptr;
-    pingChar = nullptr;
-    pidControlChar = nullptr;
-    pumpModelCoeffsChar = nullptr;
-    errorChar = nullptr;
-    autotuneChar = nullptr;
-    autotuneResultChar = nullptr;
-    btnChar = nullptr;
-    infoChar = nullptr;
-    sensorChar = nullptr;
-    outputControlChar = nullptr;
-    pressureScaleChar = nullptr;
-    volumetricMeasurementChar = nullptr;
-    volumetricTareChar = nullptr;
-    ledControlChar = nullptr;
-    tofMeasurementChar = nullptr;
-    if (disconnectCallback != nullptr) {
-        disconnectCallback();
-    }
-    scan();
+
+    // scan() and disconnect callbacks can re-enter BLE/display code, so defer them.
+    enqueuePendingEvent(PendingEventType::Disconnect);
 }
 
-// Notification callback
+// Notification callback: copy payload bytes without invoking controller/plugin code.
 void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteCharacteristic, uint8_t *pData, size_t length,
-                                            bool) const {
-    char rawData[129];
-    size_t copyLength = length < (sizeof(rawData) - 1) ? length : (sizeof(rawData) - 1);
-    memcpy(rawData, pData, copyLength);
-    rawData[copyLength] = '\0';
+                                            bool) {
+    enqueuePendingEvent(getPendingEventType(pRemoteCharacteristic), pData, length);
+}
 
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(ERROR_CHAR_UUID))) {
+// Convert NimBLE callback state into queue-safe event metadata.
+NimBLEClientController::PendingEventType
+NimBLEClientController::getPendingEventType(NimBLERemoteCharacteristic *pRemoteCharacteristic) const {
+    if (pRemoteCharacteristic == nullptr) {
+        return PendingEventType::Unknown;
+    }
+
+    const NimBLEUUID uuid = pRemoteCharacteristic->getUUID();
+    if (uuid.equals(NimBLEUUID(ERROR_CHAR_UUID))) {
+        return PendingEventType::RemoteError;
+    }
+    if (uuid.equals(NimBLEUUID(BTN_UUID))) {
+        return PendingEventType::Button;
+    }
+    if (uuid.equals(NimBLEUUID(SENSOR_DATA_UUID))) {
+        return PendingEventType::SensorData;
+    }
+    if (uuid.equals(NimBLEUUID(AUTOTUNE_RESULT_UUID))) {
+        return PendingEventType::AutotuneResult;
+    }
+    if (uuid.equals(NimBLEUUID(VOLUMETRIC_MEASUREMENT_UUID))) {
+        return PendingEventType::VolumetricMeasurement;
+    }
+    if (uuid.equals(NimBLEUUID(TOF_MEASUREMENT_UUID))) {
+        return PendingEventType::TofMeasurement;
+    }
+    return PendingEventType::Unknown;
+}
+
+// Copy callback data into the queue without blocking the NimBLE task.
+bool NimBLEClientController::enqueuePendingEvent(PendingEventType type, const uint8_t *data, size_t length) {
+    if (pendingEventQueue == nullptr || type == PendingEventType::Unknown) {
+        return false;
+    }
+
+    PendingEvent event;
+    event.type = type;
+    if (data != nullptr && length > 0) {
+        const size_t copyLength =
+            length < (PENDING_EVENT_PAYLOAD_SIZE - 1) ? length : (PENDING_EVENT_PAYLOAD_SIZE - 1);
+        memcpy(event.payload, data, copyLength);
+        event.payload[copyLength] = '\0';
+    }
+
+    if (xQueueSend(pendingEventQueue, &event, 0) == pdTRUE) {
+        return true;
+    }
+
+    // Prefer the newest controller state if the display loop falls behind.
+    PendingEvent discarded;
+    xQueueReceive(pendingEventQueue, &discarded, 0);
+    if (xQueueSend(pendingEventQueue, &event, 0) == pdTRUE) {
+        ESP_LOGW(LOG_TAG, "BLE event queue full, discarded oldest event");
+        return true;
+    }
+
+    ESP_LOGE(LOG_TAG, "BLE event queue full, dropping event");
+    return false;
+}
+
+// Replay the original notification handling from application context.
+void NimBLEClientController::dispatchPendingEvent(const PendingEvent &event) {
+    const char *rawData = event.payload;
+
+    switch (event.type) {
+    case PendingEventType::RemoteError: {
         int errorCode = atoi(rawData);
         ESP_LOGV(LOG_TAG, "Error read: %d", errorCode);
         if (remoteErrorCallback != nullptr) {
             remoteErrorCallback(errorCode);
         }
+        break;
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(BTN_UUID))) {
+    case PendingEventType::Button: {
         int index = 0;
         int status = 0;
 
@@ -298,8 +366,9 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
         if (btnCallback != nullptr) {
             btnCallback(index, status);
         }
+        break;
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(SENSOR_DATA_UUID))) {
+    case PendingEventType::SensorData: {
         float temperature = 0.0f;
         float pressure = 0.0f;
         float puckFlow = 0.0f;
@@ -318,8 +387,9 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
         if (sensorCallback != nullptr) {
             sensorCallback(temperature, pressure, puckFlow, pumpFlow, puckResistance);
         }
+        break;
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(AUTOTUNE_RESULT_UUID))) {
+    case PendingEventType::AutotuneResult: {
         ESP_LOGV(LOG_TAG, "autotune result: %s", rawData);
         if (autotuneResultCallback != nullptr) {
             float Kp = 0.0f;
@@ -334,20 +404,54 @@ void NimBLEClientController::notifyCallback(NimBLERemoteCharacteristic *pRemoteC
 
             autotuneResultCallback(Kp, Ki, Kd, Kf);
         }
+        break;
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(VOLUMETRIC_MEASUREMENT_UUID))) {
+    case PendingEventType::VolumetricMeasurement: {
         float value = atof(rawData);
         ESP_LOGV(LOG_TAG, "Volumetric measurement: %.2f", value);
         if (volumetricMeasurementCallback != nullptr) {
             volumetricMeasurementCallback(value);
         }
+        break;
     }
-    if (pRemoteCharacteristic->getUUID().equals(NimBLEUUID(TOF_MEASUREMENT_UUID))) {
+    case PendingEventType::TofMeasurement: {
         int value = atoi(rawData);
         ESP_LOGV(LOG_TAG, "ToF measurement: %d", value);
         if (tofMeasurementCallback != nullptr) {
             tofMeasurementCallback(value);
         }
+        break;
+    }
+    case PendingEventType::Disconnect: {
+        tempControlChar = nullptr;
+        pumpControlChar = nullptr;
+        valveControlChar = nullptr;
+        altControlChar = nullptr;
+        tempReadChar = nullptr;
+        pingChar = nullptr;
+        pidControlChar = nullptr;
+        pumpModelCoeffsChar = nullptr;
+        errorChar = nullptr;
+        autotuneChar = nullptr;
+        autotuneResultChar = nullptr;
+        btnChar = nullptr;
+        infoChar = nullptr;
+        sensorChar = nullptr;
+        outputControlChar = nullptr;
+        pressureScaleChar = nullptr;
+        volumetricMeasurementChar = nullptr;
+        volumetricTareChar = nullptr;
+        ledControlChar = nullptr;
+        tofMeasurementChar = nullptr;
+
+        if (disconnectCallback != nullptr) {
+            disconnectCallback();
+        }
+        scan();
+        break;
+    }
+    case PendingEventType::Unknown:
+        break;
     }
 }
 

--- a/lib/NimBLEComm/src/NimBLEClientController.h
+++ b/lib/NimBLEComm/src/NimBLEClientController.h
@@ -3,6 +3,8 @@
 
 #include "NimBLEComm.h"
 #include "cstring"
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
 
 class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLEClientCallbacks {
   public:
@@ -10,6 +12,9 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void initClient();
     bool connectToServer();
     void loop();
+
+    // Drains BLE callback work from application context instead of the NimBLE task.
+    void dispatchPendingEvents();
 
     void sendAdvancedOutputControl(bool valve, float boilerSetpoint, bool pressureTarget, float pressure, float flow);
 
@@ -63,6 +68,34 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     bool readyForConnection = false;
     xTaskHandle taskHandle;
 
+    // One MTU-sized notification payload plus a null terminator for existing parsers.
+    static constexpr size_t PENDING_EVENT_PAYLOAD_SIZE = 129;
+
+    // Keep a short backlog without letting callback data grow unbounded.
+    static constexpr size_t PENDING_EVENT_QUEUE_LENGTH = 32;
+
+    // Bound dispatch work so Controller::loop() cannot spend a full pass draining BLE events.
+    static constexpr size_t MAX_PENDING_EVENTS_PER_DISPATCH = 8;
+
+    // Events copied out of NimBLE callbacks and replayed by dispatchPendingEvents().
+    enum class PendingEventType : uint8_t {
+        RemoteError,
+        Button,
+        SensorData,
+        AutotuneResult,
+        VolumetricMeasurement,
+        TofMeasurement,
+        Disconnect,
+        Unknown,
+    };
+
+    struct PendingEvent {
+        PendingEventType type = PendingEventType::Unknown;
+        char payload[PENDING_EVENT_PAYLOAD_SIZE]{};
+    };
+
+    QueueHandle_t pendingEventQueue = nullptr;
+
     remote_err_callback_t remoteErrorCallback = nullptr;
     button_callback_t btnCallback = nullptr;
     pid_control_callback_t autotuneResultCallback = nullptr;
@@ -84,7 +117,16 @@ class NimBLEClientController : public NimBLEAdvertisedDeviceCallbacks, NimBLECli
     void onDisconnect(NimBLEClient *pServer) override;
 
     // Notification callback
-    void notifyCallback(NimBLERemoteCharacteristic *pRemoteCharacteristic, uint8_t *pData, size_t length, bool isNotify) const;
+    void notifyCallback(NimBLERemoteCharacteristic *pRemoteCharacteristic, uint8_t *pData, size_t length, bool isNotify);
+
+    // Store a small enum in the queue instead of a NimBLE characteristic pointer.
+    PendingEventType getPendingEventType(NimBLERemoteCharacteristic *pRemoteCharacteristic) const;
+
+    // Must remain non-blocking and must not invoke application callbacks.
+    bool enqueuePendingEvent(PendingEventType type, const uint8_t *data = nullptr, size_t length = 0);
+
+    // Replays the original notification handling after leaving NimBLE callback context.
+    void dispatchPendingEvent(const PendingEvent &event);
 
     const char *LOG_TAG = "NimBLEClientController";
     static void loopTask(void *arg);

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -277,6 +277,8 @@ void Controller::setupWifi() {
 }
 
 void Controller::loop() {
+    // Drain BLE callback work before plugins/processes react to updated controller state.
+    clientController.dispatchPendingEvents();
     pluginManager->loop();
 
     if (screenReady) {


### PR DESCRIPTION
In the current firmware, when a DiFluid Microbalance is used and the shot is started with the rocker switch, the BLE interface hangs--the display can still be operated, but weight stops updating and shots can't be started until the display is reset. See, for example, this help request:

https://discord.com/channels/951416527721230336/1464770788144976048/1464800904233353440

This happens because the display receives a BLE notification from the controller, and inside the notification context it sends a write with response to the Microbalance. The BLE stack blocks waiting for the response, but the response is never processed because we have not returned from the BLE notification callback.

To fix this, rather than handling BLE notifications immediately, they are added to a queue which is then processed in the main loop context. With this change, the notification callback returns immediately, the notification is handled in the main loop, and the write with response is correctly handled since the BLE stack is no longer blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Bluetooth notifications now enqueue and are parsed later, then dispatched from the main loop for ordered, non-blocking processing.
  * Startup now validates the event queue and aborts initialization if it cannot be created.

* **Bug Fixes**
  * Disconnects are handled via the queued pipeline to ensure consistent cleanup and callbacks.
  * Queue overflow discards oldest events to preserve recent updates; excess enqueues are logged/dropped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->