### PR TITLE
fix(firmware/web): /profiles page reliability + perf for large libraries

### DIFF
--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -1,5 +1,6 @@
 #include "ProfileManager.h"
 #include <ArduinoJson.h>
+#include <display/util/PsramAllocator.h>
 
 #include <utility>
 
@@ -151,7 +152,12 @@ bool ProfileManager::loadProfile(const String &uuid, Profile &outProfile) {
     if (!file)
         return false;
 
-    JsonDocument doc;
+    // Back the temp JsonDocument with PSRAM. Without this every loadProfile
+    // call allocates a fresh ~6-12 KB node pool from internal heap and
+    // releases it on scope exit. For req:profiles:list that's N round-trips
+    // through internal heap per request, contributing to the fragmentation
+    // PR #710 set out to address. ESP32-S3 boards have 8 MB PSRAM otherwise idle.
+    JsonDocument doc(&psramAllocator);
     DeserializationError err = deserializeJson(doc, file);
     file.close();
     if (err)

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -1,6 +1,5 @@
 #include "ProfileManager.h"
 #include <ArduinoJson.h>
-#include <display/util/PsramAllocator.h>
 
 #include <utility>
 
@@ -152,12 +151,7 @@ bool ProfileManager::loadProfile(const String &uuid, Profile &outProfile) {
     if (!file)
         return false;
 
-    // Back the temp JsonDocument with PSRAM. Without this every loadProfile
-    // call allocates a fresh ~6-12 KB node pool from internal heap and
-    // releases it on scope exit. For req:profiles:list that's N round-trips
-    // through internal heap per request, contributing to the fragmentation
-    // PR #710 set out to address. ESP32-S3 boards have 8 MB PSRAM otherwise idle.
-    JsonDocument doc(&psramAllocator);
+    JsonDocument doc;
     DeserializationError err = deserializeJson(doc, file);
     file.close();
     if (err)

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -176,7 +176,29 @@ void WebUIPlugin::loop() {
             }
         }
 
-        ws.textAll(statusDoc.as<String>());
+        // Per-client backpressure: skip clients whose send queue is already
+        // backed up so that 500 ms status ticks don't pile up behind a
+        // larger in-flight response (e.g. /profiles list build) and
+        // overflow the per-client message queue. PR #710 documented this
+        // guard in its description but the actual implementation never
+        // landed — only `setCloseClientOnQueueFull(false)` did, which
+        // prevented the close-on-overflow disconnect but didn't avoid the
+        // overflow drops. This is the missing half.
+        constexpr size_t STATUS_BACKLOG_LIMIT = 8;
+        const String payload = statusDoc.as<String>();
+        for (auto &client : ws.getClients()) {
+            if (client.status() != WS_CONNECTED) {
+                continue;
+            }
+            if (client.queueLen() >= STATUS_BACKLOG_LIMIT) {
+                // Client is slow or stuck behind an in-flight large
+                // response. Skip this tick; the next one is only 500 ms
+                // away and the dashboard will catch up once the backlog
+                // drains.
+                continue;
+            }
+            client.text(payload);
+        }
     }
     if (now > lastCleanup + CLEANUP_PERIOD) {
         lastCleanup = now;
@@ -361,16 +383,26 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
                     resp["msg"] = "Rebuild started";
                     size_t bufferSize = measureJson(resp);
                     auto *buffer = ws.makeBuffer(bufferSize);
-                    serializeJson(resp, buffer->get(), bufferSize);
-                    client->text(buffer);
+                    if (buffer != nullptr) {
+                        serializeJson(resp, buffer->get(), bufferSize);
+                        client->text(buffer);
+                    } else {
+                        ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for res:history:rebuild — client %u will see no response",
+                                 (unsigned)bufferSize, cid);
+                    }
                     ShotHistory.startAsyncRebuild();
                 } else if (msgType.startsWith("req:history")) {
                     JsonDocument resp(&psramAllocator);
                     ShotHistory.handleRequest(doc, resp);
                     size_t bufferSize = measureJson(resp);
                     auto *buffer = ws.makeBuffer(bufferSize);
-                    serializeJson(resp, buffer->get(), bufferSize);
-                    client->text(buffer);
+                    if (buffer != nullptr) {
+                        serializeJson(resp, buffer->get(), bufferSize);
+                        client->text(buffer);
+                    } else {
+                        ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for %s — client %u will see no response",
+                                 (unsigned)bufferSize, msgType.c_str(), cid);
+                    }
                 } else if (msgType == "req:flush:start") {
                     handleFlushStart(client->id(), doc);
                 }
@@ -491,8 +523,20 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
 
     size_t bufferSize = measureJson(response);
     auto *buffer = ws.makeBuffer(bufferSize);
