### PR TITLE
fix(firmware): reset Profile copies before parseProfile-append callers

### DIFF
--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -16,6 +16,11 @@ void ProfileManager::setup() {
                               _settings.getSelectedProfile() == "" || !loadSelectedProfile(selectedProfile);
     if (needsMigrate) {
         migrate(profiles);
+        // Reset before reload: parseProfile() appends to profile.phases. The
+        // earlier loadSelectedProfile in `needsMigrate` may have pushed phases
+        // before failing validation, leaving partial state that this reload
+        // would double. Defensive — current paths almost never hit this.
+        selectedProfile = Profile{};
         loadSelectedProfile(selectedProfile);
     }
     _settings.setFavoritedProfiles(getFavoritedProfiles(true));

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -201,6 +201,12 @@ void DefaultUI::init() {
                       [this](Event const &) { changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init); });
 
     pluginManager->on("profiles:profile:select", [this](Event const &event) {
+        // Reset the local copy before reload: parseProfile() appends to
+        // profile.phases rather than replacing, so feeding it the already-
+        // populated member would double the phase count on every profile
+        // switch (memory leak + corrupted internal phase count). Mirrors the
+        // pattern ProfileManager::selectProfile uses for the same reason.
+        selectedProfile = Profile{};
         profileManager->loadSelectedProfile(selectedProfile);
         selectedProfileId = event.getString("id");
         targetDuration = profileManager->getSelectedProfile().getTotalDuration();
@@ -366,6 +372,10 @@ void DefaultUI::setupState() {
     pressureAvailable = controller->getSystemInfo().capabilities.pressure ? 1 : 0;
     pressureScaling = std::ceil(settings.getPressureScaling());
     selectedProfileId = settings.getSelectedProfile();
+    // Defense in depth: reset before reload (this site is currently safe in
+    // practice because setupState runs once with a fresh field-initialized
+    // member, but keeps the pattern consistent with the event handler above).
+    selectedProfile = Profile{};
     profileManager->loadSelectedProfile(selectedProfile);
     profileVolumetric = selectedProfile.isVolumetric();
 }


### PR DESCRIPTION
## Summary

`parseProfile()` at `src/display/models/profile.h:245-322` appends to `profile.phases` rather than replacing it, so callers must pass a freshly default-constructed Profile to avoid duplicating phases across reloads. This PR fixes the two sites that were leaking and adds defense-in-depth at one more.

### What was wrong

- **`DefaultUI.cpp:204`** — the `profiles:profile:select` event handler reuses the class member `selectedProfile`. Every profile switch doubled the phase count of that local copy. Memory leak across the session; user-facing target/duration numbers were unaffected because they read from `profileManager`'s own (correctly-reset) copy.
- **`ProfileManager.cpp:19`** — the second `loadSelectedProfile` after `migrate()` can hit the same shape if the first call at line 16 partially populated `phases` before failing validation. Latent under normal boot but the defect shape is identical.

### Fix

Reset the local Profile to `Profile{}` before each `loadSelectedProfile` call into a non-fresh Profile. Mirrors the pattern `ProfileManager::selectProfile` (line 216) and `Controller::deactivate` already use for exactly this reason.

Also applied defensively at `DefaultUI.cpp:369` (the `setupState` path). That site is currently safe because the field initializer runs once with an empty member, but keeping the pattern consistent prevents future regression.

`parseProfile()` itself is left intentionally untouched — making it idempotent would be a contract change that could affect other callers (web JSON parse helpers, etc.). Caller-side reset is the more conservative fix.

## Test plan

- [ ] Switch profiles repeatedly via web UI or device wheel — no crash, target weight/time display stays correct, no unbounded memory growth
- [ ] Factory-fresh boot triggering `migrate()` path — selected profile loads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where profile loading during system boot and profile selection could result in duplicate or accumulated configuration state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->