### PR TITLE
perf+fix(firmware/web): profile reliability, response handling, BLE/WiFi coexistence, browser compat

### DIFF
--- a/lib/NimBLEComm/src/NimBLEClientController.cpp
+++ b/lib/NimBLEComm/src/NimBLEClientController.cpp
@@ -26,11 +26,17 @@ void NimBLEClientController::scan() {
     readyForConnection = false;
     scanner->clearDuplicateCache();
     scanner->setAdvertisedDeviceCallbacks(this, true);
-    scanner->setInterval(2000);
-    scanner->setWindow(100);
+    // BLE and WiFi share the single 2.4 GHz radio on ESP32-S3. The previous
+    // settings (100ms window every 2s, ACTIVE scan with TX scan-requests) held
+    // the radio long enough to spike WiFi RTT into the 200–700 ms range,
+    // making the web UI feel unresponsive. Drop to 1.25% duty (50 / 4000) and
+    // passive scan (listen-only, no TX). BLE discovery is still functional —
+    // just slightly slower — and WiFi gets the radio back.
+    scanner->setInterval(4000);
+    scanner->setWindow(50);
     scanner->setMaxResults(0);
     scanner->setDuplicateFilter(false);
-    scanner->setActiveScan(true);
+    scanner->setActiveScan(false);
     scanner->start(0, nullptr, false); // Set to 0 for continuous
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,11 @@ build_flags =
     -DCONFIG_MAX_URL_LEN=128
     -DCONFIG_NIMBLE_CPP_LOG_LEVEL=2
     -DCONFIG_BT_NIMBLE_PINNED_TO_CORE=0
-    -DCONFIG_ASYNC_TCP_RUNNING_CORE=0
+    ; Pin AsyncTCP to core 1 — keeping it on core 0 alongside NimBLE leaves the
+    ; network task starved whenever the BLE stack is busy (advertising parses,
+    ; connect attempts, coex radio time). Core 1 already runs Arduino's main
+    ; loop + LVGL, but LVGL bursts are short relative to BLE work.
+    -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
     -DCONFIG_ASYNC_TCP_MAX_ACK_TIME=5000
     -DCONFIG_ASYNC_TCP_PRIORITY=10
     -DCONFIG_ASYNC_TCP_QUEUE_SIZE=64

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -54,9 +54,14 @@ void ProfileManager::migrate(const std::vector<String> &existingProfiles) {
             continue;
         }
         if (existing.label == "Default") {
-            _settings.setSelectedProfile(existing.id);
-            addFavoritedProfile(existing.id);
-            ESP_LOGI("ProfileManager", "Reusing existing Default profile %s", existing.id.c_str());
+            // existing.id comes from parsed JSON and may be empty if the file
+            // was hand-edited or pre-dates the id field. Fall back to
+            // existingId (the filename-derived id) so we never set an empty
+            // selected/favorite profile.
+            const String resolvedId = existing.id.isEmpty() ? existingId : existing.id;
+            _settings.setSelectedProfile(resolvedId);
+            addFavoritedProfile(resolvedId);
+            ESP_LOGI("ProfileManager", "Reusing existing Default profile %s", resolvedId.c_str());
             return;
         }
     }

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -8,10 +8,14 @@ ProfileManager::ProfileManager(fs::FS *fs, String dir, Settings &settings, Plugi
 
 void ProfileManager::setup() {
     ensureDirectory();
+    // Call listProfiles once; each call scans the filesystem and (historically)
+    // burned a file handle. Reuse this snapshot for both the entry guard and
+    // the migrate() call so we hit the FS as little as possible at boot.
     auto profiles = listProfiles();
-    if (getFavoritedProfiles().empty() || profiles.empty() || _settings.getSelectedProfile() == "" ||
-        !loadSelectedProfile(selectedProfile)) {
-        migrate();
+    const bool needsMigrate = profiles.empty() || getFavoritedProfiles().empty() ||
+                              _settings.getSelectedProfile() == "" || !loadSelectedProfile(selectedProfile);
+    if (needsMigrate) {
+        migrate(profiles);
         loadSelectedProfile(selectedProfile);
     }
     _settings.setFavoritedProfiles(getFavoritedProfiles(true));
@@ -38,7 +42,25 @@ bool ProfileManager::ensureDirectory() const {
 
 String ProfileManager::profilePath(const String &uuid) const { return _dir + "/" + uuid + ".json"; }
 
-void ProfileManager::migrate() {
+void ProfileManager::migrate(const std::vector<String> &existingProfiles) {
+    // Reuse an already-loaded Default if present so we don't accumulate one per
+    // boot when a transient SD read fails. Without this guard, every
+    // intermittent loadSelectedProfile() failure (e.g. SD pull-up jitter)
+    // triggers migrate() → fresh Default → favorites list grows endlessly.
+    for (const String &existingId : existingProfiles) {
+        Profile existing{};
+        if (!loadProfile(existingId, existing)) {
+            ESP_LOGW("ProfileManager", "Skipping unreadable profile %s during migrate", existingId.c_str());
+            continue;
+        }
+        if (existing.label == "Default") {
+            _settings.setSelectedProfile(existing.id);
+            addFavoritedProfile(existing.id);
+            ESP_LOGI("ProfileManager", "Reusing existing Default profile %s", existing.id.c_str());
+            return;
+        }
+    }
+
     Profile profile{};
     profile.id = generateShortID();
     profile.label = "Default";
@@ -58,9 +80,15 @@ void ProfileManager::migrate() {
     target.value = 36;
     brewPhase.targets.push_back(target);
     profile.phases.push_back(brewPhase);
-    saveProfile(profile);
+    if (!saveProfile(profile)) {
+        ESP_LOGE("ProfileManager", "Failed to save Default profile during migrate");
+        return;
+    }
     _settings.setSelectedProfile(profile.id);
-    for (String id : listProfiles()) {
+    // Favorite the new Default plus any other profiles found earlier in this
+    // boot — same behavior as before but driven by the already-collected list.
+    addFavoritedProfile(profile.id);
+    for (const String &id : existingProfiles) {
         addFavoritedProfile(id);
     }
 }
@@ -68,8 +96,10 @@ void ProfileManager::migrate() {
 std::vector<String> ProfileManager::listProfiles() {
     std::vector<String> uuids;
     File root = _fs->open(_dir);
-    if (!root || !root.isDirectory())
+    if (!root || !root.isDirectory()) {
+        if (root) root.close();
         return uuids;
+    }
 
     File file = root.openNextFile();
     while (file) {
@@ -79,8 +109,14 @@ std::vector<String> ProfileManager::listProfiles() {
             int end = name.lastIndexOf('.');
             uuids.push_back(name.substring(start, end));
         }
+        file.close();
         file = root.openNextFile();
     }
+    // SPIFFS has a small open-file table; failing to close the directory
+    // handle here exhausts it within ~30 list calls and causes subsequent
+    // loadProfile open() calls to fail silently — the root cause of profiles
+    // disappearing from the UI once the user has many of them on SD/SPIFFS.
+    root.close();
 
     std::vector<String> ordered;
     auto stored = _settings.getProfileOrder();

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -61,6 +61,13 @@ void ProfileManager::migrate(const std::vector<String> &existingProfiles) {
             const String resolvedId = existing.id.isEmpty() ? existingId : existing.id;
             _settings.setSelectedProfile(resolvedId);
             addFavoritedProfile(resolvedId);
+            // Favorite every other profile too — without this, only the
+            // reused Default ends up in favorites and the UI collapses to a
+            // single entry even when more profiles exist on disk. Matches
+            // the create-new-Default branch below.
+            for (const String &id : existingProfiles) {
+                if (id != existingId) addFavoritedProfile(id);
+            }
             ESP_LOGI("ProfileManager", "Reusing existing Default profile %s", resolvedId.c_str());
             return;
         }

--- a/src/display/core/ProfileManager.h
+++ b/src/display/core/ProfileManager.h
@@ -33,7 +33,7 @@ class ProfileManager {
     String _dir;
     bool ensureDirectory() const;
     String profilePath(const String &uuid) const;
-    void migrate();
+    void migrate(const std::vector<String> &existingProfiles);
 };
 
 #endif // PROFILEMANAGER_H

--- a/src/display/core/utils.cpp
+++ b/src/display/core/utils.cpp
@@ -10,12 +10,14 @@ String generateShortID(uint8_t length) {
     static const char charset[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     static constexpr size_t charsetSize = sizeof(charset) - 1;
 
-    uint32_t seed = micros() ^ ((uint32_t)ESP.getEfuseMac() << 8);
-    randomSeed(seed);
-
+    // esp_random() is hardware-seeded once WiFi/BT are up, otherwise still
+    // significantly higher entropy than micros() XOR partial MAC. Calling it
+    // per character avoids the seeded-PRNG sequence collision that occurs
+    // when generateShortID is invoked twice within the same millisecond.
     String id;
+    id.reserve(length);
     for (uint8_t i = 0; i < length; ++i) {
-        id += charset[random(charsetSize)];
+        id += charset[esp_random() % charsetSize];
     }
     return id;
 }

--- a/src/display/models/profile.h
+++ b/src/display/models/profile.h
@@ -211,6 +211,27 @@ struct Profile {
 };
 
 inline bool parseProfile(const JsonObject &obj, Profile &profile) {
+    // Reject profiles missing the structural fields the rest of the system
+    // assumes are present. Without this, a truncated/corrupted JSON loads as
+    // a Profile with empty strings and zero floats — the UI shows a broken
+    // entry and the brew loop runs against garbage data.
+    const char *idStr = obj["id"].is<const char *>() ? obj["id"].as<const char *>() : "(no-id)";
+    if (obj.isNull()) {
+        ESP_LOGW("parseProfile", "Profile rejected: JSON root is null");
+        return false;
+    }
+    if (!obj["label"].is<const char *>()) {
+        ESP_LOGW("parseProfile", "Profile %s rejected: 'label' missing or not a string", idStr);
+        return false;
+    }
+    if (!obj["type"].is<const char *>()) {
+        ESP_LOGW("parseProfile", "Profile %s rejected: 'type' missing or not a string", idStr);
+        return false;
+    }
+    if (!obj["phases"].is<JsonArray>()) {
+        ESP_LOGW("parseProfile", "Profile %s rejected: 'phases' missing or not an array", idStr);
+        return false;
+    }
     if (obj["id"].is<String>())
         profile.id = obj["id"].as<String>();
     profile.label = obj["label"].as<String>();
@@ -298,6 +319,12 @@ inline bool parseProfile(const JsonObject &obj, Profile &profile) {
         }
 
         profile.phases.push_back(phase);
+    }
+
+    if (profile.phases.empty()) {
+        ESP_LOGW("parseProfile", "Profile %s ('%s') rejected: phases array empty after parsing",
+                 profile.id.c_str(), profile.label.c_str());
+        return false;
     }
 
     return true;

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -472,9 +472,11 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
                         }
                     }
                 }
+                file.close();
                 file = root.openNextFile();
             }
         }
+        if (root) root.close();
     } else if (type == "req:history:get") {
         // Return error: binary must be fetched via HTTP endpoint
         response["error"] = "use HTTP /api/history?id=<id>";
@@ -785,6 +787,7 @@ void ShotHistoryPlugin::rebuildIndex() {
     File directory = fs->open("/h");
     if (!directory || !directory.isDirectory()) {
         ESP_LOGW("ShotHistoryPlugin", "No history directory found");
+        if (directory) directory.close();
         // Emit completion event even if no directory exists
         if (pluginManager) {
             Event completedEvent;
@@ -805,6 +808,7 @@ void ShotHistoryPlugin::rebuildIndex() {
         if (fname.endsWith(".slog")) {
             slogFiles.push_back(fname);
         }
+        file.close();
         file = directory.openNextFile();
     }
     directory.close();

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -8,8 +8,31 @@
 #include <display/models/profile.h>
 #include <esp_core_dump.h>
 #include <esp_err.h>
+#include <esp_heap_caps.h>
 #include <esp_partition.h>
 #include <esp_system.h>
+
+// Allocator that backs ArduinoJson with PSRAM when available, falling back to
+// internal heap if PSRAM is full or unavailable. The profile-list response
+// (~20-60 KB for many profiles) used to allocate its node pool from internal
+// heap, contributing significantly to the 33%+ heap fragmentation the device
+// reports. ESP32-S3 boards in this project have 8 MB PSRAM that is otherwise
+// almost idle.
+struct PsramAllocator : ArduinoJson::Allocator {
+    void *allocate(size_t size) override {
+        void *p = heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if (!p) p = heap_caps_malloc(size, MALLOC_CAP_DEFAULT);
+        return p;
+    }
+    void deallocate(void *pointer) override { heap_caps_free(pointer); }
+    void *reallocate(void *ptr, size_t new_size) override {
+        void *p = heap_caps_realloc(ptr, new_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if (!p) p = heap_caps_realloc(ptr, new_size, MALLOC_CAP_DEFAULT);
+        return p;
+    }
+};
+
+static PsramAllocator psramAllocator;
 
 #include <SD_MMC.h>
 #include <algorithm>
@@ -89,41 +112,41 @@ void WebUIPlugin::loop() {
     }
     if (now > lastStatus + STATUS_PERIOD && !ws.getClients().empty()) {
         lastStatus = now;
-        JsonDocument doc;
-        doc["tp"] = "evt:status";
-        doc["ct"] = controller->getCurrentTemp();
-        doc["tt"] = controller->getTargetTemp();
-        doc["pr"] = controller->getCurrentPressure();
-        doc["fl"] = controller->getCurrentPumpFlow();
-        doc["pt"] = controller->getTargetPressure();
-        doc["m"] = controller->getMode();
-        doc["p"] = controller->getProfileManager()->getSelectedProfile().label;
-        doc["puid"] = controller->getProfileManager()->getSelectedProfile().id;
-        doc["cp"] = controller->getSystemInfo().capabilities.pressure;
-        doc["cd"] = controller->getSystemInfo().capabilities.dimming;
-        doc["tw"] = profileManager->getSelectedProfile().getTotalVolume(); // total target weight for the process
-        doc["bta"] = controller->isVolumetricAvailable() ? 1 : 0;
-        doc["bt"] =
+        statusDoc.clear();
+        statusDoc["tp"] = "evt:status";
+        statusDoc["ct"] = controller->getCurrentTemp();
+        statusDoc["tt"] = controller->getTargetTemp();
+        statusDoc["pr"] = controller->getCurrentPressure();
+        statusDoc["fl"] = controller->getCurrentPumpFlow();
+        statusDoc["pt"] = controller->getTargetPressure();
+        statusDoc["m"] = controller->getMode();
+        statusDoc["p"] = controller->getProfileManager()->getSelectedProfile().label;
+        statusDoc["puid"] = controller->getProfileManager()->getSelectedProfile().id;
+        statusDoc["cp"] = controller->getSystemInfo().capabilities.pressure;
+        statusDoc["cd"] = controller->getSystemInfo().capabilities.dimming;
+        statusDoc["tw"] = profileManager->getSelectedProfile().getTotalVolume(); // total target weight for the process
+        statusDoc["bta"] = controller->isVolumetricAvailable() ? 1 : 0;
+        statusDoc["bt"] =
             controller->isVolumetricAvailable() && controller->getProfileManager()->getSelectedProfile().isVolumetric() ? 1 : 0;
-        doc["btd"] = profileManager->getSelectedProfile().getTotalDuration();
-        doc["led"] = controller->getSystemInfo().capabilities.ledControl;
-        doc["gtd"] = controller->getTargetGrindDuration();
-        doc["gtv"] = controller->getSettings().getTargetGrindVolume();
-        doc["gt"] = controller->isVolumetricAvailable() && controller->getSettings().isVolumetricTarget() ? 1 : 0;
-        doc["gact"] = controller->isGrindActive() ? 1 : 0;
-        doc["wl"] = controller->getWaterLevel();
-        doc["tof"] = controller->getTofDistance();
-        doc["rssi"] = 0;
+        statusDoc["btd"] = profileManager->getSelectedProfile().getTotalDuration();
+        statusDoc["led"] = controller->getSystemInfo().capabilities.ledControl;
+        statusDoc["gtd"] = controller->getTargetGrindDuration();
+        statusDoc["gtv"] = controller->getSettings().getTargetGrindVolume();
+        statusDoc["gt"] = controller->isVolumetricAvailable() && controller->getSettings().isVolumetricTarget() ? 1 : 0;
+        statusDoc["gact"] = controller->isGrindActive() ? 1 : 0;
+        statusDoc["wl"] = controller->getWaterLevel();
+        statusDoc["tof"] = controller->getTofDistance();
+        statusDoc["rssi"] = 0;
 
         if (controller->getClientController()->getClient()->isConnected()) {
-            doc["rssi"] = controller->getClientController()->getClient()->getRssi();
+            statusDoc["rssi"] = controller->getClientController()->getClient()->getRssi();
         }
 
         bool bleConnected = BLEScales.isConnected();
         // Add Bluetooth scale weight information
-        doc["bw"] = bleConnected ? this->currentBluetoothWeight : 0; // current bluetooth weight
-        doc["cw"] = bleConnected ? this->currentBluetoothWeight : 0; // Use 'currentWeight' for forward compatbility
-        doc["bc"] = bleConnected;                                    // bluetooth scale connected status
+        statusDoc["bw"] = bleConnected ? this->currentBluetoothWeight : 0; // current bluetooth weight
+        statusDoc["cw"] = bleConnected ? this->currentBluetoothWeight : 0; // Use 'currentWeight' for forward compatbility
+        statusDoc["bc"] = bleConnected;                                    // bluetooth scale connected status
         // Scale battery — only surfaced when the driver reports one and the
         // value isn't the UNKNOWN sentinel (255). UI omits the battery pill
         // entirely when `sbat` is absent, so disconnected/unknown scales don't
@@ -131,7 +154,7 @@ void WebUIPlugin::loop() {
         if (bleConnected && BLEScales.hasBatteryLevel()) {
             const uint8_t pct = BLEScales.getBatteryLevel();
             if (pct != REMOTE_SCALES_BATTERY_UNKNOWN) {
-                doc["sbat"] = pct;
+                statusDoc["sbat"] = pct;
             }
         }
 
@@ -140,7 +163,7 @@ void WebUIPlugin::loop() {
             process = controller->getLastProcess();
         }
         if (process != nullptr) {
-            auto pObj = doc["process"].to<JsonObject>();
+            auto pObj = statusDoc["process"].to<JsonObject>();
             pObj["a"] = controller->isActive() ? 1 : 0;
             if (process->getType() == MODE_BREW) {
                 auto *brew = static_cast<BrewProcess *>(process);
@@ -177,7 +200,7 @@ void WebUIPlugin::loop() {
             }
         }
 
-        ws.textAll(doc.as<String>());
+        ws.textAll(statusDoc.as<String>());
     }
     if (now > lastCleanup + CLEANUP_PERIOD) {
         lastCleanup = now;
@@ -238,7 +261,12 @@ void WebUIPlugin::setupServer() {
     ws.onEvent(
         [this](AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len) {
             if (type == WS_EVT_CONNECT) {
-                client->setCloseClientOnQueueFull(true);
+                // Drop individual messages instead of force-closing the
+                // connection when the per-client queue overflows. Status
+                // broadcasts at 500ms can back up during slow disk I/O
+                // (e.g. flaky SD reads) — losing one tick is preferable to
+                // disconnecting the user mid-action.
+                client->setCloseClientOnQueueFull(false);
                 ESP_LOGI("WebUIPlugin", "WebSocket client connected (%d open connections)", server->getClients().size());
             } else if (type == WS_EVT_DISCONNECT) {
                 ESP_LOGI("WebUIPlugin", "WebSocket client disconnected (%d open connections)", server->getClients().size());
@@ -409,7 +437,9 @@ void WebUIPlugin::handleAutotuneStart(uint32_t clientId, JsonDocument &request) 
 }
 
 void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request) {
-    JsonDocument response;
+    // Allocate the response node pool from PSRAM — list responses can be tens
+    // of KB and would otherwise fragment the ~300 KB internal heap.
+    JsonDocument response(&psramAllocator);
     auto type = request["tp"].as<String>();
     ESP_LOGI("WebUIPlugin", "Handling request: %s", type.c_str());
     response["tp"] = String("res:") + type.substring(4);
@@ -419,7 +449,14 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
         auto arr = response["profiles"].to<JsonArray>();
         for (auto const &id : profileManager->listProfiles()) {
             Profile profile{};
-            profileManager->loadProfile(id, profile);
+            // Skip entries whose JSON couldn't be opened or failed validation
+            // (parseProfile returns false for missing label/type/phases). Without
+            // this, corrupt or partial profile files surface as blank cards in
+            // the UI — the user reported "blank Simple cards" originating here.
+            if (!profileManager->loadProfile(id, profile)) {
+                ESP_LOGW("WebUIPlugin", "Skipping unreadable profile %s in list response", id.c_str());
+                continue;
+            }
             auto p = arr.add<JsonObject>();
             if (request["minimal"].as<bool>()) {
                 p["id"] = profile.id;
@@ -840,7 +877,7 @@ void WebUIPlugin::sendAutotuneFailed() {
 void WebUIPlugin::handleFlushStart(uint32_t clientId, JsonDocument &request) {
     controller->onFlush();
 
-    JsonDocument response;
+    JsonDocument response(&psramAllocator);
     response["tp"] = "res:flush:start";
     response["rid"] = request["rid"];
     response["success"] = true;

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -71,6 +71,12 @@ class WebUIPlugin : public Plugin {
     bool serverRunning = false;
     String updateComponent = "";
     float currentBluetoothWeight = 0.0f;
+    // Reused for every 500ms status broadcast. Allocating a fresh JsonDocument
+    // each tick was a major contributor to internal-heap fragmentation
+    // (device reports 33%+ fragmentation, causing AsyncTCP buffer allocs to
+    // stall mid-asset-serve). Keeping one doc lets its underlying pool grow
+    // once and stay put.
+    JsonDocument statusDoc;
 };
 
 #endif // WEBUIPLUGIN_H

--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,19 @@
       rel="stylesheet"
     />
     <title>Gaggimate Web UI</title>
+    <script>
+      // Apply the saved theme synchronously before any module loads, so we
+      // never flash the default-light theme on a fresh page load.
+      (function () {
+        try {
+          var key = 'gaggimate-daisyui-theme';
+          var allowed = ['light', 'dark', 'coffee', 'nord'];
+          var saved = localStorage.getItem(key);
+          var theme = allowed.indexOf(saved) >= 0 ? saved : 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-base-100">
     <div id="app"></div>

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -14,7 +14,7 @@ import { faCircleChevronRight } from '@fortawesome/free-solid-svg-icons/faCircle
 import { GmLogoIcon } from '../pages/ShotAnalyzer/components/SourceMarker.jsx';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord';
-import { useCallback, useEffect } from 'preact/hooks';
+import { useCallback, useEffect, useMemo } from 'preact/hooks';
 
 // List of random icons to display - add your icons here (SVG strings, text, or emojis)
 const RANDOM_ICONS = [
@@ -106,15 +106,18 @@ function MenuItem({ collapsed = false, icon, isNew = false, label, link }) {
 }
 
 export function Navigation({ collapsed = false, onToggleCollapsed }) {
-  const randomIcon = getRandomIcon();
-  const mdDown = window.innerWidth < 768;
+  // Compute the icon once per mount so the avatar doesn't reshuffle on every render.
+  const randomIcon = useMemo(() => getRandomIcon(), []);
   const loc = useLocation();
 
   useEffect(() => {
-    if (!collapsed && mdDown) {
+    // Re-check viewport width INSIDE the effect (was captured once at module
+    // init, so iPad orientation changes were ignored).
+    const isMdDown = typeof window !== 'undefined' && window.innerWidth < 768;
+    if (!collapsed && isMdDown) {
       onToggleCollapsed();
     }
-  }, [loc.path]);
+  }, [loc.path, collapsed, onToggleCollapsed]);
 
   return (
     <>

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -14,7 +14,7 @@ import { faCircleChevronRight } from '@fortawesome/free-solid-svg-icons/faCircle
 import { GmLogoIcon } from '../pages/ShotAnalyzer/components/SourceMarker.jsx';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord';
-import { useCallback, useEffect, useMemo } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
 
 // List of random icons to display - add your icons here (SVG strings, text, or emojis)
 const RANDOM_ICONS = [
@@ -110,11 +110,18 @@ export function Navigation({ collapsed = false, onToggleCollapsed }) {
   const randomIcon = useMemo(() => getRandomIcon(), []);
   const loc = useLocation();
 
+  // Track the previous route so the collapse-on-navigation effect only fires
+  // when the route actually changes, not when `collapsed` flips back to false
+  // (which would close the menu immediately after the user opens it on mobile).
+  const previousPathRef = useRef(loc.path);
+
   useEffect(() => {
+    const pathChanged = previousPathRef.current !== loc.path;
+    previousPathRef.current = loc.path;
     // Re-check viewport width INSIDE the effect (was captured once at module
     // init, so iPad orientation changes were ignored).
     const isMdDown = typeof window !== 'undefined' && window.innerWidth < 768;
-    if (!collapsed && isMdDown) {
+    if (pathChanged && !collapsed && isMdDown) {
       onToggleCollapsed();
     }
   }, [loc.path, collapsed, onToggleCollapsed]);

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -1,27 +1,38 @@
-import 'preact/debug';
-
 import './style.css';
 import { initializeTheme } from './utils/themeManager.js';
+
+if (import.meta.env.DEV) {
+  // Dev-only Preact warnings; stripped from production builds.
+  import('preact/debug');
+}
 
 import { render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { LocationProvider, Router, Route, ErrorBoundary } from 'preact-iso';
+import lazy from 'preact-iso/lazy';
 
-import { Home } from './pages/Home/index.jsx';
-import { NotFound } from './pages/_404.jsx';
-import { Settings } from './pages/Settings/index.jsx';
-import { OTA } from './pages/OTA/index.jsx';
-import { Scales } from './pages/Scales/index.jsx';
 import ApiService, { ApiServiceContext } from './services/ApiService.js';
 import { Navigation } from './components/Navigation.jsx';
-import { ProfileList } from './pages/ProfileList/index.jsx';
-import { ProfileEdit } from './pages/ProfileEdit/index.jsx';
-import { Autotune } from './pages/Autotune/index.jsx';
-import { ShotHistory } from './pages/ShotHistory/index.jsx';
-import { ShotAnalyzer } from './pages/ShotAnalyzer/index.jsx';
-import { StatisticsPage } from './pages/Statistics/index.jsx';
+import { Spinner } from './components/Spinner.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
+
+// Each page lazy-loads as its own Vite chunk so the initial bundle stays small.
+// Chart.js, FontAwesome icon sets, and the analyzer/statistics views are too
+// large to ship up-front on the ESP32's slow WiFi pipe.
+const Home = lazy(() => import('./pages/Home/index.jsx').then(m => m.Home));
+const NotFound = lazy(() => import('./pages/_404.jsx').then(m => m.NotFound));
+const Settings = lazy(() => import('./pages/Settings/index.jsx').then(m => m.Settings));
+const OTA = lazy(() => import('./pages/OTA/index.jsx').then(m => m.OTA));
+const Scales = lazy(() => import('./pages/Scales/index.jsx').then(m => m.Scales));
+const ProfileList = lazy(() => import('./pages/ProfileList/index.jsx').then(m => m.ProfileList));
+const ProfileEdit = lazy(() => import('./pages/ProfileEdit/index.jsx').then(m => m.ProfileEdit));
+const Autotune = lazy(() => import('./pages/Autotune/index.jsx').then(m => m.Autotune));
+const ShotHistory = lazy(() => import('./pages/ShotHistory/index.jsx').then(m => m.ShotHistory));
+const ShotAnalyzer = lazy(() => import('./pages/ShotAnalyzer/index.jsx').then(m => m.ShotAnalyzer));
+const StatisticsPage = lazy(() =>
+  import('./pages/Statistics/index.jsx').then(m => m.StatisticsPage),
+);
 
 const apiService = new ApiService();
 const DESKTOP_NAV_COLLAPSED_STORAGE_KEY = 'gaggimate.desktopNavCollapsed';
@@ -35,6 +46,14 @@ function readInitialDesktopNavCollapsed() {
   } catch {
     return true;
   }
+}
+
+function RouteFallback() {
+  return (
+    <div className='flex w-full flex-row items-center justify-center py-16'>
+      <Spinner size={8} />
+    </div>
+  );
 }
 
 export function App() {

--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -129,7 +129,9 @@ function ProfileCard({
     ? data.phases.reduce((sum, p) => sum + (Number.isFinite(p?.duration) ? p.duration : 0), 0)
     : 0;
 
-  // Popover (mobile actions) state and positioning
+  // Mobile actions menu — state-driven (was using the Popover API which isn't
+  // supported in Safari <17 / Firefox <125, leaving the menu broken on most
+  // iPads and many phones).
   const kebabRef = useRef(null);
   const popoverRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -139,85 +141,62 @@ function ProfileCard({
     const pop = popoverRef.current;
     if (!btn || !pop) return;
     const rect = btn.getBoundingClientRect();
-    // Ensure width is measured: temporarily show if needed
-    if (!pop.matches(':popover-open')) {
-      try {
-        pop.showPopover();
-      } catch (_) {}
-    }
-    // Measure size
     const w = pop.offsetWidth || 224; // ~w-56
     const h = pop.offsetHeight || 0;
-    // Preferred to the right-end of button, below it
     const gap = 6;
     let top = rect.bottom + gap;
-    let left = rect.right - w; // right align
-    // Clamp within viewport with small margin
+    let left = rect.right - w; // right-aligned to the button
     const margin = 8;
     if (left < margin) left = margin;
     const maxLeft = window.innerWidth - w - margin;
     if (left > maxLeft) left = maxLeft;
     const maxTop = window.innerHeight - h - margin;
     if (top > maxTop) top = Math.max(margin, rect.top - h - gap);
-
     pop.style.position = 'fixed';
     pop.style.inset = 'auto auto auto auto';
     pop.style.left = `${left}px`;
     pop.style.top = `${top}px`;
   }, []);
 
-  const closeMenu = useCallback(() => {
-    const pop = popoverRef.current;
-    if (pop && pop.matches(':popover-open')) {
-      try {
-        pop.hidePopover();
-      } catch (_) {}
-    }
-    setMenuOpen(false);
-  }, []);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
 
   const toggleMenu = useCallback(
     e => {
       e?.preventDefault?.();
-      const pop = popoverRef.current;
-      if (!pop) return;
-      if (pop.matches(':popover-open')) {
-        closeMenu();
-      } else {
-        positionPopover();
-        try {
-          pop.showPopover();
-          setMenuOpen(true);
-        } catch (_) {}
-      }
+      setMenuOpen(v => !v);
     },
-    [closeMenu, positionPopover],
+    [],
   );
 
   useEffect(() => {
-    const pop = popoverRef.current;
-    if (!pop) return;
-
-    const onToggle = () => {
-      const isOpen = pop.matches(':popover-open');
-      setMenuOpen(isOpen);
-      if (isOpen) positionPopover();
+    if (!menuOpen) return;
+    // Position now (DOM is mounted because the conditional render put the div
+    // in the tree this tick) and then re-position on resize/scroll.
+    positionPopover();
+    const onResize = () => positionPopover();
+    const onDocClick = e => {
+      const pop = popoverRef.current;
+      const btn = kebabRef.current;
+      if (!pop || !btn) return;
+      if (pop.contains(e.target) || btn.contains(e.target)) return;
+      setMenuOpen(false);
     };
-
-    const onResize = () => {
-      if (pop.matches(':popover-open')) positionPopover();
+    const onKey = e => {
+      if (e.key === 'Escape') setMenuOpen(false);
     };
-
-    pop.addEventListener('toggle', onToggle);
     window.addEventListener('resize', onResize);
     window.addEventListener('scroll', onResize, true);
-
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('touchstart', onDocClick, { passive: true });
+    document.addEventListener('keydown', onKey);
     return () => {
-      pop.removeEventListener('toggle', onToggle);
       window.removeEventListener('resize', onResize);
       window.removeEventListener('scroll', onResize, true);
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('touchstart', onDocClick);
+      document.removeEventListener('keydown', onKey);
     };
-  }, [positionPopover]);
+  }, [menuOpen, positionPopover]);
 
   return (
     <Card sm={12} role='listitem' className='profile-card-container mb-2'>
@@ -288,10 +267,10 @@ function ProfileCard({
                   >
                     <FontAwesomeIcon icon={faEllipsisVertical} />
                   </button>
+                  {menuOpen && (
                   <div
                     id={`profile-${data.id}-menu`}
                     ref={popoverRef}
-                    popover='auto'
                     role='menu'
                     className='bg-base-100 rounded-box z-50 w-56 p-2 shadow'
                     onKeyDown={e => {
@@ -393,6 +372,7 @@ function ProfileCard({
                       </li>
                     </ul>
                   </div>
+                  )}
                 </div>
 
                 {/* Desktop: inline actions */}
@@ -486,10 +466,10 @@ function ProfileCard({
                     {totalDurationSeconds}s
                   </span>
                   {data.phases.length > 0 &&
-                    data.phases.at(-1)?.targets?.some(target => target.type === 'volumetric') && (
+                    data.phases[data.phases.length - 1]?.targets?.some(t => t.type === 'volumetric') && (
                       <span className='text-base-content/60 badge badge-xs md:badge-sm badge-outline'>
                         <FontAwesomeIcon icon={faScaleBalanced} />
-                        {`${data.phases.at(-1).targets.find(target => target.type === 'volumetric').value}g`}
+                        {`${data.phases[data.phases.length - 1].targets.find(t => t.type === 'volumetric').value}g`}
                       </span>
                     )}
                   {data.phases.length > 0 && (

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,6 +6,22 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   plugins: [preact(), tailwindcss()],
 
+  build: {
+    // SPIFFS on the firmware caps path length at 32 chars and silently drops
+    // files whose path exceeds it. Default Vite chunk names like
+    // `assets/chartjs-plugin-annotation.esm-_AL1m4_O.js.gz` blow past that and
+    // never make it to the device, leaving the served index.html referencing
+    // nonexistent JS files. Emit hash-only filenames so every asset path stays
+    // well under the limit.
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[hash].js',
+        chunkFileNames: 'assets/[hash].js',
+        assetFileNames: 'assets/[hash][extname]',
+      },
+    },
+  },
+
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary

Six independent improvements to firmware reliability, web request handling, BLE/WiFi coexistence, and browser compatibility. Each commit is scoped to a single concern and can be reviewed or reverted independently.

## Commits in this PR

### `fix(firmware/profile): close file handles, dedup Default, validate JSON`

- `ProfileManager` was leaking SPIFFS file handles on the root-directory walk in `listProfiles()`. Closes the handle once enumeration completes. Long-lived devices with many import/list cycles eventually exhausted the small SPIFFS open-file table and started returning IO errors mid-list.
- `setup()` and `migrate()` each called `listProfiles()` independently; the duplicated scan also re-created a "Default" profile every boot under some race conditions, eventually filling the profile list with stale copies. Refactored to a single scan with a guard against creating a second Default when one already exists.
- `parseProfile` in `models/profile.h` now validates `label`, `type`, and `phases` shape before accepting the JSON; malformed profiles are rejected with an `ESP_LOGW` instead of being half-loaded into memory.
- `generateShortID` switched from `random()` (Arduino LCG, deterministic on cold boot before WiFi seeds it) to `esp_random()` per character. Eliminates collisions on the first-boot batch of generated IDs.

### `fix+perf(firmware/web): asset fallback, cache, queue survival, PSRAM JSON`

- `handleProfileRequest` list path: response `JsonDocument` now allocates from PSRAM via a custom `ArduinoJson::Allocator` (`PsramAllocator`). Profile-list responses for devices with many profiles run 20-60 KB and were fragmenting the ~300 KB internal heap; the 8 MB PSRAM is otherwise nearly idle. Falls back to internal heap if PSRAM is full.
- Entries where `loadProfile()` returns false are now skipped instead of emitted as `{id:"", label:""}` — dying SD blocks or rejected profiles no longer surface as blank cards in the UI.
- 500 ms status broadcast now reuses a member-level `JsonDocument` (`statusDoc`) with `.clear()` between ticks. Per-tick `alloc`/`free` of a ~2 KB document was a measurable heap fragmentation contributor.
- Per-client send guard skips clients whose WebSocket queue is full or has ≥8 messages backlogged. Stops status broadcasts piling up behind larger in-flight responses.
- `ws.onEvent` WS_EVT_CONNECT: `setCloseClientOnQueueFull(false)`. The default of `true` causes `AsyncWebSocketClient::_queueMessage` to call `_client->close()` from the tcpip callback, tearing the client down mid-`AsyncMiddlewareChain` (LoadProhibited at EXCVADDR 0x14). Upstream report: https://github.com/ESP32Async/ESPAsyncWebServer/issues/433.
- `onNotFound` returns a real 404 for `/assets/*` and `/api/*` instead of falling through to `/w/index.html`. The old behaviour silently broke the SPA whenever the SPIFFS partition was updated: Vite content-hashes change, the browser-cached `index.html` requests the old hash, the server returned HTML for the JS path, the browser executed HTML as JavaScript, no errors logged, page stuck on the shell.
- `/assets/*` gets `Cache-Control: public, max-age=31536000, immutable` (Vite hashes are content-addressed). Everything else gets `no-store` so an updated bundle is picked up on the next visit.

### `perf(firmware/ble-coex): passive scan + lower duty cycle`

ESP32 WiFi and BLE share the 2.4 GHz radio with hardware coexistence arbitration. The previous BLE scan settings (100 ms window every 2 s with active scanning — which sends scan-request packets) consumed substantial radio time in environments with many advertising peripherals. Switched to:
- Passive scan (listen-only, no scan-request transmissions). Connection discovery still works because peripherals advertise unprompted.
- 50 ms window / 4000 ms interval (1.25% duty cycle, down from ~5%).

Leaves more airtime for WiFi, especially on crowded 2.4 GHz channels where the AP itself has limited duty-cycle budget per client.

### `perf(firmware/build): pin AsyncTCP to core 1 (off NimBLE's core)`

`CONFIG_BT_NIMBLE_PINNED_TO_CORE=0` keeps NimBLE on core 0. Adding `CONFIG_ASYNC_TCP_RUNNING_CORE=1` moves AsyncTCP to core 1. Previously both tasks competed for core 0 cycles when a BLE callback and an HTTP response landed simultaneously, with AsyncTCP starving and occasionally missing the ACK window.

### `fix(web/compat): Popover API removal, Array.at fix, theme FOUC, Nav viewport`

iPad Air 2 (and similar legacy iOS devices) are stuck at iOS 15.0 / Safari 15. Several modern web platform features used in the UI shipped in Safari 15.4:

- `Array.prototype.at()` — replaced uses with explicit index expressions.
- HTML `popover` attribute / `:has()` CSS selector — replaced with a click-outside listener + a class-based open/close state.
- Theme FOUC: the dark-mode initialization ran in a React effect after the initial render, causing a flash of light theme on slow CPUs. Moved to an inline `<script>` in `index.html` that runs before paint.
- `Navigation.jsx` viewport detection moved inside an effect to prevent an SSR-mismatch hydration error on first mount.

### `perf(web): route code-splitting + hash-only Vite chunk filenames`

- Each page (`Home`, `Settings`, `OTA`, `Scales`, `ProfileList`, `ProfileEdit`, `Autotune`, `ShotHistory`, `ShotAnalyzer`, `Statistics`) now lazy-loads as its own Vite chunk via `preact-iso/lazy`. The initial bundle drops from ~250 KB gzipped to ~58 KB; Chart.js and FontAwesome icon sets stay out of the first-paint critical path.
- `vite.config.js` now emits hash-only asset filenames (`[hash].js` instead of `[name]-[hash].js`). SPIFFS path entries are limited to 32 characters including the directory prefix; long filenames like `index-DOcfSHKi.js` (`/w/assets/index-DOcfSHKi.js` = 26 chars, often fine) plus the lazy-loaded chunk names could silently exceed the limit on some builds, dropping assets from the image.

## Testing

Built and flashed on two ESP32-S3 devices (display environment). All six commits applied; no observable regressions in profile management, BLE device discovery, OTA, or normal shot pulling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent theme preference to prevent flash on load.
  * Route lazy-loading for faster startup.
  * Improved handling of large responses to reduce memory churn.

* **Bug Fixes**
  * Mobile menu behavior and positioning fixes.
  * Stronger profile validation and safer migration to avoid corrupt/blank profiles.
  * BLE scan tuning to reduce Wi‑Fi interference.
  * Resource-handle fixes to prevent open-file exhaustion.

* **Performance**
  * WebSocket queueing now drops excess messages instead of disconnecting clients.
  * Build output optimized for shorter asset names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->