### PR TITLE
feat(display): back WebSocket rxBuffers with PSRAM (GM-8)

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -14,12 +14,18 @@
 #include <algorithm>
 #include <display/plugins/BLEScalePlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
+#include <display/util/PsramStlAllocator.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <version.h>
 
-static std::unordered_map<uint32_t, std::string> rxBuffers;
+// Incoming WebSocket payloads (profile uploads reserve up to 64 KB) are
+// reassembled here. Back the character storage with PSRAM so these large,
+// transient buffers don't spike the scarce internal SRAM. The map nodes
+// themselves stay on the default heap (tiny: an id + a string handle).
+using PsramString = std::basic_string<char, std::char_traits<char>, PsramStlAllocator<char>>;
+static std::unordered_map<uint32_t, PsramString> rxBuffers;
 static WebUIPlugin *g_webUIPlugin = nullptr;
 
 WebUIPlugin::WebUIPlugin() : server(80), ws("/ws") { g_webUIPlugin = this; }

--- a/src/display/util/PsramStlAllocator.h
+++ b/src/display/util/PsramStlAllocator.h
@@ -1,0 +1,41 @@
+#ifndef PSRAMSTLALLOCATOR_H
+#define PSRAMSTLALLOCATOR_H
+
+#include <cstddef>
+#include <cstdlib>
+#include <esp_heap_caps.h>
+
+// Minimal C++11 STL allocator that places storage in PSRAM, falling back to
+// internal heap when PSRAM is full or unavailable. Intended for large,
+// CPU-only containers (e.g. WebSocket reassembly buffers up to 64 KB) so they
+// stay off the scarce internal SRAM. Do not use for DMA- or ISR-accessed data.
+//
+// On total allocation failure it aborts (matching the default operator new),
+// so callers don't need exceptions enabled.
+template <typename T> struct PsramStlAllocator {
+    using value_type = T;
+
+    PsramStlAllocator() noexcept = default;
+    template <typename U> PsramStlAllocator(const PsramStlAllocator<U> &) noexcept {}
+
+    T *allocate(std::size_t n) {
+        const std::size_t bytes = n * sizeof(T);
+        void *p = heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if (!p)
+            p = heap_caps_malloc(bytes, MALLOC_CAP_DEFAULT);
+        if (!p)
+            abort();
+        return static_cast<T *>(p);
+    }
+
+    void deallocate(T *p, std::size_t) noexcept { heap_caps_free(p); }
+};
+
+template <typename T, typename U> bool operator==(const PsramStlAllocator<T> &, const PsramStlAllocator<U> &) noexcept {
+    return true;
+}
+template <typename T, typename U> bool operator!=(const PsramStlAllocator<T> &, const PsramStlAllocator<U> &) noexcept {
+    return false;
+}
+
+#endif // PSRAMSTLALLOCATOR_H


### PR DESCRIPTION
## Summary

Incoming WebSocket message reassembly (`rxBuffers`) reserved up to 64 KB of internal SRAM per client for profile uploads (x up to 3 clients).

- Add a minimal `PsramStlAllocator<T>` (`src/display/util/PsramStlAllocator.h`) - `heap_caps_malloc(MALLOC_CAP_SPIRAM)` with internal-heap fallback, aborts on total failure (no exceptions needed).
- Back the `rxBuffers` reassembly strings with it via a `PsramString` typedef.

The large transient payload buffers now live in PSRAM; the map nodes (id + string handle) stay on the default heap. This buffer is CPU-only (not DMA/ISR), so PSRAM is safe. Part of GM-6.

Closes GM-8.

## Test plan
- [x] `platformio run -e display` succeeds
- [x] `platformio run -e display-headless` succeeds
- [ ] On-device: upload a large profile (fragmented frames) across multiple clients; confirm correct reassembly and no internal-SRAM spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory usage for WebSocket message handling by utilizing external PSRAM storage for temporary buffers, reducing pressure on internal SRAM and improving overall system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->