-    serializeJson(response, buffer->get(), bufferSize);
-    ws.text(clientId, buffer);
+    if (buffer != nullptr) {
+        serializeJson(response, buffer->get(), bufferSize);
+        ws.text(clientId, buffer);
+    } else {
+        // makeBuffer allocates from internal heap (AsyncWebSocketMessageBuffer
+        // is not PSRAM-aware). After several minutes of uptime the 500 ms
+        // status broadcast tends to fragment the ~300 KB internal heap; a
+        // 25-50 KB list response can then fail to allocate even when total
+        // free heap looks healthy. Without this guard the next line would
+        // null-deref. Log + drop the response — the client times out and the
+        // page surfaces the failure rather than hanging forever.
+        ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for %s — client %u will see no response",
+                 (unsigned)bufferSize, type.c_str(), clientId);
+    }
 }
 
 void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -86,11 +86,14 @@ void WebUIPlugin::loop() {
         return;
     }
     const long now = millis();
-    if ((lastUpdateCheck == 0 || now > lastUpdateCheck + UPDATE_CHECK_INTERVAL)) {
-        ota->checkForUpdates();
-        pluginManager->trigger("ota:update:status", "value", ota->isUpdateAvailable());
+    if ((lastUpdateCheck == 0 || now > lastUpdateCheck + UPDATE_CHECK_INTERVAL) && !otaCheckInProgress) {
         lastUpdateCheck = now;
-        updateOTAStatus(ota->getCurrentVersion());
+        otaCheckInProgress = true;
+        // Dedicated task — checkForUpdates() does HTTPS to github.com and
+        // blocks until the response or the HTTPClient timeout. On a flaky
+        // network that's a 30+ s stall, which prior to this fix blocked
+        // the WS status broadcast and made the dashboard appear dead.
+        xTaskCreate(otaCheckTask, "WebUI::otaCheck", 8192, this, 1, nullptr);
     }
     if (now > lastStatus + STATUS_PERIOD && !ws.getClients().empty()) {
         lastStatus = now;
@@ -538,6 +541,17 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
         ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for %s — client %u will see no response",
                  (unsigned)bufferSize, type.c_str(), clientId);
     }
+}
+
+void WebUIPlugin::otaCheckTask(void *arg) {
+    auto *plugin = static_cast<WebUIPlugin *>(arg);
+    plugin->ota->checkForUpdates();
+    // Listeners just toggle a couple of int flags (rerender,
+    // updateAvailable) — racy but benign on word-sized writes.
+    plugin->pluginManager->trigger("ota:update:status", "value", plugin->ota->isUpdateAvailable());
+    plugin->updateOTAStatus(plugin->ota->getCurrentVersion());
+    plugin->otaCheckInProgress = false;
+    vTaskDelete(nullptr);
 }
 
 void WebUIPlugin::profileListWorkerTask(void *arg) {

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -66,6 +66,12 @@ void WebUIPlugin::setup(Controller *_controller, PluginManager *_pluginManager) 
     pluginManager->on("controller:volumetric-measurement:bluetooth:change",
                       [this](Event const &event) { this->currentBluetoothWeight = event.getFloat("value"); });
 
+    // Spin up the profile-list worker. Pinned to core 0 so it doesn't
+    // contend with AsyncTCP (core 1) or the Arduino loop. Priority 1 so
+    // the BLE/Controller work on core 0 stays responsive.
+    profileListQueue = xQueueCreate(4, sizeof(ProfileListJob *));
+    xTaskCreatePinnedToCore(profileListWorkerTask, "WebUI::profileList", 6144, this, 1, &profileListTaskHandle, 0);
+
     setupServer();
 }
 
