### PR TITLE
feat(profile-import): add Meticulous JSON profile importer

### DIFF
--- a/web/src/pages/ProfileList/utils.js
+++ b/web/src/pages/ProfileList/utils.js
@@ -4,7 +4,7 @@ export function parseProfile(input) {
   try {
     let profiles = JSON.parse(input);
     if (!Array.isArray(profiles)) {
-      profiles = parseJsonProfile(profiles);
+      profiles = convertJsonProfile(profiles);
       profiles = [profiles];
     }
     return profiles;
@@ -16,6 +16,27 @@ export function parseProfile(input) {
     // Input isn't JSON, try TCL
   }
   return [];
+}
+
+// Detect the source profile format and dispatch to the appropriate importer.
+// Falls through to returning the raw input (existing behaviour) when no
+// recognised format matches.
+function convertJsonProfile(input) {
+  if (!input || typeof input !== 'object') return input;
+  // Meticulous signature: stages[] with a dynamics object on each stage.
+  // Reference: https://github.com/MeticulousHome/espresso-profile-schema
+  if (
+    Array.isArray(input.stages) &&
+    input.stages.length > 0 &&
+    input.stages.some(s => s && typeof s === 'object' && s.dynamics)
+  ) {
+    return convertMeticulousProfile(input);
+  }
+  // Gaggiuino signature: waterTemperature + phases[].
+  if (input.waterTemperature !== undefined && Array.isArray(input.phases)) {
+    return parseJsonProfile(input);
+  }
+  return input;
 }
 
 function parseJsonProfile(input) {
@@ -90,4 +111,180 @@ function parseJsonProfile(input) {
     return profile;
   }
   return input;
+}
+
+// ---- Meticulous JSON → Gaggimate ------------------------------------------
+// Reference schema: https://github.com/MeticulousHome/espresso-profile-schema
+
+const PREINFUSION_KEYWORDS = ['preinfu', 'soak', 'bloom', 'fill', 'wet'];
+
+function isPositive(value) {
+  return typeof value === 'number' && value > 0 && Number.isFinite(value);
+}
+
+function clampDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0.5;
+  return Math.max(0.5, Math.min(300, seconds));
+}
+
+function mapInterpolation(interpolation) {
+  if (interpolation === 'linear') return 'linear';
+  if (interpolation === 'curve') return 'ease-in-out';
+  return 'instant';
+}
+
+function mapComparison(comparison) {
+  return comparison === '<=' ? 'lte' : 'gte';
+}
+
+function buildVariableResolver(variables) {
+  const table = {};
+  for (const v of variables || []) {
+    if (v && typeof v.key === 'string') table[v.key] = v.value;
+  }
+  return value => {
+    if (typeof value !== 'string') return value;
+    if (!value.startsWith('$')) return value;
+    const replaced = table[value.slice(1)];
+    return replaced === undefined ? 0 : replaced;
+  };
+}
+
+function deriveDurations(stage, resolve) {
+  const points = (stage.dynamics?.points || []).map(([x, y]) => [
+    Number(resolve(x)) || 0,
+    Number(resolve(y)) || 0,
+  ]);
+  const isTimeAxis = stage.dynamics?.over === 'time';
+  const rampSpan =
+    isTimeAxis && points.length >= 2
+      ? Math.max(0, points[points.length - 1][0] - points[0][0])
+      : 0;
+  const timeTrigger = (stage.exit_triggers || []).find(
+    t => t && t.type === 'time' && t.relative !== false,
+  );
+  const triggerSeconds = timeTrigger ? Number(resolve(timeTrigger.value)) || 0 : 0;
+  const fallback = isTimeAxis && points.length ? points[points.length - 1][0] : 0;
+  const rawDuration = triggerSeconds > 0 ? triggerSeconds : fallback || 300;
+  return {
+    points,
+    duration: clampDuration(rawDuration),
+    rampDuration: Math.min(rampSpan, 300),
+  };
+}
+
+function buildPump(stage, points, resolve) {
+  const setpoint = points.length ? points[points.length - 1][1] : 0;
+  // `power` stages map to a fixed pump duty cycle (Gaggimate's simple pump form).
+  if (stage.type === 'power') {
+    const percent = Math.round(Math.max(0, Math.min(100, setpoint)));
+    return percent;
+  }
+  const limits = stage.limits || [];
+  const pressureLimit = limits.find(l => l && l.type === 'pressure');
+  const flowLimit = limits.find(l => l && l.type === 'flow');
+  const resolvedPressureLimit = pressureLimit ? Number(resolve(pressureLimit.value)) || 0 : 0;
+  const resolvedFlowLimit = flowLimit ? Number(resolve(flowLimit.value)) || 0 : 0;
+  if (stage.type === 'pressure') {
+    return { target: 'pressure', pressure: setpoint, flow: resolvedFlowLimit };
+  }
+  return { target: 'flow', pressure: resolvedPressureLimit, flow: setpoint };
+}
+
+function buildTargets(stage, resolve) {
+  const out = [];
+  for (const trigger of stage.exit_triggers || []) {
+    if (!trigger || trigger.type === 'time') continue;
+    // Relative weight is "delta since stage start"; Gaggimate's volumetric target compares
+    // absolute scale mass, so applying a relative value would fire too early. Drop them.
+    if (trigger.type === 'weight' && trigger.relative === true) continue;
+    let type;
+    if (trigger.type === 'weight') type = 'volumetric';
+    else if (trigger.type === 'pressure') type = 'pressure';
+    else if (trigger.type === 'flow') type = 'flow';
+    else continue;
+    const value = Number(resolve(trigger.value));
+    if (!Number.isFinite(value) || value < 0) continue;
+    out.push({ type, operator: mapComparison(trigger.comparison), value });
+  }
+  return out;
+}
+
+function convertStage(stage, index, profileTemperature, resolve) {
+  const { points, duration, rampDuration } = deriveDurations(stage, resolve);
+  const isPreinfusion = PREINFUSION_KEYWORDS.some(kw =>
+    (stage.name || '').toLowerCase().includes(kw),
+  );
+  const phase = {
+    name: stage.name || `Phase ${index + 1}`,
+    phase: isPreinfusion ? 'preinfusion' : 'brew',
+    valve: 1,
+    duration,
+    pump: buildPump(stage, points, resolve),
+    transition: {
+      type: mapInterpolation(stage.dynamics?.interpolation),
+      duration: Math.min(rampDuration, duration),
+      adaptive: false,
+    },
+  };
+  if (isPositive(stage.temperature_delta) || isPositive(-stage.temperature_delta)) {
+    const overridden = profileTemperature + stage.temperature_delta;
+    if (overridden > 0) phase.temperature = Number(overridden.toFixed(2));
+  }
+  const targets = buildTargets(stage, resolve);
+  if (targets.length > 0) phase.targets = targets;
+  return phase;
+}
+
+function pickDescription(display) {
+  if (!display) return '';
+  if (typeof display.description === 'string') return display.description;
+  if (typeof display.shortDescription === 'string') return display.shortDescription;
+  return '';
+}
+
+function convertMeticulousProfile(input) {
+  const resolve = buildVariableResolver(input.variables);
+  const profile = {
+    label: typeof input.name === 'string' && input.name.trim() ? input.name : 'Imported Profile',
+    type: 'pro',
+    description: pickDescription(input.display),
+    temperature: isPositive(input.temperature) ? input.temperature : 93,
+    phases: [],
+  };
+
+  for (let i = 0; i < input.stages.length; i++) {
+    profile.phases.push(convertStage(input.stages[i], i, profile.temperature, resolve));
+  }
+
+  // Apply final_weight to every phase as a global overflow cap.
+  //
+  // Why every phase, not just the last brew phase?
+  // - Matches the behaviour of the existing Gaggiuino importer
+  //   (`globalStopConditions.weight` fallback in the per-phase loop), so both
+  //   JSON paths produce profiles with the same shape.
+  // - Meticulous/DE semantics would gate the global weight stop until after
+  //   preinfusion frames (those platforms have their own safety nets that
+  //   prevent overflow during pre-wet). Gaggia Classic and similar hardware
+  //   the firmware targets have no such safety nets — broadcasting the cap
+  //   to every phase prevents the cup overflowing on a broken/missing puck
+  //   or channeled shot where flow becomes excessive before reaching the
+  //   final phase.
+  // - In a normal shot the cap only fires during the last brew phase anyway
+  //   (preinfusion typically produces 0-5 g of output), so the broader cap
+  //   is invisible when things are working. It only kicks in as a failsafe.
+  // - Profile authors who want per-phase weight stops can still set them via
+  //   per-frame `weight` exit_triggers (handled in buildTargets() above) —
+  //   those take precedence because they are placed first.
+  if (isPositive(input.final_weight)) {
+    for (const phase of profile.phases) {
+      phase.targets = phase.targets || [];
+      const hasVolumetric = phase.targets.some(t => t.type === 'volumetric');
+      if (!hasVolumetric) {
+        phase.targets.push({ type: 'volumetric', operator: 'gte', value: input.final_weight });
+      }
+    }
+  }
+
+  return profile;
 }


