### PR TITLE
fix(firmware): local-capture lastProcess/currentProcess in onVolumetr…

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -749,11 +749,19 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
         ESP_LOGD(LOG_TAG, "Ignoring volumetric measurement, source does not match");
         return;
     }
-    if (currentProcess != nullptr) {
-        currentProcess->updateVolume(measurement);
+    // Local capture to avoid use-after-free with deactivate() / clear() running
+    // on another core. This callback fires from the NimBLE task on core 0 each
+    // time the BLE scale reports weight; deactivate() / clear() run on core 1
+    // (AsyncTCP/LVGL) and can `delete lastProcess` between our nullptr check
+    // and the dereference. Mirrors the same capture pattern used in
+    // updateControl() above (see comment around line 560).
+    Process *curr = currentProcess;
+    Process *last = lastProcess;
+    if (curr != nullptr) {
+        curr->updateVolume(measurement);
     }
-    if (lastProcess != nullptr && !lastProcess->isComplete()) {
-        lastProcess->updateVolume(measurement);
+    if (last != nullptr && !last->isComplete()) {
+        last->updateVolume(measurement);
     }
 }
 


### PR DESCRIPTION
## Summary

Mirror the local-capture pattern already used in `Controller::updateControl` (see comment around `Controller.cpp:560`) to close a use-after-free window in `onVolumetricMeasurement`.

### What was wrong

`Controller::onVolumetricMeasurement` (`Controller.cpp:761-779`) is invoked from the NimBLE callback on core 0 each time the BLE scale reports weight. `deactivate()` and `clear()` run on core 1 (AsyncTCP / LVGL / Arduino loop) and can `delete lastProcess` between the nullptr check and the dereference of `updateVolume()` — exactly the cross-core race the existing `Controller.cpp:560` comment calls out and that `updateControl` already guards against.

### Fix

Cache the pointers locally before the nullptr checks so a concurrent deletion cannot void them mid-call. Two-line addition mirroring the existing pattern.

### User-visible impact

Rare crash window at brew-end when a BLE scale weight sample arrives at the exact instant a brew is being deactivated. Manifests as an unexpected reboot during the last sample of a brew, or silently as a later crash from corrupted heap allocator state. Hard to reproduce on demand; closing the window pre-emptively prevents future field reports.

## Test plan

- [ ] Normal brew with BLE scale — scale weight still updates live on dashboard during brew
- [ ] Brew completion + cleanup happens normally without crashes across many brew/clear cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause the app to crash during volumetric measurement operations when background processes run concurrently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->