### PR TITLE
fix(firmware/web): /scales page reliability + UX surfacing for BLE scale lifecycle

### DIFF
--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -164,61 +164,62 @@ void BLEScalePlugin::update() {
         return;
 
     if (scale != nullptr) {
-        // Call scale update with error checking
-        scale->update();
-        if (!hasConnectedScale) {
-            reconnectionTries++;
-            if (reconnectionTries > RECONNECTION_TRIES) {
-                ESP_LOGW("BLEScalePlugin", "Max reconnection attempts reached, disconnecting");
-                // Surface the giving-up moment to the UI exactly once per
-                // disconnect cycle. The disconnect() call below will null
-                // out `scale`, so the next `update()` won't re-enter this
-                // branch — but if we're paranoid we latch anyway.
-                if (!disconnectEventFired && pluginManager != nullptr) {
-                    disconnectEventFired = true;
-                    pluginManager->trigger("scale:disconnect");
-                }
-                disconnect();
-                scan();
-            }
-        } else {
-            // Poll slow-changing metadata (battery, unit). Flow rate is
-            // emitted inline with each weight measurement, not polled here.
-            pollScaleMetadata();
-        }
+        pollConnectedScale(hasConnectedScale);
     } else if (!doConnect && controller->getSettings().getSavedScale() != "" && scanner != nullptr) {
-        // Saved-scale auto-reconnect path. Two guards before we look:
-        //   1. `!doConnect` — the user may have already requested a connect
-        //      to a DIFFERENT scale via the /scales web UI. If we don't
-        //      respect that, this loop silently overwrites their choice
-        //      (uuid + doConnect) on the next tick. User-initiated wins.
-        //   2. SAVED_SCALE_RETRY_BUDGET — if the saved scale never appears
-        //      (powered off, out of range), we'd otherwise hit this path
-        //      every 1 s forever, hammering the scanner and battery for
-        //      no benefit. After the budget is spent, stop until the next
-        //      manual scan / reboot resets `savedScaleRetries`.
-        if (savedScaleRetries < SAVED_SCALE_RETRY_BUDGET) {
-            auto discoveredScales = scanner->getDiscoveredScales();
-            const String savedAddr = controller->getSettings().getSavedScale();
-            bool foundInList = false;
-            for (const auto &d : discoveredScales) {
-                if (d.getAddress().toString() == savedAddr.c_str()) {
-                    ESP_LOGI("BLEScalePlugin", "Connecting to last known scale");
-                    connect(d.getAddress().toString());
-                    foundInList = true;
-                    savedScaleRetries = 0;
-                    break;
-                }
-            }
-            if (!foundInList) {
-                savedScaleRetries++;
-                if (savedScaleRetries == SAVED_SCALE_RETRY_BUDGET) {
-                    ESP_LOGW("BLEScalePlugin",
-                             "Saved scale %s not seen in %u attempts — giving up auto-reconnect until next manual scan",
-                             savedAddr.c_str(), SAVED_SCALE_RETRY_BUDGET);
-                }
-            }
+        tryAutoReconnectSaved();
+    }
+}
+
+void BLEScalePlugin::pollConnectedScale(bool hasConnectedScale) {
+    // Drive the connected scale forward and handle the reconnect-retry
+    // exhaustion path. Extracted from update() to keep that function under
+    // SonarQube's cognitive-complexity / nesting limits.
+    scale->update();
+    if (hasConnectedScale) {
+        // Poll slow-changing metadata (battery, unit). Flow rate is
+        // emitted inline with each weight measurement, not polled here.
+        pollScaleMetadata();
+        return;
+    }
+    reconnectionTries++;
+    if (reconnectionTries <= RECONNECTION_TRIES) {
+        return;
+    }
+    ESP_LOGW("BLEScalePlugin", "Max reconnection attempts reached, disconnecting");
+    // Surface the giving-up moment to the UI exactly once per disconnect
+    // cycle. The disconnect() call below nulls out `scale`, so the next
+    // `update()` won't re-enter this branch — latched anyway for safety.
+    if (!disconnectEventFired && pluginManager != nullptr) {
+        disconnectEventFired = true;
+        pluginManager->trigger("scale:disconnect");
+    }
+    disconnect();
+    scan();
+}
+
+void BLEScalePlugin::tryAutoReconnectSaved() {
+    // Saved-scale auto-reconnect path. The outer caller already gated on
+    // `!doConnect` (user-initiated connect wins) and `scanner != nullptr`
+    // / `savedScale` non-empty. Here we enforce the budget so we don't
+    // hammer the scanner forever when the saved scale is powered off.
+    if (savedScaleRetries >= SAVED_SCALE_RETRY_BUDGET) {
+        return;
+    }
+    auto discoveredScales = scanner->getDiscoveredScales();
+    const String savedAddr = controller->getSettings().getSavedScale();
+    for (const auto &d : discoveredScales) {
+        if (d.getAddress().toString() == savedAddr.c_str()) {
+            ESP_LOGI("BLEScalePlugin", "Connecting to last known scale");
+            connect(d.getAddress().toString());
+            savedScaleRetries = 0;
+            return;
         }
+    }
+    savedScaleRetries++;
+    if (savedScaleRetries == SAVED_SCALE_RETRY_BUDGET) {
+        ESP_LOGW("BLEScalePlugin",
+                 "Saved scale %s not seen in %u attempts — giving up auto-reconnect until next manual scan",
+                 savedAddr.c_str(), SAVED_SCALE_RETRY_BUDGET);
     }
 }
 

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -123,6 +123,19 @@ void BLEScalePlugin::loop() {
         establishConnection();
     }
     const unsigned long now = millis();
+    // Emit scan:complete exactly once when the time-boxed scan window
+    // closes, so the frontend can clear its spinner and distinguish
+    // "scan finished with no results" from "scan still running."
+    if (scanInProgress && static_cast<long>(now - scanDeadline) >= 0) {
+        scanInProgress = false;
+        int count = 0;
+        if (scanner != nullptr) {
+            count = static_cast<int>(scanner->getDiscoveredScales().size());
+        }
+        if (pluginManager != nullptr) {
+            pluginManager->trigger("scale:scan:complete", "count", count);
+        }
+    }
     if (now - lastUpdate > UPDATE_INTERVAL_MS) {
         lastUpdate = now;
         update();
@@ -157,24 +170,53 @@ void BLEScalePlugin::update() {
             reconnectionTries++;
             if (reconnectionTries > RECONNECTION_TRIES) {
                 ESP_LOGW("BLEScalePlugin", "Max reconnection attempts reached, disconnecting");
-                disconnect();
-                if (scanner != nullptr) {
-                    scanner->initializeAsyncScan();
+                // Surface the giving-up moment to the UI exactly once per
+                // disconnect cycle. The disconnect() call below will null
+                // out `scale`, so the next `update()` won't re-enter this
+                // branch — but if we're paranoid we latch anyway.
+                if (!disconnectEventFired && pluginManager != nullptr) {
+                    disconnectEventFired = true;
+                    pluginManager->trigger("scale:disconnect");
                 }
+                disconnect();
+                scan();
             }
         } else {
             // Poll slow-changing metadata (battery, unit). Flow rate is
             // emitted inline with each weight measurement, not polled here.
             pollScaleMetadata();
         }
-    } else if (controller->getSettings().getSavedScale() != "" && scanner != nullptr) {
-        // Protected scanner access with null checks
-        auto discoveredScales = scanner->getDiscoveredScales();
-        for (const auto &d : discoveredScales) {
-            if (d.getAddress().toString() == controller->getSettings().getSavedScale().c_str()) {
-                ESP_LOGI("BLEScalePlugin", "Connecting to last known scale");
-                connect(d.getAddress().toString());
-                break;
+    } else if (!doConnect && controller->getSettings().getSavedScale() != "" && scanner != nullptr) {
+        // Saved-scale auto-reconnect path. Two guards before we look:
+        //   1. `!doConnect` — the user may have already requested a connect
+        //      to a DIFFERENT scale via the /scales web UI. If we don't
+        //      respect that, this loop silently overwrites their choice
+        //      (uuid + doConnect) on the next tick. User-initiated wins.
+        //   2. SAVED_SCALE_RETRY_BUDGET — if the saved scale never appears
+        //      (powered off, out of range), we'd otherwise hit this path
+        //      every 1 s forever, hammering the scanner and battery for
+        //      no benefit. After the budget is spent, stop until the next
+        //      manual scan / reboot resets `savedScaleRetries`.
+        if (savedScaleRetries < SAVED_SCALE_RETRY_BUDGET) {
+            auto discoveredScales = scanner->getDiscoveredScales();
+            const String savedAddr = controller->getSettings().getSavedScale();
+            bool foundInList = false;
+            for (const auto &d : discoveredScales) {
+                if (d.getAddress().toString() == savedAddr.c_str()) {
+                    ESP_LOGI("BLEScalePlugin", "Connecting to last known scale");
+                    connect(d.getAddress().toString());
+                    foundInList = true;
+                    savedScaleRetries = 0;
+                    break;
+                }
+            }
+            if (!foundInList) {
+                savedScaleRetries++;
+                if (savedScaleRetries == SAVED_SCALE_RETRY_BUDGET) {
+                    ESP_LOGW("BLEScalePlugin",
+                             "Saved scale %s not seen in %u attempts — giving up auto-reconnect until next manual scan",
+                             savedAddr.c_str(), SAVED_SCALE_RETRY_BUDGET);
+                }
             }
         }
     }
@@ -193,17 +235,41 @@ void BLEScalePlugin::connect(const std::string &uuid) {
     doConnect = true;
     this->uuid = uuid;
     controller->getSettings().setSavedScale(uuid.data());
+    // Any explicit connect() — user-initiated from the /scales page, or
+    // the saved-scale auto-reconnect path itself — should give the
+    // budget a fresh window. Otherwise a manual connect attempt during
+    // the auto-reconnect budget-exhausted state would do nothing visible
+    // until the next mode change / reboot.
+    savedScaleRetries = 0;
 }
 
-void BLEScalePlugin::scan() const {
+void BLEScalePlugin::scan() {
+    // Two cases where we don't actually start a scan: a scale is already
+    // connected (BLE radio is busy), or the scanner failed to initialize.
+    // Emit scan:complete synthetically so the frontend's "Scanning..."
+    // spinner clears immediately instead of waiting for a deadline that
+    // will never arrive.
     if (scale != nullptr && scale->isConnected()) {
+        if (pluginManager != nullptr) {
+            pluginManager->trigger("scale:scan:complete", "count", 1);
+        }
         return;
     }
     if (scanner == nullptr) {
         ESP_LOGE("BLEScalePlugin", "Scanner not initialized, cannot start scan");
+        if (pluginManager != nullptr) {
+            pluginManager->trigger("scale:scan:complete", "count", 0);
+        }
         return;
     }
     scanner->initializeAsyncScan();
+    scanInProgress = true;
+    scanDeadline = millis() + SCAN_DURATION_MS;
+    // Manual scan resets the saved-scale retry budget so the user gets a
+    // fresh auto-reconnect window. If the saved scale powered back on
+    // between the previous budget exhaustion and this scan, we want to
+    // pick it up again.
+    savedScaleRetries = 0;
 }
 
 void BLEScalePlugin::disconnect() {
@@ -229,14 +295,20 @@ void BLEScalePlugin::disconnect() {
 }
 
 void BLEScalePlugin::onProcessStart() const {
-    if (scale != nullptr && scale->isConnected()) {
-        // Double tare with validation
-        scale->tare();
+    // Same local-capture pattern as the public accessors: narrow the
+    // window where another task can null `scale` between the nullness
+    // check and the dereference. Note this is harm-reduction, not full
+    // UAF prevention — broader concurrency hardening (mutex or
+    // shared_ptr atomic_load) is tracked separately.
+    auto *s = scale.get();
+    if (s != nullptr && s->isConnected()) {
+        s->tare();
         delay(50);
-
-        // Check if scale is still connected before second tare
-        if (scale != nullptr && scale->isConnected()) {
-            scale->tare();
+        // Re-capture after the delay so the second tare uses a fresh
+        // pointer read; the unique_ptr may have been reset during sleep.
+        auto *s2 = scale.get();
+        if (s2 != nullptr && s2->isConnected()) {
+            s2->tare();
         }
     }
 }
@@ -261,6 +333,13 @@ void BLEScalePlugin::pollScaleMetadata() {
 void BLEScalePlugin::tare() const { onProcessStart(); }
 
 void BLEScalePlugin::establishConnection() {
+    // Clear doConnect immediately so the loop() check at line ~122 doesn't
+    // re-enter this function on the next tick (which would happen if the
+    // connect succeeded but doConnect was still latched, or if a rapid
+    // second connect() with the same UUID set doConnect=true again before
+    // the first attempt finished). Idempotency in.
+    doConnect = false;
+
     if (uuid.empty()) {
         ESP_LOGE("BLEScalePlugin", "Cannot establish connection with empty UUID");
         return;
@@ -272,25 +351,46 @@ void BLEScalePlugin::establishConnection() {
         return;
     }
 
+    // If we're aborting a scan that was previously kicked off by scan()
+    // (either user-initiated from the /scales page or the bluetooth-
+    // connect / mode-change auto-scan), the frontend has its spinner
+    // pinned waiting for scale:scan:complete. The loop()'s deadline-
+    // driven emission won't fire because we're flipping scanInProgress
+    // to false below — so emit the synthetic completion event here.
+    // Without this the spinner spins forever once an auto-reconnect or
+    // user-initiated connect lands during the scan window.
+    const bool wasScanInProgress = scanInProgress;
     scanner->stopAsyncScan();
+    scanInProgress = false;
+    if (wasScanInProgress && pluginManager != nullptr) {
+        int count = 0;
+        if (scanner != nullptr) {
+            count = static_cast<int>(scanner->getDiscoveredScales().size());
+        }
+        pluginManager->trigger("scale:scan:complete", "count", count);
+    }
 
     auto discoveredScales = scanner->getDiscoveredScales();
     bool deviceFound = false;
+    const String addressForEvent = String(uuid.c_str());
 
     for (const auto &d : discoveredScales) {
         if (d.getAddress().toString() == uuid) {
             deviceFound = true;
             reconnectionTries = 0;
+            disconnectEventFired = false;
 
             auto factory = RemoteScalesFactory::getInstance();
             if (factory == nullptr) {
                 ESP_LOGE("BLEScalePlugin", "RemoteScalesFactory instance is null");
+                emitConnectError(addressForEvent, "factory_null");
                 return;
             }
 
             scale = factory->create(d);
             if (!scale) {
                 ESP_LOGE("BLEScalePlugin", "Connection to device %s failed", d.getName().c_str());
+                emitConnectError(addressForEvent, "factory_create_failed");
                 return;
             }
 
@@ -315,10 +415,20 @@ void BLEScalePlugin::establishConnection() {
             bool connectResult = scale->connect();
             if (!connectResult) {
                 ESP_LOGW("BLEScalePlugin", "Failed to connect to scale, retrying scan");
+                emitConnectError(addressForEvent, "ble_connect_failed");
                 disconnect();
-                if (scanner != nullptr) {
-                    scanner->initializeAsyncScan();
-                }
+                scan();
+            } else if (pluginManager != nullptr) {
+                // Fire-and-forget success event so the frontend can drop any
+                // residual disconnect/error banners immediately rather than
+                // waiting for the 10 s /api/scales/info poll to surface the
+                // reconnected state. Paired with the scale:disconnect
+                // emission elsewhere; together the UI tracks the connection
+                // lifecycle without polling lag.
+                Event ok;
+                ok.id = "scale:connect:success";
+                ok.setString("address", addressForEvent);
+                pluginManager->trigger(ok);
             }
             break;
         }
@@ -326,10 +436,19 @@ void BLEScalePlugin::establishConnection() {
 
     if (!deviceFound) {
         ESP_LOGW("BLEScalePlugin", "Device %s not found in discovered scales", uuid.c_str());
-        if (scanner != nullptr) {
-            scanner->initializeAsyncScan();
-        }
+        emitConnectError(addressForEvent, "device_not_found");
+        scan();
     }
+}
+
+void BLEScalePlugin::emitConnectError(const String &address, const char *reason) {
+    if (pluginManager == nullptr)
+        return;
+    Event event;
+    event.id = "scale:connect:error";
+    event.setString("address", address);
+    event.setString("reason", String(reason));
+    pluginManager->trigger(event);
 }
 
 void BLEScalePlugin::onMeasurement(float value) const {

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -29,7 +29,6 @@ class BLEScalePlugin : public Plugin {
 
     void setup(Controller *controller, PluginManager *pluginManager) override;
     void loop() override;
-    ;
 
     void connect(const std::string &uuid);
     void scan();

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -110,6 +110,13 @@ class BLEScalePlugin : public Plugin {
 
   private:
     void update();
+    // update() helpers — split out so the function stays under the
+    // cognitive-complexity / nesting limits enforced by SonarQube.
+    // `pollConnectedScale` runs when a scale pointer exists (whether
+    // currently connected or in mid-reconnect-retries); `tryAutoReconnect`
+    // runs when no scale pointer exists and a saved-scale address is set.
+    void pollConnectedScale(bool hasConnectedScale);
+    void tryAutoReconnectSaved();
     void onProcessStart() const;
     void pollScaleMetadata();
 

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -8,6 +8,19 @@ void on_ble_measurement(float value);
 
 constexpr unsigned long UPDATE_INTERVAL_MS = 1000;
 constexpr unsigned int RECONNECTION_TRIES = 15;
+// Cap on how many consecutive update() ticks (at UPDATE_INTERVAL_MS each)
+// the saved-scale auto-reconnect path will run without seeing the saved
+// scale in the discovered list. After this we stop trying until a manual
+// scan / mode change / reboot resets the counter. Without this cap the
+// loop runs every 1 s indefinitely when the saved scale is powered off,
+// hammering the scanner and producing no value.
+constexpr unsigned int SAVED_SCALE_RETRY_BUDGET = 60;
+// How long the firmware considers an async BLE scan to be "in progress"
+// before emitting scale:scan:complete. NimBLE's `initializeAsyncScan` in
+// the remote-scales lib doesn't surface a completion callback, so we
+// time-box it. ~5 s matches the lib's internal default and is long
+// enough for sleeping scales to advertise at least once.
+constexpr unsigned long SCAN_DURATION_MS = 5000;
 
 class BLEScalePlugin : public Plugin {
   public:
@@ -19,25 +32,39 @@ class BLEScalePlugin : public Plugin {
     ;
 
     void connect(const std::string &uuid);
-    void scan() const;
+    void scan();
     void disconnect();
     void onMeasurement(float value) const;
-    bool isConnected() { return scale != nullptr && scale->isConnected(); };
+    // All scale accessors local-capture the `scale` unique_ptr's raw
+    // pointer before testing+dereferencing it. Without this, a check-then-
+    // use across `if (scale != nullptr) scale->foo()` is unsafe whenever
+    // another task (the bluetooth-disconnect event handler on core 0, or
+    // `update()`'s reconnection-tries timeout on core 1) can null `scale`
+    // between the check and the call. Mirror of the local-capture pattern
+    // already applied to `Controller::onVolumetricMeasurement` for the
+    // same family of cross-core UAF.
+    bool isConnected() {
+        auto *s = scale.get();
+        return s != nullptr && s->isConnected();
+    };
     std::string getName() {
-        if (scale != nullptr && scale->isConnected()) {
-            return scale->getDeviceName();
+        auto *s = scale.get();
+        if (s != nullptr && s->isConnected()) {
+            return s->getDeviceName();
         }
         return "";
     };
     std::string getUUID() {
-        if (scale != nullptr && scale->isConnected()) {
-            return scale->getDeviceAddress();
+        auto *s = scale.get();
+        if (s != nullptr && s->isConnected()) {
+            return s->getDeviceAddress();
         }
         return "";
     };
     int getRSSI() {
-        if (scale != nullptr && scale->isConnected()) {
-            return scale->getRSSI();
+        auto *s = scale.get();
+        if (s != nullptr && s->isConnected()) {
+            return s->getRSSI();
         }
         return 0;
     };
@@ -47,18 +74,39 @@ class BLEScalePlugin : public Plugin {
 
     // Accessors for the native scale fields that drivers optionally expose
     // (see RemoteScales). Each returns a sentinel value if not supported.
-    float getFlowRate() const { return scale != nullptr && scale->hasFlowRate() ? scale->getFlowRate() : 0.0f; }
-    bool hasFlowRate() const { return scale != nullptr && scale->hasFlowRate(); }
+    // Same local-capture pattern as the connectivity accessors above.
+    float getFlowRate() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasFlowRate() ? s->getFlowRate() : 0.0f;
+    }
+    bool hasFlowRate() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasFlowRate();
+    }
     uint8_t getBatteryLevel() const {
-        return scale != nullptr && scale->hasBatteryLevel() ? scale->getBatteryLevel() : REMOTE_SCALES_BATTERY_UNKNOWN;
+        auto *s = scale.get();
+        return s != nullptr && s->hasBatteryLevel() ? s->getBatteryLevel() : REMOTE_SCALES_BATTERY_UNKNOWN;
     }
-    bool hasBatteryLevel() const { return scale != nullptr && scale->hasBatteryLevel(); }
+    bool hasBatteryLevel() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasBatteryLevel();
+    }
     ScaleWeightUnit getWeightUnit() const {
-        return scale != nullptr && scale->hasWeightUnit() ? scale->getWeightUnit() : ScaleWeightUnit::UNKNOWN;
+        auto *s = scale.get();
+        return s != nullptr && s->hasWeightUnit() ? s->getWeightUnit() : ScaleWeightUnit::UNKNOWN;
     }
-    bool hasWeightUnit() const { return scale != nullptr && scale->hasWeightUnit(); }
-    uint32_t getScaleTimerMs() const { return scale != nullptr && scale->hasScaleTimer() ? scale->getScaleTimerMs() : 0; }
-    bool hasScaleTimer() const { return scale != nullptr && scale->hasScaleTimer(); }
+    bool hasWeightUnit() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasWeightUnit();
+    }
+    uint32_t getScaleTimerMs() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasScaleTimer() ? s->getScaleTimerMs() : 0;
+    }
+    bool hasScaleTimer() const {
+        auto *s = scale.get();
+        return s != nullptr && s->hasScaleTimer();
+    }
 
   private:
     void update();
@@ -66,6 +114,7 @@ class BLEScalePlugin : public Plugin {
     void pollScaleMetadata();
 
     void establishConnection();
+    void emitConnectError(const String &address, const char *reason);
 
     bool active = false;
     bool doConnect = false;
@@ -73,6 +122,22 @@ class BLEScalePlugin : public Plugin {
 
     unsigned long lastUpdate = 0;
     unsigned int reconnectionTries = 0;
+
+    // Scan-completion bookkeeping. `scanInProgress` flips true when scan()
+    // is called and false when SCAN_DURATION_MS elapses; the loop fires
+    // `scale:scan:complete` exactly once at that boundary so the frontend
+    // can clear its "Scanning…" spinner instead of guessing.
+    bool scanInProgress = false;
+    unsigned long scanDeadline = 0;
+    // Counts consecutive update() ticks where the saved scale wasn't in
+    // the discovered list. See SAVED_SCALE_RETRY_BUDGET above. Reset to 0
+    // on a successful saved-scale connect or on any user-initiated scan
+    // (giving the user a fresh window to find their scale).
+    unsigned int savedScaleRetries = 0;
+    // One-shot latch for the "mid-shot scale disconnect, reconnection
+    // attempts exhausted" event — so we don't spam it every loop tick
+    // while `scale` is non-null but disconnected.
+    bool disconnectEventFired = false;
 
     // Cached scale-metadata values used to avoid firing an event for each
     // unchanged poll tick. Reset when the scale disconnects.

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -66,6 +66,37 @@ void WebUIPlugin::setup(Controller *_controller, PluginManager *_pluginManager) 
     pluginManager->on("controller:volumetric-measurement:bluetooth:change",
                       [this](Event const &event) { this->currentBluetoothWeight = event.getFloat("value"); });
 
+    // Surface BLE-scale lifecycle to the web UI. Without these the
+    // /scales page cannot distinguish "scan in progress" from "scan
+    // finished, no scales found", cannot tell the user when a connect
+    // attempt failed, and cannot notify them that a mid-brew scale
+    // disconnect went past RECONNECTION_TRIES. Each maps to an
+    // evt:scale:* WS broadcast handled by ApiService.js.
+    pluginManager->on("scale:scan:complete", [this](Event const &event) {
+        JsonDocument doc;
+        doc["tp"] = "evt:scale:scan:complete";
+        doc["count"] = event.getInt("count");
+        ws.textAll(doc.as<String>());
+    });
+    pluginManager->on("scale:connect:error", [this](Event const &event) {
+        JsonDocument doc;
+        doc["tp"] = "evt:scale:connect:error";
+        doc["address"] = event.getString("address");
+        doc["reason"] = event.getString("reason");
+        ws.textAll(doc.as<String>());
+    });
+    pluginManager->on("scale:disconnect", [this](Event const &) {
+        JsonDocument doc;
+        doc["tp"] = "evt:scale:disconnect";
+        ws.textAll(doc.as<String>());
+    });
+    pluginManager->on("scale:connect:success", [this](Event const &event) {
+        JsonDocument doc;
+        doc["tp"] = "evt:scale:connect:success";
+        doc["address"] = event.getString("address");
+        ws.textAll(doc.as<String>());
+    });
+
     setupServer();
 }
 

--- a/web/src/pages/Scales/index.jsx
+++ b/web/src/pages/Scales/index.jsx
@@ -125,7 +125,7 @@ export function Scales() {
     // the scan).
     machine.value = {
       ...machine.value,
-      scale: { ...(machine.value.scale || {}), scanning: true },
+      scale: { ...machine.value.scale, scanning: true },
     };
     setConnectError(null);
     try {
@@ -142,7 +142,7 @@ export function Scales() {
       console.error('Scan failed:', error);
       machine.value = {
         ...machine.value,
-        scale: { ...(machine.value.scale || {}), scanning: false },
+        scale: { ...machine.value.scale, scanning: false },
       };
     }
   }, []);
@@ -172,7 +172,7 @@ export function Scales() {
   // arrives; we copy into setConnectError to scope per-page dismissal.
   useEffect(() => {
     const err = machine.value.scale?.lastConnectError;
-    if (err && err.at) {
+    if (err?.at) {
       setConnectError(err);
     }
   }, [machine.value.scale?.lastConnectError?.at]);

--- a/web/src/pages/Scales/index.jsx
+++ b/web/src/pages/Scales/index.jsx
@@ -30,11 +30,35 @@ function batteryColorClass(pct) {
   return 'text-base-content/60'; // everyday — same tone as RSSI
 }
 
+// Map firmware-emitted connect:error `reason` codes to user-readable text.
+// Stays in sync with BLEScalePlugin::emitConnectError call sites.
+function describeConnectErrorReason(reason) {
+  switch (reason) {
+    case 'device_not_found':
+      return "Device disappeared before connection could complete. Try scanning again.";
+    case 'ble_connect_failed':
+      return 'BLE connection refused. Power-cycle the scale and try again.';
+    case 'factory_create_failed':
+    case 'factory_null':
+      return 'Scale driver unavailable. This model may not be supported.';
+    case 'request_failed':
+      return 'Network request failed. Check the device is reachable.';
+    default:
+      return 'Connection failed. See logs for details.';
+  }
+}
+
 export function Scales() {
   const [key, setKey] = useState(0);
   const [scaleData, setScaleData] = useState([]);
-  const [isScanning, setIsScanning] = useState(false);
+  const [connectError, setConnectError] = useState(null);
+  const [disconnectedAt, setDisconnectedAt] = useState(0);
   const mode = machine.value.status.mode;
+  // Firmware-driven scan state: the back end emits evt:scale:scan:complete
+  // SCAN_DURATION_MS (~5 s) after a scan starts, and ApiService writes
+  // machine.scale.scanning. We mirror that here so the spinner stays up
+  // for the actual scan window, not just until the HTTP POST returns.
+  const isScanning = !!machine.value.scale?.scanning;
 
   useEffect(() => {
     const intervalHandle = setInterval(() => {
@@ -50,6 +74,9 @@ export function Scales() {
     data: fetchedScales = [],
   } = useQuery(`scales-${key}`, async () => {
     const response = await fetch(`/api/scales/list`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
     const data = await response.json();
     return data;
   });
@@ -60,34 +87,65 @@ export function Scales() {
     data: connectedScale = [],
   } = useQuery(`scale-info-${key}`, async () => {
     const response = await fetch(`/api/scales/info`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
     const data = await response.json();
     return data;
   });
 
   useEffect(() => {
-    if (!connectedScale || fetchedScales.length === 0) {
+    // If a scale is already connected (e.g. auto-reconnected to the last
+    // known scale at boot), show it even when the discovery list is empty.
+    // The prior `fetchedScales.length === 0` early-return meant a connected
+    // scale silently disappeared from /scales whenever no scan had populated
+    // the list yet — even though it was correctly streaming weight to the
+    // dashboard.
+    if (!connectedScale) {
+      setScaleData(fetchedScales);
       return;
     }
-    const scales = connectedScale.connected ? [connectedScale] : fetchedScales;
-    setScaleData(scales);
+    if (connectedScale.connected) {
+      setScaleData([connectedScale]);
+      // Belt-and-suspenders: if a connect-success WS event was missed
+      // (e.g. WS reconnected mid-event), the 10 s /api/scales/info poll
+      // is our other source-of-truth for "scale is now connected." Clear
+      // the stale disconnect banner + lingering connect error here too.
+      setDisconnectedAt(0);
+      setConnectError(null);
+    } else {
+      setScaleData(fetchedScales);
+    }
   }, [connectedScale, fetchedScales]);
 
   const onScan = useCallback(async () => {
-    setIsScanning(true);
+    // Optimistically flip scanning=true so the UI updates immediately;
+    // the firmware will flip it back to false via evt:scale:scan:complete
+    // when the scan window closes (or sooner if a connect attempt aborts
+    // the scan).
+    machine.value = {
+      ...machine.value,
+      scale: { ...(machine.value.scale || {}), scanning: true },
+    };
+    setConnectError(null);
     try {
       await fetch('/api/scales/scan', {
         method: 'post',
       });
-      // Refresh the data after scan
+      // Refresh the displayed list after scan kicks off; the firmware
+      // event drives the spinner-off transition independently.
       setKey(Date.now().valueOf());
     } catch (error) {
       console.error('Scan failed:', error);
-    } finally {
-      setIsScanning(false);
+      machine.value = {
+        ...machine.value,
+        scale: { ...(machine.value.scale || {}), scanning: false },
+      };
     }
-  }, [setIsScanning]);
+  }, []);
 
   const onConnect = useCallback(async uuid => {
+    setConnectError(null);
     try {
       const data = new FormData();
       data.append('uuid', uuid);
@@ -99,8 +157,53 @@ export function Scales() {
       setKey(Date.now().valueOf());
     } catch (error) {
       console.error('Connection failed:', error);
+      setConnectError({ address: uuid, reason: 'request_failed' });
     }
   }, []);
+
+  // Mirror firmware-emitted scale events into local state for banners.
+  // The machine.scale signal updates from ApiService when the WS event
+  // arrives; we copy into setConnectError to scope per-page dismissal.
+  useEffect(() => {
+    const err = machine.value.scale?.lastConnectError;
+    if (err && err.at) {
+      setConnectError(err);
+    }
+  }, [machine.value.scale?.lastConnectError?.at]);
+
+  useEffect(() => {
+    const ts = machine.value.scale?.lastDisconnectAt;
+    if (ts) {
+      setDisconnectedAt(ts);
+    }
+  }, [machine.value.scale?.lastDisconnectAt]);
+
+  // Force the disconnect banner to auto-clear at the 60 s deadline so it
+  // doesn't sit stuck on screen if the user idles. The render-time
+  // `Date.now() - disconnectedAt < 60000` check only re-evaluates on
+  // parent state changes; without this timer the banner would stay
+  // visible past its intended dismissal window.
+  useEffect(() => {
+    if (disconnectedAt === 0) return;
+    const elapsed = Date.now() - disconnectedAt;
+    if (elapsed >= 60000) {
+      setDisconnectedAt(0);
+      return;
+    }
+    const handle = setTimeout(() => setDisconnectedAt(0), 60000 - elapsed);
+    return () => clearTimeout(handle);
+  }, [disconnectedAt]);
+
+  // Clear residual banners when the device enters standby. Without this
+  // a "scale disconnected" or "connect failed" notice persists into a
+  // mode where the user has no actionable response (scan is disabled),
+  // confusing the dashboard until they navigate away and back.
+  useEffect(() => {
+    if (mode === 0) {
+      setDisconnectedAt(0);
+      setConnectError(null);
+    }
+  }, [mode]);
 
   const loading = isLoading || isInfoLoading || isScanning;
 
@@ -113,6 +216,34 @@ export function Scales() {
           {mode > 0 && loading && <Spinner size={8} className='ml-4' />}
         </button>
       </div>
+
+      {connectError && (
+        <div role='alert' className='alert alert-error mb-4'>
+          <div className='flex-1'>
+            <span className='font-semibold'>Connection failed.</span>{' '}
+            <span className='opacity-80'>{describeConnectErrorReason(connectError.reason)}</span>
+            {connectError.address && (
+              <span className='ml-2 font-mono text-xs opacity-60'>({connectError.address})</span>
+            )}
+          </div>
+          <button type='button' className='btn btn-sm' onClick={() => setConnectError(null)}>
+            Dismiss
+          </button>
+        </div>
+      )}
+      {disconnectedAt > 0 && Date.now() - disconnectedAt < 60000 && (
+        <div role='alert' className='alert alert-warning mb-4'>
+          <div className='flex-1'>
+            <span className='font-semibold'>Scale disconnected.</span>{' '}
+            <span className='opacity-80'>
+              Reconnection attempts were exhausted. Re-scan or check the scale's power.
+            </span>
+          </div>
+          <button type='button' className='btn btn-sm' onClick={() => setDisconnectedAt(0)}>
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <div className='grid grid-cols-1 gap-4 lg:grid-cols-12'>
         <Card sm={12} title='Available Devices'>

--- a/web/src/pages/Scales/index.jsx
+++ b/web/src/pages/Scales/index.jsx
@@ -129,9 +129,12 @@ export function Scales() {
     };
     setConnectError(null);
     try {
-      await fetch('/api/scales/scan', {
+      const response = await fetch('/api/scales/scan', {
         method: 'post',
       });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
       // Refresh the displayed list after scan kicks off; the firmware
       // event drives the spinner-off transition independently.
       setKey(Date.now().valueOf());
@@ -149,10 +152,13 @@ export function Scales() {
     try {
       const data = new FormData();
       data.append('uuid', uuid);
-      await fetch('/api/scales/connect', {
+      const response = await fetch('/api/scales/connect', {
         method: 'post',
         body: data,
       });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
       // Refresh the data after connection
       setKey(Date.now().valueOf());
     } catch (error) {

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -59,9 +59,19 @@ export default class ApiService {
 
   _onClose() {
     console.log('WebSocket connection closed');
+    // Reset transient scan state on socket close. If the socket dropped
+    // mid-scan, the firmware's evt:scale:scan:complete will never reach
+    // this client, so the optimistic `scanning=true` flag set in
+    // Scales/index.jsx's onScan would stay latched forever — the
+    // "Scanning..." spinner would never clear. Clearing here lets the
+    // UI recover cleanly on the next reconnect.
     machine.value = {
       ...machine.value,
       connected: false,
+      scale: {
+        ...(machine.value.scale || {}),
+        scanning: false,
+      },
     };
     this._scheduleReconnect();
   }

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -272,6 +272,7 @@ export const machine = signal({
     lastScanAt: 0,
     lastConnectError: null,
     lastDisconnectAt: 0,
+    lastConnectAt: 0,
   },
   status: {
     currentTemperature: 0,

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -102,6 +102,49 @@ export default class ApiService {
     const listeners = Object.values(this.listeners[message.tp] || {});
     if (message.tp === 'evt:status') {
       this._onStatus(message);
+    } else if (message.tp === 'evt:scale:scan:complete') {
+      machine.value = {
+        ...machine.value,
+        scale: {
+          ...(machine.value.scale || {}),
+          scanning: false,
+          lastScanCount: message.count || 0,
+          lastScanAt: Date.now(),
+        },
+      };
+    } else if (message.tp === 'evt:scale:connect:error') {
+      machine.value = {
+        ...machine.value,
+        scale: {
+          ...(machine.value.scale || {}),
+          lastConnectError: {
+            address: message.address || '',
+            reason: message.reason || 'unknown',
+            at: Date.now(),
+          },
+        },
+      };
+    } else if (message.tp === 'evt:scale:disconnect') {
+      machine.value = {
+        ...machine.value,
+        scale: {
+          ...(machine.value.scale || {}),
+          lastDisconnectAt: Date.now(),
+        },
+      };
+    } else if (message.tp === 'evt:scale:connect:success') {
+      // A scale just (re)connected — drop any lingering disconnect /
+      // connect-error state so the /scales banners clear immediately
+      // instead of riding out the 60 s auto-dismiss timer.
+      machine.value = {
+        ...machine.value,
+        scale: {
+          ...(machine.value.scale || {}),
+          lastDisconnectAt: 0,
+          lastConnectError: null,
+          lastConnectAt: Date.now(),
+        },
+      };
     }
     for (const listener of listeners) {
       listener(message);
@@ -213,6 +256,13 @@ export const ApiServiceContext = createContext(null);
 
 export const machine = signal({
   connected: false,
+  scale: {
+    scanning: false,
+    lastScanCount: 0,
+    lastScanAt: 0,
+    lastConnectError: null,
+    lastDisconnectAt: 0,
+  },
   status: {
     currentTemperature: 0,
     targetTemperature: 0,

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -69,7 +69,7 @@ export default class ApiService {
       ...machine.value,
       connected: false,
       scale: {
-        ...(machine.value.scale || {}),
+        ...machine.value.scale,
         scanning: false,
       },
     };
@@ -116,7 +116,7 @@ export default class ApiService {
       machine.value = {
         ...machine.value,
         scale: {
-          ...(machine.value.scale || {}),
+          ...machine.value.scale,
           scanning: false,
           lastScanCount: message.count || 0,
           lastScanAt: Date.now(),
@@ -126,7 +126,7 @@ export default class ApiService {
       machine.value = {
         ...machine.value,
         scale: {
-          ...(machine.value.scale || {}),
+          ...machine.value.scale,
           lastConnectError: {
             address: message.address || '',
             reason: message.reason || 'unknown',
@@ -138,7 +138,7 @@ export default class ApiService {
       machine.value = {
         ...machine.value,
         scale: {
-          ...(machine.value.scale || {}),
+          ...machine.value.scale,
           lastDisconnectAt: Date.now(),
         },
       };
@@ -149,7 +149,7 @@ export default class ApiService {
       machine.value = {
         ...machine.value,
         scale: {
-          ...(machine.value.scale || {}),
+          ...machine.value.scale,
           lastDisconnectAt: 0,
           lastConnectError: null,
           lastConnectAt: Date.now(),


### PR DESCRIPTION
Improves /scales reliability + UX: the scan spinner now tracks the actual scan window instead of clearing as soon as the POST returns, connected scales no longer vanish from the list when no scan has run, connection errors and scale disconnects are now surfaced to the user, and saved-scale auto-reconnect no longer races a user-initiated connect.

**Firmware**
- Auto-reconnect now gated on `!doConnect` so it can't override a pending user-initiated connect.
- `establishConnection` clears `doConnect` at entry (previously it was only cleared in `disconnect()`).
- Saved-scale retry now bounded (`SAVED_SCALE_RETRY_BUDGET = 60`); resets on find / scan / connect. Previously the auto-reconnect path ran every tick when the saved scale was powered off.
- New `scale:scan:complete` / `connect:error` (with reason code) / `connect:success` / `disconnect` events from `BLEScalePlugin`, re-broadcast by `WebUIPlugin` as `evt:scale:*`. Scan window time-boxed via `SCAN_DURATION_MS = 5000` to drive the `scan:complete` emission.
- Existing public `scale` accessors hardened to local-capture the raw pointer via `scale.get()` before deref — narrows the check-then-use race but doesn't eliminate UAF; a full fix (mutex / `shared_ptr` + `atomic_load`) belongs in a broader concurrency pass.
- `update()` split into `pollConnectedScale` / `tryAutoReconnectSaved` helpers (SonarQube complexity).

**Frontend**
- Spinner driven by `machine.scale.scanning` instead of a local flag; also cleared on WS close so a mid-scan socket drop doesn't leave it stuck.
- Connect-error and scale-disconnect banners — dismissible, 60s auto-clear, also cleared on standby or when the scale reconnects.
- `/scales` no longer hides a connected scale when the discovered list is empty.
- `fetch()` checks `response.ok` before parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added connection failure alerts with descriptive error messages
  * Added timed scale disconnection notifications that auto-dismiss

* **Bug Fixes**
  * Improved BLE scan completion with deadline-driven timing instead of polling
  * Enhanced connection and reconnection behavior for greater reliability
  * Fixed UI stuck in scanning state after connection loss
  * Strengthened error handling with structured feedback for connection failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->