### PR TITLE
fix(firmware): close shot-history file/header inheritance race across…

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -101,22 +101,12 @@ void ShotHistoryPlugin::record() {
             currentFile = fs->open("/h/" + currentId + ".slog", FILE_WRITE);
             if (currentFile) {
                 isFileOpen = true;
-                // Prepare header
-                memset(&header, 0, sizeof(header));
-                header.magic = SHOT_LOG_MAGIC;
-                header.version = SHOT_LOG_VERSION;
-                header.reserved0 = (uint8_t)SHOT_LOG_SAMPLE_SIZE; // record sample size actually used
-                header.headerSize = SHOT_LOG_HEADER_SIZE;
-                header.sampleInterval = SHOT_LOG_SAMPLE_INTERVAL_MS;
-                header.fieldsMask = SHOT_LOG_FIELDS_MASK_ALL;
-                header.startEpoch = getTime();
-                Profile profile = controller->getProfileManager()->getSelectedProfile();
-                strncpy(header.profileId, profile.id.c_str(), sizeof(header.profileId) - 1);
-                header.profileId[sizeof(header.profileId) - 1] = '\0';
-                strncpy(header.profileName, profile.label.c_str(), sizeof(header.profileName) - 1);
-                header.profileName[sizeof(header.profileName) - 1] = '\0';
-                header.phaseTransitionCount = 0; // Initialize phase transition count
-                // Write header placeholder
+                // Header was populated synchronously in startRecording() —
+                // including profileId / profileName captured from the running
+                // BrewProcess's per-shot immutable profile copy. We only need
+                // to write the placeholder header to the file here; the
+                // sampleCount / durationMs / finalWeight fields will be
+                // patched by finalizeShotFile() when the shot ends.
                 currentFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
             }
         }
@@ -208,46 +198,56 @@ void ShotHistoryPlugin::record() {
         }
     }
     if (!recording && !extendedRecording && isFileOpen) {
-        flushBuffer();
-        // Patch header with sampleCount and duration
-        header.sampleCount = sampleCount;
-        header.durationMs = millis() - shotStart;
-        float finalWeight = currentBluetoothWeight;
-        header.finalWeight = finalWeight > 0.0f ? encodeUnsigned(finalWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE) : 0;
-        currentFile.seek(0, SeekSet);
-        currentFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
-        currentFile.close();
-        isFileOpen = false;
-        unsigned long duration = header.durationMs;
-        if (duration <= 7500) { // Exclude failed shots and flushes
-            fs->remove("/h/" + currentId + ".slog");
+        finalizeShotFile();
+    }
+}
 
