### PR TITLE
Add events for shot save/delete/notes-save and profile delete

### DIFF
--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -157,7 +157,11 @@ bool ProfileManager::deleteProfile(const String &uuid) {
     if (_settings.getStartupProfile() == uuid) {
         _settings.setStartupProfile("");
     }
-    return _fs->remove(profilePath(uuid));
+    bool ok = _fs->remove(profilePath(uuid));
+    if (ok) {
+        _plugin_manager->trigger("profiles:profile:delete", "id", uuid);
+    }
+    return ok;
 }
 
 bool ProfileManager::profileExists(const String &uuid) { return _fs->exists(profilePath(uuid)); }

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -248,6 +248,7 @@ void ShotHistoryPlugin::record() {
             if (!appendToIndex(indexEntry)) {
                 ESP_LOGE("ShotHistoryPlugin", "CRITICAL: Failed to add completed shot %u to index", indexEntry.id);
             }
+            pluginManager->trigger("history:shot:save", "id", currentId);
         }
     }
 }
@@ -480,10 +481,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         response["error"] = "use HTTP /api/history?id=<id>";
     } else if (type == "req:history:delete") {
         auto id = request["id"].as<String>();
-        String paddedId = id;
-        while (paddedId.length() < 6) {
-            paddedId = "0" + paddedId;
-        }
+        String paddedId = padId(id);
         fs->remove("/h/" + paddedId + ".slog");
         fs->remove("/h/" + paddedId + ".json");
 
@@ -491,6 +489,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         markIndexDeleted(id.toInt());
 
         response["msg"] = "Ok";
+        pluginManager->trigger("history:shot:delete", "id", paddedId);
     } else if (type == "req:history:notes:get") {
         auto id = request["id"].as<String>();
         JsonDocument notes;
@@ -517,6 +516,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         updateIndexMetadata(id.toInt(), rating, volume);
 
         response["msg"] = "Ok";
+        pluginManager->trigger("history:shot:notes:save", "id", padId(id));
     } else if (type == "req:history:rebuild") {
         // Rebuild is now handled asynchronously by WebUIPlugin
         // This path shouldn't be reached, but handle it just in case


### PR DESCRIPTION
This PR fills out the existing plugin event "grid" so that plugins can receive notifications on save/delete for profiles, shots and notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of profile deletion operations to ensure proper cleanup.
  * Enhanced shot history recording and deletion to provide more accurate state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->