### PR TITLE
feat(dashboard): Brew-mode quick-adjust steppers + over-pressure alert

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -651,8 +651,18 @@ void Controller::deactivate() {
         // raise/lowerBrewTarget) revert back to the profile's saved values
         // after each brew. For permanent changes the user should save via
         // the Profiles page or the display's Save button.
+        //
+        // Reset the profile in place before reload: parseProfile() appends to
+        // profile.phases rather than replacing, so feeding it the already-
+        // populated selectedProfile would double the phases on every brew
+        // (60s utility profile reading 1:00 → 2:00 → 3:00 across runs, and
+        // the brew loop actually executing the duplicated phases). Mirrors
+        // the `selectedProfile = Profile{}` pattern that
+        // ProfileManager::selectProfile already uses for the same reason.
         if (profileManager) {
-            profileManager->loadSelectedProfile(profileManager->getSelectedProfile());
+            Profile &p = profileManager->getSelectedProfile();
+            p = Profile{};
+            profileManager->loadSelectedProfile(p);
         }
     } else if (lastProcess->getType() == MODE_GRIND) {
         pluginManager->trigger("controller:grind:end");

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -645,6 +645,15 @@ void Controller::deactivate() {
     currentProcess = nullptr;
     if (lastProcess->getType() == MODE_BREW) {
         pluginManager->trigger("controller:brew:end");
+        // Reload the selected profile from disk so any temporary temp/weight
+        // adjustments made via the dashboard +/- steppers or the display's
+        // gear-icon BrewScreen Settings panel (raise/lowerTemp,
+        // raise/lowerBrewTarget) revert back to the profile's saved values
+        // after each brew. For permanent changes the user should save via
+        // the Profiles page or the display's Save button.
+        if (profileManager) {
+            profileManager->loadSelectedProfile(profileManager->getSelectedProfile());
+        }
     } else if (lastProcess->getType() == MODE_GRIND) {
         pluginManager->trigger("controller:grind:end");
     }

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -339,6 +339,13 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
                     controller->raiseGrindTarget();
                 } else if (msgType == "req:lower-grind-target") {
                     controller->lowerGrindTarget();
+                } else if (msgType == "req:raise-brew-target") {
+                    // Web dashboard Brew-mode +/- buttons. The web client has
+                    // long been sending this via raiseTarget() but no firmware
+                    // handler existed, so the message was silently dropped.
+                    controller->raiseBrewTarget();
+                } else if (msgType == "req:lower-brew-target") {
+                    controller->lowerBrewTarget();
                 } else if (msgType == "req:change-mode") {
                     if (doc["mode"].is<uint8_t>()) {
                         auto mode = doc["mode"].as<uint8_t>();

--- a/web/src/pages/Home/CompactProcessControls.jsx
+++ b/web/src/pages/Home/CompactProcessControls.jsx
@@ -32,10 +32,10 @@ import {
 
 const status = computed(() => machine.value.status);
 
-const Metric = ({ icon, current, target, unit, rotation }) => (
+const Metric = ({ icon, current, target, unit, rotation, currentClassName = 'text-base-content' }) => (
   <div className='flex items-center gap-1.5'>
     <FontAwesomeIcon icon={icon} className='text-base-content/60 text-xs' />
-    <span className='text-base-content tabular-nums'>{current}</span>
+    <span className={`${currentClassName} tabular-nums`}>{current}</span>
     <span className='text-success font-semibold tabular-nums'>
       / {target}
       {unit}
@@ -54,6 +54,29 @@ const TargetToggle = ({ value, onChange }) => {
       <button className={pill(value === 1)} onClick={() => onChange(1)}>
         <FontAwesomeIcon icon={faWeightScale} className='text-[0.65rem]' /> <span>Weight</span>
       </button>
+    </div>
+  );
+};
+
+// Compact two-up stepper for Brew mode (TEMP + WEIGHT side-by-side).
+// Slimmer than the full <Adjuster> so two of them fit in the narrow Compact
+// card width even on smaller tablets / portrait windows.
+const MiniStepper = ({ label, value, onDecrease, onIncrease }) => {
+  const btn = 'btn btn-ghost btn-xs flex h-6 w-6 items-center justify-center rounded-full p-0';
+  return (
+    <div className='flex flex-col items-center gap-1'>
+      <div className='text-base-content/60 text-[0.6rem] font-light tracking-wider'>{label}</div>
+      <div className='flex items-center space-x-1'>
+        <button onClick={onDecrease} className={btn} aria-label={`Lower ${label}`}>
+          <FontAwesomeIcon icon={faMinus} className='h-2.5 w-2.5' />
+        </button>
+        <div className='text-base-content min-w-[44px] text-center text-sm font-bold tabular-nums'>
+          {value}
+        </div>
+        <button onClick={onIncrease} className={btn} aria-label={`Raise ${label}`}>
+          <FontAwesomeIcon icon={faPlus} className='h-2.5 w-2.5' />
+        </button>
+      </div>
     </div>
   );
 };
@@ -126,7 +149,7 @@ const InfoView = ({ title, hint }) => (
   </div>
 );
 
-const BrewIdleView = ({ s, brewTarget, sendTarget }) => (
+const BrewIdleView = ({ s, brewTarget, sendTarget, send }) => (
   <div className='flex w-full max-w-sm min-w-0 flex-col items-stretch gap-3'>
     <a
       href='/profiles'
@@ -145,6 +168,28 @@ const BrewIdleView = ({ s, brewTarget, sendTarget }) => (
         </span>
       </span>
     </a>
+    {/* Same +/- steppers as the full ProcessControls — temp left, weight
+        right. Calls the same Controller methods that the device's gear-icon
+        BrewScreen uses; firmware reverts profile to disk values after each
+        brew (Controller::deactivate). Uses a slimmer inline layout (not the
+        shared <Adjuster>) so two steppers fit side-by-side in the narrow
+        Compact container even on tight viewports. */}
+    <div className='flex flex-row items-start justify-center gap-8'>
+      <MiniStepper
+        label='TEMP'
+        value={`${s.targetTemperature ?? 0}°C`}
+        onDecrease={() => send('req:lower-temp')}
+        onIncrease={() => send('req:raise-temp')}
+      />
+      {brewTarget && s.volumetricAvailable && (
+        <MiniStepper
+          label='WEIGHT'
+          value={`${(s.targetWeight ?? 0).toFixed(0)}g`}
+          onDecrease={() => send('req:lower-brew-target')}
+          onIncrease={() => send('req:raise-brew-target')}
+        />
+      )}
+    </div>
     {s.volumetricAvailable && <TargetToggle value={brewTarget ? 1 : 0} onChange={sendTarget} />}
   </div>
 );
@@ -241,7 +286,8 @@ export default function CompactProcessControls({ brew, mode, changeMode }) {
     if (processRunning && finished) return <FinishedView elapsed={fmtElapsed(p?.e)} />;
     if (processRunning) return <ActiveView p={p} grind={grind} />;
     if (mode === 0) return <InfoView title='Standby' hint='Machine is ready' />;
-    if (mode === 1) return <BrewIdleView s={s} brewTarget={brewTarget} sendTarget={sendTarget} />;
+    if (mode === 1)
+      return <BrewIdleView s={s} brewTarget={brewTarget} sendTarget={sendTarget} send={send} />;
     if (mode === 2 || mode === 3) return <TemperatureView s={s} mode={mode} send={send} />;
     if (grind && !grindAvailable)
       return <InfoView title='Grind' hint='Grind function not available' />;
@@ -283,6 +329,14 @@ export default function CompactProcessControls({ brew, mode, changeMode }) {
           current={(s.currentPressure ?? 0).toFixed(1)}
           target={(s.targetPressure ?? 0).toFixed(1)}
           unit=' bar'
+          /* Red alert when over 1 bar in Brew mode — boiler is likely
+             over-pressurized from previous shot/heat-up; flush or open
+             steam wand before brewing. */
+          currentClassName={
+            brew && (s.currentPressure ?? 0) > 1.0
+              ? 'text-error font-semibold'
+              : 'text-base-content'
+          }
         />
       </div>
 

--- a/web/src/pages/Home/CompactProcessControls.jsx
+++ b/web/src/pages/Home/CompactProcessControls.jsx
@@ -184,8 +184,13 @@ const BrewIdleView = ({ s, brewTarget, sendTarget, send }) => (
         onDecrease={() => send('req:lower-temp')}
         onIncrease={() => send('req:raise-temp')}
       />
+      {/* "TARGET" prefix on the morphing label makes the read honest:
+          the value is the brew-stopping condition the firmware will use,
+          and that condition depends on the loaded profile (volumetric or
+          duration). Matches the wording the full-layout ProcessControls
+          already uses (TARGET WEIGHT / TARGET TIME). */}
       <MiniStepper
-        label={brewTarget ? 'WEIGHT' : 'TIME'}
+        label={brewTarget ? 'TARGET WEIGHT' : 'TARGET TIME'}
         value={
           brewTarget
             ? `${(s.targetWeight ?? 0).toFixed(0)}g`

--- a/web/src/pages/Home/CompactProcessControls.jsx
+++ b/web/src/pages/Home/CompactProcessControls.jsx
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import { ApiServiceContext, machine } from '../../services/ApiService.js';
 import { ModeTab } from './ModeTab.jsx';
 import {
+  fmtDuration,
   fmtElapsed,
   fmtPhaseTarget,
   getPhaseLabel,
@@ -168,12 +169,14 @@ const BrewIdleView = ({ s, brewTarget, sendTarget, send }) => (
         </span>
       </span>
     </a>
-    {/* Same +/- steppers as the full ProcessControls — temp left, weight
-        right. Calls the same Controller methods that the device's gear-icon
-        BrewScreen uses; firmware reverts profile to disk values after each
-        brew (Controller::deactivate). Uses a slimmer inline layout (not the
-        shared <Adjuster>) so two steppers fit side-by-side in the narrow
-        Compact container even on tight viewports. */}
+    {/* Mirrors the device's gear-icon BrewScreen Settings panel exactly:
+        always show TEMP, plus a second slot that morphs between WEIGHT and
+        TIME based on `brewTarget` (firmware's `bt` flag = scale connected
+        AND profile is volumetric). Both modes call the SAME Controller
+        methods — `raiseBrewTarget` / `lowerBrewTarget` — which decide
+        internally whether to adjust the profile's volumetric target or its
+        phase duration based on the same condition. Format is the only
+        visible difference. */}
     <div className='flex flex-row items-start justify-center gap-8'>
       <MiniStepper
         label='TEMP'
@@ -181,16 +184,17 @@ const BrewIdleView = ({ s, brewTarget, sendTarget, send }) => (
         onDecrease={() => send('req:lower-temp')}
         onIncrease={() => send('req:raise-temp')}
       />
-      {brewTarget && s.volumetricAvailable && (
-        <MiniStepper
-          label='WEIGHT'
-          value={`${(s.targetWeight ?? 0).toFixed(0)}g`}
-          onDecrease={() => send('req:lower-brew-target')}
-          onIncrease={() => send('req:raise-brew-target')}
-        />
-      )}
+      <MiniStepper
+        label={brewTarget ? 'WEIGHT' : 'TIME'}
+        value={
+          brewTarget
+            ? `${(s.targetWeight ?? 0).toFixed(0)}g`
+            : fmtDuration(s.brewTargetDuration ?? 0)
+        }
+        onDecrease={() => send('req:lower-brew-target')}
+        onIncrease={() => send('req:raise-brew-target')}
+      />
     </div>
-    {s.volumetricAvailable && <TargetToggle value={brewTarget ? 1 : 0} onChange={sendTarget} />}
   </div>
 );
 
@@ -329,11 +333,13 @@ export default function CompactProcessControls({ brew, mode, changeMode }) {
           current={(s.currentPressure ?? 0).toFixed(1)}
           target={(s.targetPressure ?? 0).toFixed(1)}
           unit=' bar'
-          /* Red alert when over 1 bar in Brew mode — boiler is likely
-             over-pressurized from previous shot/heat-up; flush or open
-             steam wand before brewing. */
+          /* Red alert when over 1 bar while sitting idle in Brew mode —
+             boiler is likely over-pressurized from previous shot/heat-up;
+             flush or open steam wand before brewing. Suppressed during an
+             active brew (high pressure is expected) and immediately after
+             (pressure takes a moment to bleed off). */
           currentClassName={
-            brew && (s.currentPressure ?? 0) > 1.0
+            brew && !active && !finished && (s.currentPressure ?? 0) > 1.0
               ? 'text-error font-semibold'
               : 'text-base-content'
           }

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -321,8 +321,8 @@ const ProcessControls = props => {
             {status.value.currentTemperature.toFixed(1) || 0}
           </span>
           <span className='text-success font-semibold'>
-            {' '}
-            / {status.value.targetTemperature || 0}°C
+            {' / '}
+            {status.value.targetTemperature || 0}°C
           </span>
         </div>
         {status.value.volumetricAvailable && mode !== 0 && (
@@ -334,8 +334,8 @@ const ProcessControls = props => {
                   {(status.value.currentWeight ?? 0).toFixed(1)}g
                 </span>
                 <span className='text-success font-semibold'>
-                  {' '}
-                  / {(status.value.targetWeight ?? 0).toFixed(0)}g
+                  {' / '}
+                  {(status.value.targetWeight ?? 0).toFixed(0)}g
                 </span>
               </>
             )}
@@ -344,7 +344,21 @@ const ProcessControls = props => {
         <div className='flex flex-row items-center gap-2 text-center text-base sm:text-right sm:text-lg'>
           <FontAwesomeIcon icon={faGauge} className='text-base-content/60' />
           <span className='text-base-content'>
-            {status.value.currentPressure?.toFixed(1) || 0} /{' '}
+            {/* Only the CURRENT pressure value turns red when above 1 bar in
+                Brew mode — typically means the boiler is over-pressurized
+                from the previous shot or heat-up cycle, and the user should
+                flush or open the steam wand before brewing to avoid wrecking
+                the puck. The target pressure and units stay normal color. */}
+            <span
+              className={
+                brew && (status.value.currentPressure ?? 0) > 1.0
+                  ? 'text-error font-semibold'
+                  : ''
+              }
+            >
+              {status.value.currentPressure?.toFixed(1) || 0}
+            </span>
+            {' / '}
             {status.value.targetPressure?.toFixed(1) || 0} bar
           </span>
         </div>
@@ -476,6 +490,79 @@ const ProcessControls = props => {
             </div>
           )}
         {/* Controls for different modes */}
+        {mode === 1 && !active && !finished && (
+          <div className='flex flex-col items-center gap-4'>
+            {/* Brew mode: quick stepper adjustments for the active profile's
+                target temp and weight, laid out side-by-side (temp left,
+                weight right). Each tap calls the same raiseTemp / lowerTemp
+                / raiseBrewTarget / lowerBrewTarget controller methods that
+                the device's gear-icon BrewScreen uses, so the behaviour is
+                identical across web + display. Changes mutate the in-memory
+                profile and the firmware reverts to the on-disk profile after
+                the next brew completes (Controller::deactivate) — for
+                permanent changes use the Profiles page. */}
+            <div className='flex flex-row flex-wrap items-start justify-center gap-x-8 gap-y-4'>
+              <div className='flex flex-col items-center gap-2'>
+                <div className='text-base-content/60 text-xs font-light tracking-wider'>
+                  TEMPERATURE
+                </div>
+                <div className='flex items-center space-x-2'>
+                  <Tooltip content='Lower temperature'>
+                    <button
+                      onClick={lowerTemp}
+                      className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                      aria-label='Lower target temperature'
+                    >
+                      <FontAwesomeIcon icon={faMinus} className='h-3 w-3' />
+                    </button>
+                  </Tooltip>
+                  <div className='text-base-content min-w-[80px] text-center text-lg font-bold'>
+                    {status.value.targetTemperature || 0}°C
+                  </div>
+                  <Tooltip content='Raise temperature'>
+                    <button
+                      onClick={raiseTemp}
+                      className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                      aria-label='Raise target temperature'
+                    >
+                      <FontAwesomeIcon icon={faPlus} className='h-3 w-3' />
+                    </button>
+                  </Tooltip>
+                </div>
+              </div>
+              {brewTarget && status.value.volumetricAvailable && (
+                <div className='flex flex-col items-center gap-2'>
+                  <div className='text-base-content/60 text-xs font-light tracking-wider'>
+                    TARGET WEIGHT
+                  </div>
+                  <div className='flex items-center space-x-2'>
+                    <Tooltip content='Lower target weight'>
+                      <button
+                        onClick={lowerTarget}
+                        className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                        aria-label='Lower target weight'
+                      >
+                        <FontAwesomeIcon icon={faMinus} className='h-3 w-3' />
+                      </button>
+                    </Tooltip>
+                    <div className='text-base-content min-w-[80px] text-center text-lg font-bold'>
+                      {(status.value.targetWeight ?? 0).toFixed(0)}g
+                    </div>
+                    <Tooltip content='Raise target weight'>
+                      <button
+                        onClick={raiseTarget}
+                        className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                        aria-label='Raise target weight'
+                      >
+                        <FontAwesomeIcon icon={faPlus} className='h-3 w-3' />
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
         {mode === 2 && (
           <div className='flex flex-col items-center gap-4 space-y-4'>
             {/* Temperature adjustment controls for steam mode */}

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -17,7 +17,7 @@ import { ProcessProfileChart } from '../../components/ProcessProfileChart.jsx';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { Tooltip } from '../../components/Tooltip.jsx';
-import { MODES } from './utils.js';
+import { fmtDuration, MODES } from './utils.js';
 import { ModeTab } from './ModeTab.jsx';
 
 const status = computed(() => machine.value.status);
@@ -344,14 +344,20 @@ const ProcessControls = props => {
         <div className='flex flex-row items-center gap-2 text-center text-base sm:text-right sm:text-lg'>
           <FontAwesomeIcon icon={faGauge} className='text-base-content/60' />
           <span className='text-base-content'>
-            {/* Only the CURRENT pressure value turns red when above 1 bar in
-                Brew mode — typically means the boiler is over-pressurized
-                from the previous shot or heat-up cycle, and the user should
-                flush or open the steam wand before brewing to avoid wrecking
-                the puck. The target pressure and units stay normal color. */}
+            {/* Only the CURRENT pressure value turns red when above 1 bar
+                while sitting idle in Brew mode — typically means the boiler
+                is over-pressurized from the previous shot or heat-up cycle,
+                and the user should flush or open the steam wand before
+                brewing to avoid wrecking the puck. Suppressed once a brew
+                is active or just finished, since high pressure is expected
+                during the shot and takes a moment to bleed off after. The
+                target pressure and units always stay normal color. */}
             <span
               className={
-                brew && (status.value.currentPressure ?? 0) > 1.0
+                brew &&
+                !active &&
+                !finished &&
+                (status.value.currentPressure ?? 0) > 1.0
                   ? 'text-error font-semibold'
                   : ''
               }
@@ -492,15 +498,17 @@ const ProcessControls = props => {
         {/* Controls for different modes */}
         {mode === 1 && !active && !finished && (
           <div className='flex flex-col items-center gap-4'>
-            {/* Brew mode: quick stepper adjustments for the active profile's
-                target temp and weight, laid out side-by-side (temp left,
-                weight right). Each tap calls the same raiseTemp / lowerTemp
-                / raiseBrewTarget / lowerBrewTarget controller methods that
-                the device's gear-icon BrewScreen uses, so the behaviour is
-                identical across web + display. Changes mutate the in-memory
-                profile and the firmware reverts to the on-disk profile after
-                the next brew completes (Controller::deactivate) — for
-                permanent changes use the Profiles page. */}
+            {/* Brew mode quick steppers — mirrors the device's gear-icon
+                BrewScreen Settings panel: always show TEMP, plus a single
+                second slot that morphs between WEIGHT and TIME based on
+                `brewTarget` (firmware's `bt` flag = scale connected AND
+                profile is volumetric). Both modes call the same Controller
+                methods (raiseBrewTarget / lowerBrewTarget) which decide
+                internally whether to adjust the profile's volumetric target
+                or its phase duration based on the same condition. Changes
+                are transient — firmware reverts the in-memory profile to its
+                on-disk values after each brew (Controller::deactivate). For
+                permanent edits use the Profiles page. */}
             <div className='flex flex-row flex-wrap items-start justify-center gap-x-8 gap-y-4'>
               <div className='flex flex-col items-center gap-2'>
                 <div className='text-base-content/60 text-xs font-light tracking-wider'>
@@ -530,36 +538,36 @@ const ProcessControls = props => {
                   </Tooltip>
                 </div>
               </div>
-              {brewTarget && status.value.volumetricAvailable && (
-                <div className='flex flex-col items-center gap-2'>
-                  <div className='text-base-content/60 text-xs font-light tracking-wider'>
-                    TARGET WEIGHT
-                  </div>
-                  <div className='flex items-center space-x-2'>
-                    <Tooltip content='Lower target weight'>
-                      <button
-                        onClick={lowerTarget}
-                        className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
-                        aria-label='Lower target weight'
-                      >
-                        <FontAwesomeIcon icon={faMinus} className='h-3 w-3' />
-                      </button>
-                    </Tooltip>
-                    <div className='text-base-content min-w-[80px] text-center text-lg font-bold'>
-                      {(status.value.targetWeight ?? 0).toFixed(0)}g
-                    </div>
-                    <Tooltip content='Raise target weight'>
-                      <button
-                        onClick={raiseTarget}
-                        className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
-                        aria-label='Raise target weight'
-                      >
-                        <FontAwesomeIcon icon={faPlus} className='h-3 w-3' />
-                      </button>
-                    </Tooltip>
-                  </div>
+              <div className='flex flex-col items-center gap-2'>
+                <div className='text-base-content/60 text-xs font-light tracking-wider'>
+                  {brewTarget ? 'TARGET WEIGHT' : 'TARGET TIME'}
                 </div>
-              )}
+                <div className='flex items-center space-x-2'>
+                  <Tooltip content={brewTarget ? 'Lower target weight' : 'Lower target time'}>
+                    <button
+                      onClick={lowerTarget}
+                      className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                      aria-label={brewTarget ? 'Lower target weight' : 'Lower target time'}
+                    >
+                      <FontAwesomeIcon icon={faMinus} className='h-3 w-3' />
+                    </button>
+                  </Tooltip>
+                  <div className='text-base-content min-w-[80px] text-center text-lg font-bold'>
+                    {brewTarget
+                      ? `${(status.value.targetWeight ?? 0).toFixed(0)}g`
+                      : fmtDuration(status.value.brewTargetDuration ?? 0)}
+                  </div>
+                  <Tooltip content={brewTarget ? 'Raise target weight' : 'Raise target time'}>
+                    <button
+                      onClick={raiseTarget}
+                      className='btn btn-ghost btn-sm flex h-8 w-8 items-center justify-center rounded-full p-0'
+                      aria-label={brewTarget ? 'Raise target weight' : 'Raise target time'}
+                    >
+                      <FontAwesomeIcon icon={faPlus} className='h-3 w-3' />
+                    </button>
+                  </Tooltip>
+                </div>
+              </div>
             </div>
           </div>
         )}

--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -63,10 +63,10 @@ export function Home() {
           className={`landscape:max-lg:min-h-0 landscape:sm:col-span-5 ${dashboardLayout === DASHBOARD_LAYOUTS.ORDER_FIRST ? 'order-first' : 'order-last'}`}
           title='Process Controls'
         >
-          <div className='landscape:hmd:hidden potrait:md:hidden contents'>
+          <div className='landscape:hmd:hidden portrait:md:hidden contents'>
             <CompactProcessControls brew={mode === 1} mode={mode} changeMode={changeMode} />
           </div>
-          <div className='landscape:hmd:contents potrait:md:contents hidden'>
+          <div className='landscape:hmd:contents portrait:md:contents hidden'>
             <ProcessControls brew={mode === 1} mode={mode} changeMode={changeMode} />
           </div>
         </Card>

--- a/web/src/pages/Home/utils.js
+++ b/web/src/pages/Home/utils.js
@@ -20,6 +20,14 @@ export const fmtElapsed = (ms = 0) => {
   return `${Math.floor(secs / 60)}:${String(secs % 60).padStart(2, '0')}`;
 };
 
+// fmtDuration takes a value in SECONDS (vs fmtElapsed which takes ms) and
+// renders M:SS. Used by the Brew-mode stepper when the profile/scale combo
+// puts it in time mode rather than weight mode.
+export const fmtDuration = (s = 0) => {
+  const secs = Math.floor(s);
+  return `${Math.floor(secs / 60)}:${String(secs % 60).padStart(2, '0')}`;
+};
+
 export const fmtPhaseTarget = (p, grind) => {
   if (p?.tt === 'time') return `${(p.pt / 1000).toFixed(0)}s`;
   if (p?.tt === 'volumetric') return `${p.pt.toFixed(grind ? 1 : 0)}g`;


### PR DESCRIPTION
## Summary

Adds a Brew-mode quick-adjust workflow to the web Dashboard plus a visual cue when the boiler is still pressurised before a shot. Behaviour is consistent with the device's on-screen gear-icon BrewScreen Settings panel — no firmware semantics change beyond wiring up two missing WebSocket handlers.

### 1. Brew-mode +/- steppers (TEMP + WEIGHT/TIME)

When in Brew mode with no process running, the Process Controls card shows a TEMP stepper plus a second slot that morphs based on the firmware status flag `bt = isVolumetricAvailable && profile.isVolumetric`:

- `bt=true`  → label **TARGET WEIGHT**, value `Xg`, `+`/`−` adjusts the profile's volumetric target
- `bt=false` → label **TARGET TIME**, value `M:SS`, `+`/`−` adjusts the profile's phase duration

Both modes call the same `req:raise-brew-target` / `req:lower-brew-target` WS messages; `Controller::raiseBrewTarget` / `lowerBrewTarget` decide internally whether to adjust the profile's volumetric value or its phase durations based on the same condition. This is the exact logic the device's gear-icon BrewScreen Settings panel already uses — users get consistent affordances across both interfaces, and time-based profiles (or any brew without a connected scale) are no longer second-class citizens in the dashboard.

These are **transient "next-brew-only" adjustments**, not a profile editor. The firmware reloads the selected profile from disk after each brew completes (`Controller::deactivate`), so values revert. Permanent edits still go through the Profiles page.

Implemented in both `ProcessControls` (full layout) and `CompactProcessControls` (responsive layout, slimmer `MiniStepper` so two fit side-by-side).

### 2. Over-pressure red alert (idle only)

In Brew mode, the current pressure value turns `text-error` (red, semibold) when above 1.0 bar **and the brew is idle** — i.e. no shot active and no finished view shown. The cue is suppressed during the brew itself and the immediate post-brew finished view, since 8+ bar is the expected state during the shot and pressure takes a moment to bleed off after. The cue returns automatically once the user clears the finished view and the card is back to idle.

Visual purpose: warn the user that the boiler/group is still pressurised from a prior shot or heat-up before starting the next brew, without adding red noise during the periods when high pressure is normal.

Two reasons this matters:

- **Pressure-aware profiles depend on a clean baseline.** Adaptive / pressure-driven profiles read current pressure to drive phase transitions, predictive delay, and decline behaviour. Residual pressure above the profile's preinfusion thresholds at process start can skip or misadvance phases, producing a shot that doesn't follow the intended curve.
- **Back-pressurised group heads channel.** Common physical cause of blown pucks and uneven extraction, especially first shot of a session or after steaming.

Localised to the current pressure reading only (target + unit stay normal colour), and only triggers in Brew mode (>1 bar is normal in Steam).

### 3. Bonus fix: `potrait` typo in responsive variant

While working on the dashboard I noticed `Home/index.jsx` has `potrait:md:hidden` and `potrait:md:contents`. Tailwind silently ignores undefined variants, so the portrait switch between Compact and full layouts never worked — Compact was always shown in portrait orientation, even on tablets at widths where the full layout fits comfortably. Renamed to `portrait:` so the intended responsive behaviour activates.

### Firmware changes (minimal)

- `WebUIPlugin::handleWebSocketData`: add `req:raise-brew-target` / `req:lower-brew-target` handlers. The web client already sent these via the existing `raiseTarget()` callback (the Grind +/- buttons use the same pattern) but firmware had no matching handler — they were silently dropped.
- `Controller::deactivate`: reload the selected profile from disk on brew end, so stepper adjustments are transient.

## Test plan

- [ ] In Brew mode (idle), `−`/`+` adjusts TEMP — value updates immediately
- [ ] In Brew mode with BLE scale connected and a volumetric profile → second stepper labelled `TARGET WEIGHT`, `−`/`+` adjusts weight
- [ ] In Brew mode without scale (or with a non-volumetric profile) → second stepper labelled `TARGET TIME` (M:SS), `−`/`+` adjusts duration
- [ ] Disconnect/reconnect the scale mid-session → second stepper morphs between WEIGHT and TIME automatically on the next status tick
- [ ] Start a brew with adjusted values, let it finish — values revert to profile defaults afterward
- [ ] Pressure > 1 bar in Brew mode **while idle** → current value renders in red
- [ ] Pressure > 1 bar during an **active** brew or in the **finished** post-brew view → renders normal colour (red suppressed)
- [ ] Same > 1 bar value in Steam/Water/Standby/Grind → no red regardless of state
- [ ] Open dashboard in portrait orientation on a tablet ≥ 768px wide → full `ProcessControls` renders (not Compact)
- [ ] Compact view (narrow window / phone) shows the steppers side-by-side via `MiniStepper`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brew target raise/lower controls now work from the UI.
  * Compact stepper controls for temperature and weight/time in brew idle.
  * Quick brew-mode controls added; time stepper displays M:SS format.

* **Bug Fixes**
  * Fixed responsive layout class name typo.

* **Improvements**
  * Pressure value shows alert styling when high during idle.
  * Profile values automatically revert to saved settings after each brew.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->