### PR TITLE
fix(display): deactivate completed process before starting a new one (GM-5)

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -450,6 +450,15 @@ void Controller::startProcess(Process *process) {
         delete process;
         return;
     }
+    // A previous process may have finished but not yet been deactivated:
+    // deactivate() only runs on the next loop() tick (every PROGRESS_INTERVAL),
+    // so isActive() reports false while currentProcess is still allocated. The
+    // web/BLE activate() paths run on other cores and can land in this window.
+    // Deactivate it first (moves it into lastProcess, firing the proper end
+    // events) so we don't overwrite—and leak—the live currentProcess pointer.
+    if (currentProcess != nullptr) {
+        deactivate();
+    }
     processCompleted = false;
     this->currentProcess = process;
     pluginManager->trigger("controller:process:start");


### PR DESCRIPTION
## Summary

`Controller::startProcess()` assigned `currentProcess` without freeing an existing one. `isActive()` returns `false` once a process completes but **before** the next `loop()` tick calls `deactivate()` (which moves it into `lastProcess`). An `activate()` / `activateGrind()` in that ~100 ms window — easily hit from the AsyncTCP WebSocket handler on core 1 while completion runs on the main-loop core — overwrote and leaked the live `currentProcess`.

Fix: in `startProcess()`, if `currentProcess != nullptr`, call `deactivate()` first. This preserves the `lastProcess` auto-delay bookkeeping and fires the expected `controller:process:end` events, and never overwrites a live pointer.

Closes GM-5.

## Test plan
- [x] `platformio run -e display` succeeds
- [x] `platformio run -e display-headless` succeeds
- [ ] On-device: repeatedly activate -> let complete -> re-activate; confirm free heap stays stable and end/start events still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a resource management issue where active processes could be inadvertently lost in certain scenarios, improving overall system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->