@@ -445,35 +451,30 @@ void WebUIPlugin::handleAutotuneStart(uint32_t clientId, JsonDocument &request) 
 }
 
 void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request) {
+    auto type = request["tp"].as<String>();
+    ESP_LOGI("WebUIPlugin", "Handling request: %s", type.c_str());
+
+    // List requests get dispatched to the worker task — they're the only
+    // long-running operation in this handler and historically tripped the
+    // AsyncTCP watchdog (~75 s of synchronous SPIFFS reads with 50+
+    // profiles). All other types are single-profile or metadata-only and
+    // complete in well under the watchdog threshold, so they stay inline.
+    if (type == "req:profiles:list") {
+        auto *job = new ProfileListJob{clientId, request["rid"].as<String>(), request["minimal"].as<bool>()};
+        if (profileListQueue == nullptr || xQueueSend(profileListQueue, &job, 0) != pdTRUE) {
+            ESP_LOGW("WebUIPlugin", "profile-list queue full or unavailable, dropping request from client %u", clientId);
+            delete job;
+        }
+        return;
+    }
+
     // Allocate the response node pool from PSRAM — list responses can be tens
     // of KB and would otherwise fragment the ~300 KB internal heap.
     JsonDocument response(&psramAllocator);
-    auto type = request["tp"].as<String>();
-    ESP_LOGI("WebUIPlugin", "Handling request: %s", type.c_str());
     response["tp"] = String("res:") + type.substring(4);
     response["rid"] = request["rid"].as<String>();
 
-    if (type == "req:profiles:list") {
-        auto arr = response["profiles"].to<JsonArray>();
-        for (auto const &id : profileManager->listProfiles()) {
-            Profile profile{};
-            // Skip entries whose JSON couldn't be opened or failed validation
-            // (parseProfile returns false for missing label/type/phases). Without
-            // this, corrupt or partial profile files surface as blank cards in
-            // the UI — the user reported "blank Simple cards" originating here.
-            if (!profileManager->loadProfile(id, profile)) {
-                ESP_LOGW("WebUIPlugin", "Skipping unreadable profile %s in list response", id.c_str());
-                continue;
-            }
-            auto p = arr.add<JsonObject>();
-            if (request["minimal"].as<bool>()) {
-                p["id"] = profile.id;
-                p["label"] = profile.label;
-            } else {
-                writeProfile(p, profile);
-            }
-        }
-    } else if (type == "req:profiles:load") {
+    if (type == "req:profiles:load") {
         auto id = request["id"].as<String>();
         Profile profile;
         if (profileManager->loadProfile(id, profile)) {
@@ -536,6 +537,53 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
         // page surfaces the failure rather than hanging forever.
         ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for %s — client %u will see no response",
                  (unsigned)bufferSize, type.c_str(), clientId);
+    }
+}
+
+void WebUIPlugin::profileListWorkerTask(void *arg) {
+    auto *plugin = static_cast<WebUIPlugin *>(arg);
+    ProfileListJob *job = nullptr;
+    while (true) {
+        if (xQueueReceive(plugin->profileListQueue, &job, portMAX_DELAY) == pdTRUE && job != nullptr) {
+            plugin->buildAndSendProfileList(*job);
+            delete job;
+            job = nullptr;
+        }
+    }
+}
+
+void WebUIPlugin::buildAndSendProfileList(const ProfileListJob &job) {
+    JsonDocument response(&psramAllocator);
+    response["tp"] = "res:profiles:list";
+    response["rid"] = job.rid;
+    auto arr = response["profiles"].to<JsonArray>();
+    for (auto const &id : profileManager->listProfiles()) {
+        // Yield between SPIFFS reads. We're not in AsyncTCP context any
+        // more, but the SPIFFS mutex is still shared with the static-file
+        // handler and other tasks — yielding lets them interleave.
+        vTaskDelay(1);
+        Profile profile{};
+        if (!profileManager->loadProfile(id, profile)) {
+            ESP_LOGW("WebUIPlugin", "Skipping unreadable profile %s in list response", id.c_str());
+            continue;
+        }
+        auto p = arr.add<JsonObject>();
+        if (job.minimal) {
+            p["id"] = profile.id;
+            p["label"] = profile.label;
+        } else {
+            writeProfile(p, profile);
+        }
+    }
+
+    size_t bufferSize = measureJson(response);
+    auto *buffer = ws.makeBuffer(bufferSize);
+    if (buffer != nullptr) {
+        serializeJson(response, buffer->get(), bufferSize);
+        ws.text(job.clientId, buffer);
+    } else {
+        ESP_LOGE("WebUIPlugin", "makeBuffer(%u) returned null for res:profiles:list — client %u will see no response",
+                 (unsigned)bufferSize, job.clientId);
     }
 }
 

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -185,29 +185,7 @@ void WebUIPlugin::loop() {
             }
         }
 
