### PR TITLE
fix(firmware): mDNS responder reconnect leak — restore `.local` resolution

### DIFF
--- a/src/display/plugins/mDNSPlugin.cpp
+++ b/src/display/plugins/mDNSPlugin.cpp
@@ -11,12 +11,27 @@ static constexpr char LOG_TAG[] = "mDNSPlugin";
 void mDNSPlugin::setup(Controller *controller, PluginManager *pluginManager) {
     this->controller = controller;
     pluginManager->on("controller:wifi:connect", [this](Event const &event) { start(event); });
+    pluginManager->on("controller:wifi:disconnect", [this](Event const &) { stop(); });
 }
-void mDNSPlugin::start(Event const &event) const {
+
+void mDNSPlugin::start(Event const &event) {
     const int apMode = event.getInt("AP");
     if (apMode)
         return;
-    if (!MDNS.begin(controller->getSettings().getMdnsName().c_str())) {
+
+    // Defensively tear down any prior responder before starting a new one.
+    // Without this, every WiFi reconnect leaks the previous mDNS records —
+    // the underlying ESPmDNS state ends up with stale entries and clients
+    // can no longer resolve `<hostname>.local` even though the device is
+    // back on the network and the IP is reachable directly. Pairs with the
+    // controller:wifi:disconnect handler installed in setup().
+    if (responderRunning) {
+        MDNS.end();
+        responderRunning = false;
+    }
+
+    const String hostname = controller->getSettings().getMdnsName();
+    if (!MDNS.begin(hostname.c_str())) {
         ESP_LOGE(LOG_TAG, "Error setting up mDNS responder");
         return;
     }
@@ -31,5 +46,14 @@ void mDNSPlugin::start(Event const &event) const {
     MDNS.addServiceTxt("gaggimate", "tcp", "version", BUILD_GIT_VERSION);
     MDNS.addServiceTxt("gaggimate", "tcp", "type", "espresso_machine");
 
-    ESP_LOGI(LOG_TAG, "mDNS responder started with service advertisement");
+    responderRunning = true;
+    ESP_LOGI(LOG_TAG, "mDNS responder started with service advertisement (hostname=%s)", hostname.c_str());
+}
+
+void mDNSPlugin::stop() {
+    if (!responderRunning)
+        return;
+    MDNS.end();
+    responderRunning = false;
+    ESP_LOGI(LOG_TAG, "mDNS responder stopped (wifi disconnected)");
 }

--- a/src/display/plugins/mDNSPlugin.h
+++ b/src/display/plugins/mDNSPlugin.h
@@ -10,9 +10,11 @@ class mDNSPlugin : public Plugin {
     void loop() override {};
 
   private:
-    void start(Event const &event) const;
+    void start(Event const &event);
+    void stop();
 
     Controller *controller = nullptr;
+    bool responderRunning = false;
 };
 
 #endif // MDNSPLUGIN_H


### PR DESCRIPTION
**Severity: medium / chronic.** Long-standing community symptom: the
device is reachable by IP but `<hostname>.local` stops resolving after
the first WiFi flake / router rekey. Matches Issue #241 and several
closed PRs that took partial approaches.

## Root cause

`mDNSPlugin::setup` registered only a `controller:wifi:connect` event
listener. The listener called `MDNS.begin(hostname)` and added
services. There was no matching `MDNS.end()` anywhere — including on
disconnect — so every WiFi reconnect added a fresh layer of mDNS
state on top of the stale one from the previous association. The
underlying ESPmDNS responder ends up unable to authoritatively answer
A-record queries for `<hostname>.local`, even though the IP stays
reachable directly.

## Fix

- New `controller:wifi:disconnect` listener that calls `MDNS.end()`
  to tear down the responder cleanly when WiFi drops.
- Defensive `MDNS.end()` at the start of `start()` that runs if a
  prior responder is still tracked as active — covers the edge case
  where the disconnect event didn't fire (e.g. AP-fallback recovery
  paths where `WiFi.onEvent` registrations are gated on
  `WL_CONNECTED` and the disconnect handler was never installed).
- New `responderRunning` latch so end/begin can't double-fire on
  back-to-back events.

The hostname value itself is unchanged — `settings.getMdnsName()`
stays the single source of truth, no implicit suffixing or rewriting.
What's in Settings is what gets advertised.

## Test plan

- [x] Boot device, resolve `<hostname>.local` from a same-subnet
      client — works.
- [x] Force a WiFi reconnect (router rekey or `WiFi.disconnect()` +
      reconnect from serial console). Confirm `MDNS.end()` log line
      fires on disconnect, fresh `MDNS.begin()` log fires on reconnect.
- [x] Resolve `<hostname>.local` again — works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The mDNS responder now properly stops and cleans up resources whenever WiFi connectivity is lost or interrupted.
  * Added defensive initialization procedures to ensure any previously running responders are completely shut down before attempting to start new instances.
  * Enhanced state management and validation to safely handle responder initialization and shutdown edge cases without errors.
  * Expanded diagnostic logging to provide better visibility into responder startup events and WiFi disconnection lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->