-            // If we created an early index entry, mark it as deleted
-            if (indexEntryCreated) {
-                markIndexDeleted(currentId.toInt());
-            }
-        } else {
-            controller->getSettings().setHistoryIndex(controller->getSettings().getHistoryIndex() + 1);
-            cleanupHistory();
+// Finalize the in-progress shot file: patch header with final sampleCount /
+// duration / weight, close the file, and either discard (<=7.5s "failed") or
+// upsert an index entry. Extracted from record()'s cleanup branch so that
+// startRecording() can also call it defensively when a previous shot's file
+// was still open at the moment a new brew started (the cleanup-branch tick
+// only fires when recording=false AND extendedRecording=false, so a rapid
+// next-brew that flips recording=true before record()'s 250ms tick had a
+// chance to run would otherwise strand the file and the new brew would
+// inherit it).
+void ShotHistoryPlugin::finalizeShotFile() {
+    flushBuffer();
+    header.sampleCount = sampleCount;
+    header.durationMs = millis() - shotStart;
+    float finalWeight = currentBluetoothWeight;
+    header.finalWeight = finalWeight > 0.0f ? encodeUnsigned(finalWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE) : 0;
+    currentFile.seek(0, SeekSet);
+    currentFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
+    currentFile.close();
+    isFileOpen = false;
+    unsigned long duration = header.durationMs;
+    if (duration <= 7500) { // Exclude failed shots and flushes
+        fs->remove("/h/" + currentId + ".slog");
+        if (indexEntryCreated) {
+            markIndexDeleted(currentId.toInt());
+        }
+    } else {
+        controller->getSettings().setHistoryIndex(controller->getSettings().getHistoryIndex() + 1);
+        cleanupHistory();
 
-            // Always create a complete index entry via upsert.
-            // If an early entry exists, it gets overwritten with final data.
-            // If no early entry exists, a new one is appended.
-            ShotIndexEntry indexEntry{};
-            indexEntry.id = currentId.toInt();
-            indexEntry.timestamp = header.startEpoch;
-            indexEntry.duration = header.durationMs;
-            indexEntry.volume = header.finalWeight;
-            indexEntry.rating = 0;
-            indexEntry.flags = SHOT_FLAG_COMPLETED;
-            strncpy(indexEntry.profileId, header.profileId, sizeof(indexEntry.profileId) - 1);
-            indexEntry.profileId[sizeof(indexEntry.profileId) - 1] = '\0';
-            strncpy(indexEntry.profileName, header.profileName, sizeof(indexEntry.profileName) - 1);
-            indexEntry.profileName[sizeof(indexEntry.profileName) - 1] = '\0';
+        // Always create a complete index entry via upsert.
+        // If an early entry exists, it gets overwritten with final data.
+        // If no early entry exists, a new one is appended.
+        ShotIndexEntry indexEntry{};
+        indexEntry.id = currentId.toInt();
+        indexEntry.timestamp = header.startEpoch;
+        indexEntry.duration = header.durationMs;
+        indexEntry.volume = header.finalWeight;
+        indexEntry.rating = 0;
+        indexEntry.flags = SHOT_FLAG_COMPLETED;
+        strncpy(indexEntry.profileId, header.profileId, sizeof(indexEntry.profileId) - 1);
+        indexEntry.profileId[sizeof(indexEntry.profileId) - 1] = '\0';
+        strncpy(indexEntry.profileName, header.profileName, sizeof(indexEntry.profileName) - 1);
+        indexEntry.profileName[sizeof(indexEntry.profileName) - 1] = '\0';
 
-            if (!appendToIndex(indexEntry)) {
-                ESP_LOGE("ShotHistoryPlugin", "CRITICAL: Failed to add completed shot %u to index", indexEntry.id);
-            }
+        if (!appendToIndex(indexEntry)) {
+            ESP_LOGE("ShotHistoryPlugin", "CRITICAL: Failed to add completed shot %u to index", indexEntry.id);
         }
     }
 }
@@ -262,6 +262,15 @@ void ShotHistoryPlugin::startRecording() {
         // Capture initial volumetric mode state (brew by weight vs brew by time)
         shotStartedVolumetric = brewProcess->target == ProcessTarget::VOLUMETRIC;
     }
+    // Defensive cleanup: if the previous shot's file is still open (because
+    // the cleanup tick at record() hadn't run yet between brew:clear and our
+    // brew:start), finalize it now. Otherwise this new brew's samples would
+    // be appended to the previous file under the previous header, and the
+    // previous shot would lose its true ending while this shot would be
+    // mis-recorded under the previous profile's name.
+    if (isFileOpen) {
+        finalizeShotFile();
+    }
     currentId = padId(String(controller->getSettings().getHistoryIndex()));
     shotStart = millis();
     lastWeightChangeTime = 0;
@@ -270,7 +279,29 @@ void ShotHistoryPlugin::startRecording() {
     lastStableWeight = 0.0f;
     currentEstimatedWeight = 0.0f;
     currentBluetoothFlow = 0.0f;
-    currentProfileName = controller->getProfileManager()->getSelectedProfile().label;
+    // Populate the header synchronously here, while we still have the running
+    // BrewProcess's immutable per-shot profile copy. Capturing now (rather
+    // than re-reading the live selectedProfile in record() on the next tick)
+    // closes a separate race where a user-driven profile switch landing
+    // between brew:start and the first record() tick would stamp the wrong
+    // profile name into the shot file's header.
+    memset(&header, 0, sizeof(header));
+    header.magic = SHOT_LOG_MAGIC;
+    header.version = SHOT_LOG_VERSION;
+    header.reserved0 = (uint8_t)SHOT_LOG_SAMPLE_SIZE;
+    header.headerSize = SHOT_LOG_HEADER_SIZE;
+    header.sampleInterval = SHOT_LOG_SAMPLE_INTERVAL_MS;
+    header.fieldsMask = SHOT_LOG_FIELDS_MASK_ALL;
+    header.startEpoch = getTime();
+    header.phaseTransitionCount = 0;
+    if (process != nullptr && process->getType() == MODE_BREW) {
+        auto *bp = static_cast<BrewProcess *>(process);
+        strncpy(header.profileId, bp->profile.id.c_str(), sizeof(header.profileId) - 1);
+        header.profileId[sizeof(header.profileId) - 1] = '\0';
+        strncpy(header.profileName, bp->profile.label.c_str(), sizeof(header.profileName) - 1);
+        header.profileName[sizeof(header.profileName) - 1] = '\0';
+    }
+    currentProfileName = String(header.profileName);
     recording = true;
     extendedRecording = false;
     indexEntryCreated = false; // Reset flag for new shot

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -296,10 +296,12 @@ void ShotHistoryPlugin::startRecording() {
     header.phaseTransitionCount = 0;
     if (process != nullptr && process->getType() == MODE_BREW) {
         auto *bp = static_cast<BrewProcess *>(process);
-        strncpy(header.profileId, bp->profile.id.c_str(), sizeof(header.profileId) - 1);
-        header.profileId[sizeof(header.profileId) - 1] = '\0';
-        strncpy(header.profileName, bp->profile.label.c_str(), sizeof(header.profileName) - 1);
-        header.profileName[sizeof(header.profileName) - 1] = '\0';
+        // snprintf is bounded and always null-terminates within the dst
+        // buffer; the prior strncpy + manual NUL write was equivalent but
+        // tripped SonarQube's `cpp:S5816` ("strncpy may not null-terminate")
+        // security-hotspot heuristic. Same observable behavior, no hotspot.
+        snprintf(header.profileId, sizeof(header.profileId), "%s", bp->profile.id.c_str());
+        snprintf(header.profileName, sizeof(header.profileName), "%s", bp->profile.label.c_str());
     }
     currentProfileName = String(header.profileName);
     recording = true;

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -42,6 +42,7 @@ class ShotHistoryPlugin : public Plugin {
     void saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);
     void startRecording();
+    void finalizeShotFile();
 
     uint16_t getSystemInfo(); // Helper to pack system state bits
 


### PR DESCRIPTION
## Summary

When a user starts a second brew before the first brew's shot file has been finalized, `ShotHistoryPlugin` writes the new brew's samples into the previous brew's file under the previous brew's header. The user sees their most recent brew either missing from Shot History entirely, or labeled with the previous profile's name.

### What was wrong

`ShotHistoryPlugin::startRecording()` did not reset `isFileOpen` or `header`. The cleanup branch in `record()` only runs on its 250 ms tick AND only when `recording=false AND extendedRecording=false`. With a BLE scale connected, `extendedRecording` can stay `true` for up to 3 seconds after `controller:brew:end`.

The race:

1. Brew A ends. `endRecording()` flips `recording=false`, `extendedRecording=true`. Post-drip sampling continues. File still open with A's header.
2. User starts Brew B. `Controller::activate()` fires `controller:brew:clear` → `endExtendedRecording()` flips `extendedRecording=false`. Then `delay(200)` (shorter than the 250 ms `record()` interval, so the cleanup branch usually does NOT run). Then `controller:brew:start` → `startRecording()` flips `recording=true`.
3. Next `record()` tick sees `isFileOpen=true` so skips the file-open path. Brew B's samples get appended to A's file under A's header.
4. Cleanup eventually runs at end of B. Patches A's file header with B's `sampleCount` / `durationMs`. The index entry upsert at lines 622-628 overwrites the early-index entry (which had the correct "B" name) with the merged header.

Net effect: B's brew appears in Shot History under A's name and A's timestamp / id; B's separately-named `.slog` file is never created.

Compounded by a separate narrower race: `record()` reads `getSelectedProfile()` live on each tick to populate the header. If the user switches profile between `brew:start` firing and the first `record()` tick, the wrong name lands in the header even without the file-inheritance race.

### Fix

Two coupled changes:

1. **Extract the cleanup branch into `finalizeShotFile()`**, then call it defensively at the top of `startRecording()` when `isFileOpen=true`. The previous shot gets properly patched, closed, and indexed before the new shot's state is initialized.

2. **Populate the shot file header synchronously in `startRecording()`** — magic / sample-size / startEpoch / profileId / profileName / phaseTransitionCount — using the running `BrewProcess`'s per-shot immutable profile copy (`brewProcess->profile`). Closes the live-profile-read race. `record()`'s file-open path no longer initializes the header; `startRecording()` guarantees it.

The previously-dead `currentProfileName` field is repurposed as a mirror of the header value for downstream telemetry consistency.

### User-visible impact

Before: rapid back-to-back brews (within ~3s with BLE scale connected, or ~250 ms without) caused the second brew to be lost or mislabeled in Shot History.

After: each brew gets its own correctly-named entry in Shot History regardless of how quickly the next brew starts.

## Test plan

- [ ] Run brew A with profile A (BLE scale connected). Let it finish.
- [ ] Immediately start brew B with profile B (within a few seconds of A finishing, before A's extended recording would naturally complete).
- [ ] Open Shot History — both A and B appear with correct profile names in correct chronological order.
- [ ] Repeat without BLE scale connected — same expectation.
- [ ] Standard "wait a while between brews" workflow still works (no regression on the normal case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable shot recording: previous incomplete recordings are finalized before new ones start and very short/failed shots are discarded.
* **Improvements**
  * Profile details are captured at recording start for more accurate shot metadata and consistent history entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->