### PR TITLE
SonarQube fix: Restrict write access to release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ on:
     tags:
       - "*"
 
-permissions:
-  contents: write
 name: Build
 jobs:
   build:
@@ -107,9 +105,12 @@ jobs:
         with:
           name: gaggimate-firmware
           path: "out/*"
+
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download Firmware Files
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Summary
This PR updates the GitHub Actions build workflow to follow the principle of least privilege by scoping the contents: write permission exclusively to the job that requires it.

Changes Made
Removed the global permissions: contents: write block from the top level of the workflow.

Added permissions: contents: write specifically to the release job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build automation configuration for improved permission management.

**Note:** This release contains no user-facing changes. The modifications are limited to internal CI/CD infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->