-        // Per-client backpressure: skip clients whose send queue is already
-        // backed up so that 500 ms status ticks don't pile up behind a
-        // larger in-flight response (e.g. /profiles list build) and
-        // overflow the per-client message queue. PR #710 documented this
-        // guard in its description but the actual implementation never
-        // landed — only `setCloseClientOnQueueFull(false)` did, which
-        // prevented the close-on-overflow disconnect but didn't avoid the
-        // overflow drops. This is the missing half.
-        constexpr size_t STATUS_BACKLOG_LIMIT = 8;
-        const String payload = statusDoc.as<String>();
-        for (auto &client : ws.getClients()) {
-            if (client.status() != WS_CONNECTED) {
-                continue;
-            }
-            if (client.queueLen() >= STATUS_BACKLOG_LIMIT) {
-                // Client is slow or stuck behind an in-flight large
-                // response. Skip this tick; the next one is only 500 ms
-                // away and the dashboard will catch up once the backlog
-                // drains.
-                continue;
-            }
-            client.text(payload);
-        }
+        ws.textAll(statusDoc.as<String>());
     }
     if (now > lastCleanup + CLEANUP_PERIOD) {
         lastCleanup = now;

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -58,6 +58,14 @@ class WebUIPlugin : public Plugin {
     static void profileListWorkerTask(void *arg);
     void buildAndSendProfileList(const ProfileListJob &job);
 
+    // OTA check needs to be off the main loop. On a flaky network DNS
+    // failure or SSL handshake stall can hold HTTPClient for tens of
+    // seconds — long enough to starve the 500 ms status broadcast and
+    // make the dashboard look frozen. One-shot task per check; the
+    // `otaCheckInProgress` flag prevents overlapping spawns.
+    volatile bool otaCheckInProgress = false;
+    static void otaCheckTask(void *arg);
+
     // HTTP handlers
     void handleSettings(AsyncWebServerRequest *request) const;
     void handleBLEScaleList(AsyncWebServerRequest *request);

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -41,6 +41,23 @@ class WebUIPlugin : public Plugin {
     void handleProfileRequest(uint32_t clientId, JsonDocument &request);
     void handleFlushStart(uint32_t clientId, JsonDocument &request);
 
+    // Profile-list worker: building the response involves N SPIFFS opens +
+    // ArduinoJson parses (50+ profiles → 5+ s of work). Running that inside
+    // the AsyncTCP WS_EVT_DATA callback starves the AsyncTCP task long
+    // enough to trip the task watchdog, which reboots the device. We
+    // dispatch the build to a dedicated low-priority task on core 0 and
+    // send the response via ws.text() from that task — AsyncWebSocket's
+    // send methods are queue-safe across tasks.
+    struct ProfileListJob {
+        uint32_t clientId;
+        String rid;
+        bool minimal;
+    };
+    QueueHandle_t profileListQueue = nullptr;
+    TaskHandle_t profileListTaskHandle = nullptr;
+    static void profileListWorkerTask(void *arg);
+    void buildAndSendProfileList(const ProfileListJob &job);
+
     // HTTP handlers
     void handleSettings(AsyncWebServerRequest *request) const;
     void handleBLEScaleList(AsyncWebServerRequest *request);

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -387,12 +387,44 @@ void DefaultUI::onProfileFavorited(const String &id) {
     if (std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id) != favoritedProfileIds.end()) {
         return; // already cached
     }
-    // Append an empty placeholder. The Profile data is loaded lazily when
-    // the user navigates the carousel to this entry. Avoids a SPIFFS read
-    // on the event-firing task (usually AsyncTCP) for an entry the user
-    // may never look at.
-    favoritedProfileIds.emplace_back(id);
-    favoritedProfiles.emplace_back(Profile{});
+    // Insert the new favorite at its canonical carousel position rather than
+    // the tail. getFavoritedProfiles() returns IDs sorted by profileOrder and
+    // already includes this id (addFavoritedProfile updates settings before
+    // firing the event). The carousel is [selected, ...favorites-in-that-order],
+    // so map the id's position in the sorted list to a carousel index,
+    // discounting the selected entry pinned at index 0. The Profile struct
+    // itself stays a lazy placeholder, loaded on demand when the carousel
+    // reaches it — no SPIFFS read on the event-firing task. Appending at the
+    // tail (the previous behavior) made a newly-favorited profile jump to the
+    // end of the carousel instead of slotting into its configured order.
+    const auto sorted = profileManager->getFavoritedProfiles();
+    size_t insertAt = favoritedProfileIds.size(); // fallback: tail
+    int sortedPos = -1;
+    for (int i = 0; i < static_cast<int>(sorted.size()); i++)
+        if (sorted[i] == id) {
+            sortedPos = i;
+            break;
+        }
+    if (sortedPos >= 0) {
+        // Index 0 is the pinned selected profile; the favorites that follow
+        // mirror `sorted` minus that selected entry, so discount it when it
+        // sorts ahead of the new id.
+        const String &selectedId = favoritedProfileIds.front();
+        int selectedBefore = 0;
+        for (int i = 0; i < sortedPos; i++)
+            if (sorted[i] == selectedId) {
+                selectedBefore = 1;
+                break;
+            }
+        insertAt = static_cast<size_t>(1 + sortedPos - selectedBefore);
+        if (insertAt > favoritedProfileIds.size())
+            insertAt = favoritedProfileIds.size();
+    }
+    favoritedProfileIds.insert(favoritedProfileIds.begin() + insertAt, id);
+    favoritedProfiles.insert(favoritedProfiles.begin() + insertAt, Profile{});
+    // Keep the cursor on the same profile if we inserted at or before it.
+    if (static_cast<int>(insertAt) <= currentProfileIdx)
+        currentProfileIdx++;
 }
 
 void DefaultUI::onProfileUnfavorited(const String &id) {

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -1,6 +1,7 @@
 #include "DefaultUI.h"
 
 #include <WiFi.h>
+#include <cstdlib>
 #include <display/core/Controller.h>
 #include <display/core/process/BrewProcess.h>
 #include <display/core/process/Process.h>
@@ -206,12 +207,12 @@ void DefaultUI::init() {
         targetDuration = profileManager->getSelectedProfile().getTotalDuration();
         targetVolume = profileManager->getSelectedProfile().getTotalVolume();
         profileVolumetric = profileManager->getSelectedProfile().isVolumetric();
-        reloadProfiles();
+        onProfileSelected(selectedProfileId);
         rerender = true;
     });
-    pluginManager->on("profiles:profile:favorite", [this](Event const &event) { reloadProfiles(); });
-    pluginManager->on("profiles:profile:unfavorite", [this](Event const &event) { reloadProfiles(); });
-    pluginManager->on("profiles:profile:save", [this](Event const &event) { reloadProfiles(); });
+    pluginManager->on("profiles:profile:favorite", [this](Event const &event) { onProfileFavorited(event.getString("id")); });
+    pluginManager->on("profiles:profile:unfavorite", [this](Event const &event) { onProfileUnfavorited(event.getString("id")); });
+    pluginManager->on("profiles:profile:save", [this](Event const &event) { onProfileSaved(event.getString("id")); });
     pluginManager->on("controller:volumetric-measurement:bluetooth:change", [=](Event const &event) {
         double newWeight = event.getFloat("value");
         if (round(newWeight * 10.0) != round(bluetoothWeight * 10.0)) {
@@ -272,6 +273,13 @@ void DefaultUI::loop() {
 
 void DefaultUI::loopProfiles() {
     if (!profileLoaded) {
+        // Cold-start: build the full ID list (cheap — just Strings) but
+        // defer loading the Profile structs themselves. With 50+ favorited
+        // profiles a synchronous scan here would put 100 KB+ on the
+        // internal heap, starving the WiFi/BLE coexistence allocator that
+        // setupBluetooth needs after WiFi connect — coex_enable aborts and
+        // the device boot-loops. Lazy-load keeps only ~3 profile structs
+        // populated at a time, regardless of how many are favorited.
         const auto favoritedIds = profileManager->getFavoritedProfiles();
         favoritedProfileIds.clear();
         favoritedProfiles.clear();
@@ -281,13 +289,156 @@ void DefaultUI::loopProfiles() {
             if (std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id) == favoritedProfileIds.end())
                 favoritedProfileIds.emplace_back(id);
         }
-        favoritedProfiles.reserve(favoritedProfileIds.size());
-        for (const auto &profileId : favoritedProfileIds) {
-            Profile profile{};
-            profileManager->loadProfile(profileId, profile);
-            favoritedProfiles.emplace_back(std::move(profile));
-        }
+        // Empty placeholders — populated on demand via ensureProfileLoaded.
+        favoritedProfiles.resize(favoritedProfileIds.size());
         profileLoaded = 1;
+    }
+    // Maintain the warm window around the currently-displayed index every
+    // 25 ms tick. Sync loads in onNextProfile / onPreviousProfile cover the
+    // common interactive case; this handles any drift (e.g. an incremental
+    // mutator inserting an entry).
+    ensureProfileLoaded(currentProfileIdx);
+    for (int d = 1; d <= PROFILE_CACHE_RADIUS; d++) {
+        ensureProfileLoaded(currentProfileIdx - d);
+        ensureProfileLoaded(currentProfileIdx + d);
+    }
+    evictProfilesOutsideWindow(currentProfileIdx, PROFILE_CACHE_RADIUS);
+}
+
+void DefaultUI::ensureProfileLoaded(int idx) {
+    if (idx < 0 || idx >= static_cast<int>(favoritedProfileIds.size())) return;
+    if (idx >= static_cast<int>(favoritedProfiles.size())) return;
+    // "Already loaded" check: the parsed Profile always has a non-empty
+    // `id` populated by parseProfile. Default-constructed slots have empty
+    // id. This lets us distinguish "filled" from "empty placeholder"
+    // without a parallel bit-vector.
+    if (!favoritedProfiles[idx].id.isEmpty()) return;
+    Profile p{};
+    if (profileManager->loadProfile(favoritedProfileIds[idx], p)) {
+        favoritedProfiles[idx] = std::move(p);
+    }
+}
+
+void DefaultUI::evictProfilesOutsideWindow(int center, int radius) {
+    for (int i = 0; i < static_cast<int>(favoritedProfiles.size()); i++) {
+        if (std::abs(i - center) > radius && !favoritedProfiles[i].id.isEmpty()) {
+            // Assigning a default-constructed Profile triggers the previous
+            // entry's destructor, freeing its String / phases / etc heap.
+            favoritedProfiles[i] = Profile{};
+        }
+    }
+}
+
+// Each of the four incremental mutators touches only the affected cache
+// entry. They are invoked from the `profiles:profile:*` event handlers
+// installed in init() and replace what used to be a blanket
+// reloadProfiles() that invalidated the entire cache (forcing the
+// profileLoopTask to re-read every favorited profile from SPIFFS on its
+// next tick). With many favorites that full reload was 1.5-4 s of
+// contention per change; these are O(1) per change.
+//
+// If the cache hasn't completed its initial cold-start build yet, we
+// defer to reloadProfiles() so the cold-start path picks up the latest
+// settings state. After cold-start completes (profileLoaded=1) these
+// methods are the only path that mutates favoritedProfileIds /
+// favoritedProfiles.
+
+void DefaultUI::onProfileSelected(const String &id) {
+    if (!profileLoaded || id.isEmpty()) {
+        reloadProfiles();
+        return;
+    }
+    auto it = std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id);
+    if (it == favoritedProfileIds.end()) {
+        // Selected profile is not yet in the favorited cache (rare —
+        // selecting a non-favorited profile via the API). Load and
+        // prepend so it occupies the canonical "selected at index 0" slot.
+        Profile p{};
+        if (profileManager->loadProfile(id, p)) {
+            favoritedProfileIds.insert(favoritedProfileIds.begin(), id);
+            favoritedProfiles.insert(favoritedProfiles.begin(), std::move(p));
+        }
+    } else if (it != favoritedProfileIds.begin()) {
+        // Already cached but not at the front. Move both vectors so the
+        // selected entry occupies index 0, preserving relative order of
+        // the rest.
+        const size_t idx = std::distance(favoritedProfileIds.begin(), it);
+        if (idx < favoritedProfiles.size()) {
+            Profile movedProfile = std::move(favoritedProfiles[idx]);
+            favoritedProfiles.erase(favoritedProfiles.begin() + idx);
+            favoritedProfiles.insert(favoritedProfiles.begin(), std::move(movedProfile));
+        }
+        const String movedId = *it;
+        favoritedProfileIds.erase(it);
+        favoritedProfileIds.insert(favoritedProfileIds.begin(), movedId);
+    }
+    currentProfileIdx = 0;
+    // The slot may have been a lazy placeholder before the move; populate
+    // it (and the prefetch neighbor) so the ProfileScreen renders cleanly.
+    ensureProfileLoaded(0);
+    ensureProfileLoaded(1);
+}
+
+void DefaultUI::onProfileFavorited(const String &id) {
+    if (!profileLoaded || id.isEmpty()) {
+        reloadProfiles();
+        return;
+    }
+    if (std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id) != favoritedProfileIds.end()) {
+        return; // already cached
+    }
+    // Append an empty placeholder. The Profile data is loaded lazily when
+    // the user navigates the carousel to this entry. Avoids a SPIFFS read
+    // on the event-firing task (usually AsyncTCP) for an entry the user
+    // may never look at.
+    favoritedProfileIds.emplace_back(id);
+    favoritedProfiles.emplace_back(Profile{});
+}
+
+void DefaultUI::onProfileUnfavorited(const String &id) {
+    if (!profileLoaded || id.isEmpty()) {
+        reloadProfiles();
+        return;
+    }
+    auto it = std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id);
+    if (it == favoritedProfileIds.end()) {
+        return;
+    }
+    const size_t idx = std::distance(favoritedProfileIds.begin(), it);
+    favoritedProfileIds.erase(it);
+    if (idx < favoritedProfiles.size()) {
+        favoritedProfiles.erase(favoritedProfiles.begin() + idx);
+    }
+    // Clamp the rendered index so we don't paint past the end if the
+    // just-removed entry was at or before currentProfileIdx.
+    if (!favoritedProfiles.empty() && currentProfileIdx >= static_cast<int>(favoritedProfiles.size())) {
+        currentProfileIdx = static_cast<int>(favoritedProfiles.size()) - 1;
+    }
+}
+
+void DefaultUI::onProfileSaved(const String &id) {
+    if (!profileLoaded || id.isEmpty()) {
+        reloadProfiles();
+        return;
+    }
+    auto it = std::find(favoritedProfileIds.begin(), favoritedProfileIds.end(), id);
+    if (it == favoritedProfileIds.end()) {
+        return; // saved profile isn't in the favorited cache, no display update needed
+    }
+    const size_t idx = std::distance(favoritedProfileIds.begin(), it);
+    if (idx >= favoritedProfiles.size()) {
+        return;
+    }
+    // Only re-read if the slot was already populated — lazy slots will
+    // load fresh from disk next time the carousel visits them anyway, and
+    // we want to avoid SPIFFS reads on the event-firing task for entries
+    // outside the warm window.
+    if (favoritedProfiles[idx].id.isEmpty()) {
+        return;
+    }
+    Profile p{};
+    if (profileManager->loadProfile(id, p)) {
+        favoritedProfiles[idx] = std::move(p);
     }
 }
 
@@ -311,8 +462,14 @@ void DefaultUI::onProfileSwitch() {
 }
 
 void DefaultUI::onNextProfile() {
-    if (currentProfileIdx < favoritedProfileIds.size() - 1) {
+    if (currentProfileIdx < static_cast<int>(favoritedProfileIds.size()) - 1) {
         currentProfileIdx++;
+        // Synchronously load the new current + prefetch the next so the
+        // ProfileScreen LVGL effect sees populated data on its very next
+        // frame. The 25 ms loopProfiles tick is too slow if the user
+        // swipes quickly — would paint an empty label briefly.
+        ensureProfileLoaded(currentProfileIdx);
+        ensureProfileLoaded(currentProfileIdx + 1);
     }
     rerender = true;
 }
@@ -320,6 +477,8 @@ void DefaultUI::onNextProfile() {
 void DefaultUI::onPreviousProfile() {
     if (currentProfileIdx > 0) {
         currentProfileIdx--;
+        ensureProfileLoaded(currentProfileIdx);
+        ensureProfileLoaded(currentProfileIdx - 1);
     }
     rerender = true;
 }

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -380,7 +380,10 @@ void DefaultUI::onProfileSelected(const String &id) {
 }
 
 void DefaultUI::onProfileFavorited(const String &id) {
-    if (!profileLoaded || id.isEmpty()) {
+    // favoritedProfileIds.empty() guards front() below: onProfileUnfavorited can
+    // erase the last entry, and a favorite event arriving on an empty cache would
+    // otherwise deref front() on an empty vector. Defer to the cold-start rebuild.
+    if (!profileLoaded || id.isEmpty() || favoritedProfileIds.empty()) {
         reloadProfiles();
         return;
     }

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -132,6 +132,30 @@ class DefaultUI {
     int profileLoaded = 0;
     std::vector<String> favoritedProfileIds;
     std::vector<Profile> favoritedProfiles;
+
+    // Incremental cache mutations. Used by the four `profiles:profile:*`
+    // event handlers to avoid re-reading every favorited profile from
+    // SPIFFS on each profile change. Previously every select/favorite/
+    // unfavorite/save called reloadProfiles() which set profileLoaded=0
+    // and the profileLoopTask then re-read ALL favorited profiles — O(N)
+    // SPIFFS opens per change. With many favorites (e.g. 50+ after a
+    // bulk import) that is 1.5-4 seconds of contention per change.
+    // These methods touch only the affected entry.
+    void onProfileSelected(const String &id);
+    void onProfileFavorited(const String &id);
+    void onProfileUnfavorited(const String &id);
+    void onProfileSaved(const String &id);
+
+    // Lazy-load helpers. `favoritedProfiles` is a parallel vector to
+    // `favoritedProfileIds`, but only entries within a small window around
+    // `currentProfileIdx` are populated — others stay default-constructed
+    // (no String/vector heap allocations). Caps internal-heap usage at
+    // ~3 × sizeof(Profile-with-phases) regardless of favorite count.
+    // The 50+-profile import that previously starved the WiFi/BLE coex
+    // allocator at boot now fits comfortably.
+    static constexpr int PROFILE_CACHE_RADIUS = 1;
+    void ensureProfileLoaded(int idx);
+    void evictProfilesOutsideWindow(int center, int radius);
     int currentThemeMode = -1; // Force applyTheme on first loop
 
     // Screen change

--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -605,7 +605,7 @@ export function ProfileList() {
       setProfiles(list);
     } catch (err) {
       console.error('Failed to load profiles:', err);
-      setLoadError(err && err.message ? err.message : 'Request failed');
+      setLoadError(err?.message || 'Request failed');
       setProfiles([]);
     } finally {
       setLoading(false);

--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -595,10 +595,21 @@ export function ProfileList() {
     }
   }, [hasUtilityProfiles]);
 
+  const [loadError, setLoadError] = useState(null);
+
   const loadProfiles = async () => {
-    const response = await apiService.request({ tp: 'req:profiles:list' });
-    setProfiles(response.profiles);
-    setLoading(false);
+    setLoadError(null);
+    try {
+      const response = await apiService.request({ tp: 'req:profiles:list' });
+      const list = Array.isArray(response?.profiles) ? response.profiles : [];
+      setProfiles(list);
+    } catch (err) {
+      console.error('Failed to load profiles:', err);
+      setLoadError(err && err.message ? err.message : 'Request failed');
+      setProfiles([]);
+    } finally {
+      setLoading(false);
+    }
   };
 
   // Placeholder for future persistence of order (intentionally empty)
@@ -933,6 +944,25 @@ export function ProfileList() {
       <div className='mb-4 flex flex-row items-center gap-2'>
         <h1 className='flex-grow text-2xl font-bold sm:text-3xl'>Profiles</h1>
       </div>
+
+      {loadError && (
+        <div role='alert' className='alert alert-error mb-4'>
+          <div className='flex-1'>
+            <span className='font-semibold'>Failed to load profiles.</span>{' '}
+            <span className='opacity-80'>{loadError}</span>
+          </div>
+          <button
+            type='button'
+            className='btn btn-sm'
+            onClick={async () => {
+              setLoading(true);
+              await loadProfiles();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       <div className='mb-4 flex flex-col items-center gap-2 sm:flex-row'>
         {/* Controls Row */}


### PR DESCRIPTION
## What & why

**Severity: high.** Once the favorited library is large — which happens fast,
since every profile is auto-favorited on import — both the `/profiles` page and
the on-device carousel become unreliable. Several failure modes converge around
30+ profiles: a `coex_enable` boot-loop, an `async_tcp` watchdog reboot when
`/profiles` loads, a long dashboard freeze during the periodic OTA check on
flaky networks, laggy selects after bulk saves, and a spinner-forever state on a
transient WS allocation failure. This PR scales both paths and addresses each.

### Firmware

- **Lazy-load the on-device carousel** (`DefaultUI`). Cold-start builds the
  favorited-ID list (cheap strings) but defers loading the `Profile` structs;
  only a small window around the displayed entry is resident at any time.
  Loading every favorited profile synchronously put 100 KB+ on the internal
  heap, starving the Wi-Fi/BLE coexistence allocator during Bluetooth bring-up
  (`coex_enable` aborts → boot loop). Lazy-load bounds the resident set
  regardless of library size.

- **O(1) incremental cache mutators** for select / favorite / unfavorite / save,
  replacing a blanket invalidation that re-read *every* favorited profile from
  SPIFFS on the profile-loop task after each change.

- **Newly-favorited profiles keep their configured order.** `onProfileFavorited`
  inserts at the carousel index derived from `getFavoritedProfiles()` (already
  `profileOrder`-sorted), discounting the selected entry pinned at index 0,
  instead of appending at the tail — so favoriting no longer reorders the
  carousel. (Addresses review feedback.)

- **Offload `req:profiles:list` to a dedicated worker task** (`WebUIPlugin`).
  Building a large list on the AsyncTCP task stalled the WebSocket and tripped
  the `async_tcp` task watchdog; it now runs on its own FreeRTOS task fed by a
  queue, so AsyncTCP returns immediately.

- **Null-check `ws.makeBuffer()`** at all four call sites — the buffer allocates
  from internal heap and can fail under fragmentation; results were previously
  dereferenced unconditionally.

- **Run the OTA update check on a one-shot task** so a slow HTTPS check can't
  block the main loop and stall the status broadcast.

### Web

- **`/profiles` load-error handling.** The list request is wrapped in try/catch;
  on failure the page shows an error alert with a Retry button instead of a
  permanent spinner, and non-array responses are handled defensively.

### Test plan

- [x] Boots cleanly on current `master` with a large auto-favorited library — no
      `coex_enable` abort; Wi-Fi, controller link (protocol match), and webserver
      all come up
- [x] Newly-favorited profile lands at its `profileOrder` slot in the carousel,
      not the tail
- [x] `/profiles` loads without an infinite spinner; a timeout / non-2xx surfaces
      the Retry banner
- [x] `req:profiles:list` build runs off the AsyncTCP task (worker queue) — no
      `async_tcp` watchdog reboot
- [x] Dashboard stays responsive while a background OTA check is slow
- [x] Rapid select / favorite / unfavorite is snappy (no O(N) SPIFFS reload per
      event)

### Notes
- The `ProfileManager::loadProfile` PSRAM-backing an earlier revision carried is
  dropped — #723 lands the same change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Profile list and OTA checking now run off the main thread/task, improving responsiveness.
  * Profile cache switched to lazy loading with a bounded in-memory window for reduced memory use.

* **Improvements**
  * Added error messaging and a retry button when profile list loading fails.
  * WebSocket responses are now hardened to avoid crashes when message buffers cannot be allocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->