### PR DESCRIPTION
## Summary

Adds support for importing Meticulous espresso profile JSON
([reference schema](https://github.com/MeticulousHome/espresso-profile-schema))
alongside the existing Gaggiuino importer. Users can now drop a
Meticulous `.json` export into the profile import flow and have it
converted to a Gaggimate profile.

## Approach

The existing `parseJsonProfile` (Gaggiuino) is **unchanged**. A new
`convertJsonProfile` dispatcher is inserted between `parseProfile` and
the format-specific JSON converters. The full detection flow:

| Format | Detection |
|---|---|
| **Decent TCL** | Input does not parse as JSON; handed off to the existing `TclConverter.toGaggiMate()` (unchanged in this PR) |
| **Meticulous JSON** | Parses as JSON with `stages[]` array containing `dynamics` objects on each stage |
| **Gaggiuino JSON** | Parses as JSON with `waterTemperature` + `phases[]` array |
| **Unknown** | Falls through to returning the raw input (preserves existing behaviour) |

## Meticulous converter details

`convertMeticulousProfile` handles the schema's key features:

- **`$variable` references** are resolved via the profile's `variables[]`
  table. Most shipped Meticulous defaults use variables.
- **Stage types** (`power`, `pressure`, `flow`) map to the corresponding
  Gaggimate pump modes. `power` becomes a fixed pump duty cycle.
- **Limits** (`pressure`, `flow`) become the opposite-mode setpoint
  (e.g., a pressure stage with a flow limit becomes `target: pressure,
  flow: <limit>`).
- **Phase duration** is derived from the first relative `time`
  `exit_trigger`, falling back to the last `dynamics.points` x-value
  when the axis is `time`, then to a 300 s safety cap.
- **Interpolation** (`linear` / `curve` / `none`) maps to schema-valid
  transition types (`linear` / `ease-in-out` / `instant`).
- **Comparisons** (`>=` / `<=`) map to `gte` / `lte` operators.
- **Relative weight exit triggers** are dropped — Gaggimate's volumetric
  target compares absolute scale mass, so a relative value (delta since
  stage start) would fire too early.
- **`final_weight`** is applied to every phase as a volumetric cap,
  matching the existing Gaggiuino importer's behaviour with
  `globalStopConditions.weight` (the per-phase loop fallback at
  `parseJsonProfile` line 80). The Meticulous runtime gates this stop
  behind preinfusion frames, but the Gaggimate firmware lacks an
  equivalent safety net — broadcasting the cap to every phase prevents
  cup overflow on broken/missing pucks or channeled shots. Profile
  authors who want per-phase weight stops can still use per-frame
  `weight` `exit_triggers`, which are placed first in the targets list
  and therefore take precedence.

## Testing

Imported sample Meticulous profiles (variable-using and variable-free
variants) and verified that round-trip export from the device produces
correctly-shaped Gaggimate JSON with all stage names, temperatures,
phase types, pump modes, transitions, and exit conditions preserved.

The Gaggiuino import path was tested with a real Gaggiuino profile to
confirm the new dispatcher does not regress that path.

## Scope

This PR only modifies `web/src/pages/ProfileList/utils.js`. The
existing Gaggiuino `parseJsonProfile` function is byte-identical to its
prior version (verified via diff). TCL converter fixes and firmware/web
reliability changes are submitted as separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing espresso profiles from Meticulous format with automatic format detection and conversion
  * Enhanced profile handling to support advanced parameters including variables, stage configuration, temperature control, and volumetric stopping
  * Improved exit condition mapping for more precise brew control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->