### PR TITLE
feat: add Flush as a button behavior option

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -172,6 +172,31 @@ void Controller::setupBluetooth() {
             handleWaterButton(status);
             return;
         }
+        if (behavior == "flush") {
+            // Flush is a one-shot fixed-duration BrewProcess. Trigger on
+            // press only; release does nothing so the user can't
+            // accidentally cancel mid-flush by letting go (push button)
+            // or flipping the rocker back. onFlush() itself is a no-op
+            // if a process is already active, so rapid presses don't
+            // queue.
+            //
+            // Ensure we land in MODE_BREW so the flush UI renders,
+            // regardless of which mode the user came from. Without
+            // this, pressing the flush button from steam/water/standby
+            // would start the BrewProcess but the screen would still
+            // show the source mode. Mirrors the mode-switch pattern
+            // used by the other button handlers.
+            if (status) {
+                if (getMode() == MODE_STANDBY) {
+                    deactivateStandby();
+                }
+                if (getMode() != MODE_BREW) {
+                    setMode(MODE_BREW);
+                }
+                onFlush();
+            }
+            return;
+        }
         handleProfileButton(status, behavior);
     });
     clientController.registerRemoteErrorCallback([this](const int error) {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -180,17 +180,17 @@ void Controller::setupBluetooth() {
             // if a process is already active, so rapid presses don't
             // queue.
             //
-            // Ensure we land in MODE_BREW so the flush UI renders,
-            // regardless of which mode the user came from. Without
-            // this, pressing the flush button from steam/water/standby
-            // would start the BrewProcess but the screen would still
-            // show the source mode. Mirrors the mode-switch pattern
-            // used by the other button handlers.
+            // Ensure we land in MODE_BREW so the flush UI renders, but
+            // only when no other process is currently running. Mutating
+            // mode mid-process would orphan the active mode's UI while
+            // onFlush() silently no-ops on the re-entrancy guard. The
+            // setMode guard mirrors the pattern other button handlers
+            // use when they need to switch modes safely.
             if (status) {
                 if (getMode() == MODE_STANDBY) {
                     deactivateStandby();
                 }
-                if (getMode() != MODE_BREW) {
+                if (getMode() != MODE_BREW && !isActive()) {
                     setMode(MODE_BREW);
                 }
                 onFlush();

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -539,6 +539,7 @@ export function Settings() {
                 <option value='brew'>Brew button</option>
                 <option value='steam'>Steam button</option>
                 <option value='water'>Water button</option>
+                <option value='flush'>Flush</option>
                 {profiles.map(p => (
                   <option key={p.id} value={p.id}>
                     Profile: {p.label}
@@ -562,6 +563,7 @@ export function Settings() {
                 <option value='brew'>Brew button</option>
                 <option value='steam'>Steam button</option>
                 <option value='water'>Water button</option>
+                <option value='flush'>Flush</option>
                 {profiles.map(p => (
                   <option key={p.id} value={p.id}>
                     Profile: {p.label}
@@ -585,6 +587,7 @@ export function Settings() {
                 <option value='brew'>Brew button</option>
                 <option value='steam'>Steam button</option>
                 <option value='water'>Water button</option>
+                <option value='flush'>Flush</option>
                 {profiles.map(p => (
                   <option key={p.id} value={p.id}>
                     Profile: {p.label}


### PR DESCRIPTION
## Summary

- Adds `Flush` as a selectable option in the per-button dropdowns (Settings → Switch Control → Brew/Steam/Water Button Behavior), letting users map a physical button to the existing fixed-duration flush flow.
- Press-only dispatch. Release is ignored, so a flush can't be accidentally cancelled by letting go of a momentary button or flipping a rocker back mid-flush.
- Mode-correcting: if the user presses the flush button from standby / steam / water / grind, the dispatcher wakes the machine if needed and switches to `MODE_BREW` first so the flush UI renders consistently.

## Behavior

| Hardware | Action | Result |
|---|---|---|
| Stock rocker (momentary OFF) | Flip rocker down | Flush fires (one-shot) |
| Stock rocker (momentary OFF) | Flip rocker back up | No-op (release ignored) |
| Momentary push button (momentary ON) | Tap | Flush fires (one-shot) |
| Either, mid-flush | Press again | No-op — `onFlush()` short-circuits when a process is active |
| From STEAM / WATER / STANDBY | Press | Switches to BREW, then fires |

Works identically regardless of the global `Use momentary switches` setting — release semantics aren't meaningful for a fixed-duration process.

## Code

Two files, +28 / -0:

- `src/display/core/Controller.cpp` — new `if (behavior == "flush")` branch in the `registerBtnCallback` dispatcher.
- `web/src/pages/Settings/index.jsx` — new `<option value='flush'>Flush</option>` in all three button-behavior `<select>` elements.

No changes to `Settings.h` / `Settings.cpp` / `WebUIPlugin.cpp`. No new persisted state, no migration, no schema change. Existing button-behavior CSV format unchanged — `flush` is just one more valid string alongside `brew` / `steam` / `water` / `none` / profile IDs.

## Test plan

- [ ] Map Button 1 → `Flush` → Save
- [ ] Press the mapped physical button — verify the flush UI appears with countdown
- [ ] Release the button (rocker back up / let go of momentary) — verify nothing happens
- [ ] Press the button again mid-flush — verify no second flush queues
- [ ] Repeat from steam mode — machine switches to brew, flush UI renders
- [ ] Repeat from water mode — same
- [ ] Repeat from standby — machine wakes, switches to brew, flush UI renders
- [ ] Toggle `Use momentary switches` ON, retest — behavior unchanged

## Related

Issue #662 (open) requests *"Ability to flush with momentary switch button"* via long-press detection on a button mapped to brew/steam. This PR is a complementary direct-mapping approach — no new gesture detection, works on both rocker and momentary hardware. The two could coexist: this PR for "this whole button = flush", #662's design for "long-press this brew button = flush".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flush as a selectable action for Button 1/2/3 in Settings so users can assign a flush cycle to any configurable button.
  * Pressing an assigned flush button now immediately starts a flush cycle when available and skips other button handling; releasing the button has no additional effect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->