### PR TITLE
Recover from an incompatible controller via OTA (treat as protocol mismatch) [GM-82]

### DIFF
--- a/lib/NanoPbComm/src/GaggiMateClient.cpp
+++ b/lib/NanoPbComm/src/GaggiMateClient.cpp
@@ -8,9 +8,9 @@ void GaggiMateClient::init(const String &deviceName) {
         if (_connCb)
             _connCb(connected);
     });
-    _transport.onIncompatible([this]() {
+    _transport.onIncompatible([this](const String &info) {
         if (_incompatibleCb)
-            _incompatibleCb();
+            _incompatibleCb(info);
     });
     _endpoint.begin();
     _transport.init(deviceName);

--- a/lib/NanoPbComm/src/GaggiMateClient.cpp
+++ b/lib/NanoPbComm/src/GaggiMateClient.cpp
@@ -8,6 +8,10 @@ void GaggiMateClient::init(const String &deviceName) {
         if (_connCb)
             _connCb(connected);
     });
+    _transport.onIncompatible([this]() {
+        if (_incompatibleCb)
+            _incompatibleCb();
+    });
     _endpoint.begin();
     _transport.init(deviceName);
 }

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -19,7 +19,8 @@
 class GaggiMateClient {
   public:
     using ConnectionCallback = std::function<void(bool connected)>;
-    using IncompatibleCallback = std::function<void()>;
+    // Argument is the raw legacy INFO characteristic (JSON), if readable.
+    using IncompatibleCallback = std::function<void(const String &info)>;
     using SystemInfoCallback = std::function<void(const char *hardware, const char *version, uint32_t protocolVersion,
                                                   bool dimming, bool pressure, bool ledControl, bool tof)>;
     using SensorCallback =

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -19,6 +19,7 @@
 class GaggiMateClient {
   public:
     using ConnectionCallback = std::function<void(bool connected)>;
+    using IncompatibleCallback = std::function<void()>;
     using SystemInfoCallback = std::function<void(const char *hardware, const char *version, uint32_t protocolVersion,
                                                   bool dimming, bool pressure, bool ledControl, bool tof)>;
     using SensorCallback =
@@ -77,6 +78,10 @@ class GaggiMateClient {
     void send(const gm::Payload &payload) { _endpoint.send(payload); }
     void sendBatch(const gm::Payload *payloads, size_t count) { _endpoint.sendBatch(payloads, count); }
 
+    // Fired when the connected controller is missing the framed-comms
+    // characteristics (old / incompatible firmware); link is kept for OTA.
+    void onIncompatibleController(IncompatibleCallback cb) { _incompatibleCb = std::move(cb); }
+
     // Response registrations (controller -> display)
     void onConnectionChanged(ConnectionCallback cb) { _connCb = std::move(cb); }
     void onSystemInfo(SystemInfoCallback cb) { _systemInfoCb = std::move(cb); }
@@ -92,6 +97,7 @@ class GaggiMateClient {
     Endpoint _endpoint;
 
     ConnectionCallback _connCb;
+    IncompatibleCallback _incompatibleCb;
     SystemInfoCallback _systemInfoCb;
     SensorCallback _sensorCb;
     ButtonCallback _buttonCb;

--- a/lib/NanoPbComm/src/ble/BleClientTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.cpp
@@ -79,8 +79,14 @@ bool BleClientTransport::connectToServer() {
         _notifyChar = nullptr;
         _readyForConnection = false;
         _incompatible = true;
+        // Read the legacy read-only INFO characteristic (present on old
+        // controllers too) so the display can show the real hardware/version.
+        String info;
+        NimBLERemoteCharacteristic *infoChar = service->getCharacteristic(NimBLEUUID(gm_proto::INFO_CHAR_UUID));
+        if (infoChar != nullptr && infoChar->canRead())
+            info = String(infoChar->readValue().c_str());
         if (_onIncompatible)
-            _onIncompatible();
+            _onIncompatible(info);
         return true; // link intentionally kept; do not disconnect/rescan
     }
 

--- a/lib/NanoPbComm/src/ble/BleClientTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.cpp
@@ -69,10 +69,19 @@ bool BleClientTransport::connectToServer() {
     _writeChar = service->getCharacteristic(NimBLEUUID(gm_proto::RX_CHAR_UUID));
     _notifyChar = service->getCharacteristic(NimBLEUUID(gm_proto::TX_CHAR_UUID));
     if (_writeChar == nullptr || _notifyChar == nullptr) {
-        ESP_LOGE(LOG_TAG, "Characteristics not found");
-        _client->disconnect();
-        scan();
-        return false;
+        // The controller advertises the GaggiMate service but lacks the framed
+        // comms characteristics -> old/incompatible firmware. Keep the link up
+        // (the OTA service lives on a separate service and stays reachable) and
+        // report incompatibility so the display can offer an OTA recovery, the
+        // same way it handles a protocol-version mismatch.
+        ESP_LOGW(LOG_TAG, "Comms characteristics missing -- incompatible controller firmware (OTA only)");
+        _writeChar = nullptr;
+        _notifyChar = nullptr;
+        _readyForConnection = false;
+        _incompatible = true;
+        if (_onIncompatible)
+            _onIncompatible();
+        return true; // link intentionally kept; do not disconnect/rescan
     }
 
     // Without the notify subscription we would connect but never receive data;
@@ -87,6 +96,7 @@ bool BleClientTransport::connectToServer() {
     }
 
     _readyForConnection = false;
+    _incompatible = false;
     ESP_LOGI(LOG_TAG, "Connected, MTU: %d", _client->getMTU());
     emitConnection(true);
     return true;
@@ -137,6 +147,7 @@ void BleClientTransport::onDisconnect(NimBLEClient *client) {
     ESP_LOGI(LOG_TAG, "Disconnected, will rescan");
     _writeChar = nullptr;
     _notifyChar = nullptr;
+    _incompatible = false;
     emitConnection(false);
     scan();
 }

--- a/lib/NanoPbComm/src/ble/BleClientTransport.h
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.h
@@ -39,8 +39,9 @@ class BleClientTransport : public Transport, public NimBLEAdvertisedDeviceCallba
     // Fired when we connect to a GaggiMate controller that advertises the
     // service but is missing the framed-comms characteristics (an old /
     // incompatible firmware). The BLE link is intentionally kept up so the
-    // separate OTA service stays reachable.
-    void onIncompatible(std::function<void()> cb) { _onIncompatible = std::move(cb); }
+    // separate OTA service stays reachable. The argument is the raw value of the
+    // legacy read-only INFO characteristic (JSON), if readable.
+    void onIncompatible(std::function<void(const String &info)> cb) { _onIncompatible = std::move(cb); }
 
   private:
     NimBLEClient *_client = nullptr;
@@ -51,7 +52,7 @@ class BleClientTransport : public Transport, public NimBLEAdvertisedDeviceCallba
     bool _readyForConnection = false;
     bool _lowLatency = false;
     bool _incompatible = false;
-    std::function<void()> _onIncompatible = nullptr;
+    std::function<void(const String &info)> _onIncompatible = nullptr;
 
     void applyConnParams();
 

--- a/lib/NanoPbComm/src/ble/BleClientTransport.h
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.h
@@ -36,6 +36,12 @@ class BleClientTransport : public Transport, public NimBLEAdvertisedDeviceCallba
     // Native client handle, needed by ControllerOTA (OTA uses its own service).
     NimBLEClient *getNativeClient() const { return _client; }
 
+    // Fired when we connect to a GaggiMate controller that advertises the
+    // service but is missing the framed-comms characteristics (an old /
+    // incompatible firmware). The BLE link is intentionally kept up so the
+    // separate OTA service stays reachable.
+    void onIncompatible(std::function<void()> cb) { _onIncompatible = std::move(cb); }
+
   private:
     NimBLEClient *_client = nullptr;
     NimBLEScan *_scanner = nullptr;
@@ -44,6 +50,8 @@ class BleClientTransport : public Transport, public NimBLEAdvertisedDeviceCallba
     NimBLERemoteCharacteristic *_notifyChar = nullptr; // from server (TX_CHAR_UUID)
     bool _readyForConnection = false;
     bool _lowLatency = false;
+    bool _incompatible = false;
+    std::function<void()> _onIncompatible = nullptr;
 
     void applyConnParams();
 

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -175,6 +175,7 @@ void Controller::setupBluetooth() {
     comms.onSystemInfo(
         [this](const char *hardware, const char *version, uint32_t protocolVersion, bool dimming, bool pressure, bool ledControl,
                bool tof) { onSystemInfo(hardware, version, protocolVersion, dimming, pressure, ledControl, tof); });
+    comms.onIncompatibleController([this]() { onIncompatibleController(); });
     comms.onSensorData([this](float temp, float pressure, float puckFlow, float pumpFlow, float puckResistance) {
         onTempRead(temp);
         this->pressure = pressure;
@@ -320,6 +321,16 @@ void Controller::onSystemInfo(const char *hardware, const char *version, uint32_
     pluginManager->trigger("controller:bluetooth:connect");
 }
 
+void Controller::onIncompatibleController() {
+    // An old controller (no framed-comms characteristics) is, for our purposes,
+    // a protocol mismatch: reuse the exact same path. protocolVersion 0 != our
+    // PROTOCOL_VERSION, so onSystemInfo() inhibits control but still fires
+    // controller:ready so OTA can flash the controller back into compatibility.
+    // Version "0.0.0" makes the web UI offer the update.
+    waitingForController = false;
+    onSystemInfo("Legacy controller", "0.0.0", 0, false, false, false, false);
+}
+
 void Controller::setupWifi() {
     if (settings.getWifiSsid() != "" && settings.getWifiPassword() != "") {
         WiFi.setHostname(settings.getMdnsName().c_str());
@@ -402,8 +413,9 @@ void Controller::loop() {
 
     // Keepalive: updateControl() only sends control deltas now, so a steady-state
     // session would otherwise go silent. A periodic ping keeps the controller's
-    // connection watchdog fed (sent in all states, including error).
-    if (comms.isConnected() && now - lastPing >= PING_INTERVAL) {
+    // connection watchdog fed (sent in all states, including error). Skip it for
+    // an incompatible controller -- it can't parse the frame anyway.
+    if (comms.isConnected() && !systemInfo.protocolMismatch && now - lastPing >= PING_INTERVAL) {
         comms.sendPing();
         lastPing = now;
     }

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -1,7 +1,6 @@
 #include "Controller.h"
 #include "ArduinoJson.h"
 #include "esp_sntp.h"
-#include <display/util/PsramAllocator.h>
 #include <SD_MMC.h>
 #include <SPIFFS.h>
 #include <cmath>
@@ -24,6 +23,7 @@
 #include <display/plugins/SmartGrindPlugin.h>
 #include <display/plugins/WebUIPlugin.h>
 #include <display/plugins/mDNSPlugin.h>
+#include <display/util/PsramAllocator.h>
 #ifndef GAGGIMATE_HEADLESS
 #include <display/drivers/AmoledDisplayDriver.h>
 #include <display/drivers/LilyGoDriver.h>
@@ -175,7 +175,7 @@ void Controller::setupBluetooth() {
     comms.onSystemInfo(
         [this](const char *hardware, const char *version, uint32_t protocolVersion, bool dimming, bool pressure, bool ledControl,
                bool tof) { onSystemInfo(hardware, version, protocolVersion, dimming, pressure, ledControl, tof); });
-    comms.onIncompatibleController([this]() { onIncompatibleController(); });
+    comms.onIncompatibleController([this](const String &info) { onIncompatibleController(info); });
     comms.onSensorData([this](float temp, float pressure, float puckFlow, float pumpFlow, float puckResistance) {
         onTempRead(temp);
         this->pressure = pressure;
@@ -321,14 +321,30 @@ void Controller::onSystemInfo(const char *hardware, const char *version, uint32_
     pluginManager->trigger("controller:bluetooth:connect");
 }
 
-void Controller::onIncompatibleController() {
+void Controller::onIncompatibleController(const String &infoJson) {
     // An old controller (no framed-comms characteristics) is, for our purposes,
-    // a protocol mismatch: reuse the exact same path. protocolVersion 0 != our
-    // PROTOCOL_VERSION, so onSystemInfo() inhibits control but still fires
-    // controller:ready so OTA can flash the controller back into compatibility.
-    // Version "0.0.0" makes the web UI offer the update.
+    // a protocol mismatch: reuse the exact same path. We force protocolVersion 0
+    // (it cannot speak the framed protocol), so onSystemInfo() inhibits control
+    // but still fires controller:ready so OTA can flash the controller back into
+    // compatibility. The real hardware/version/capabilities come from the legacy
+    // read-only INFO characteristic the old controller still exposes.
     waitingForController = false;
-    onSystemInfo("Legacy controller", "0.0.0", 0, false, false, false, false);
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, infoJson);
+    if (err) {
+        ESP_LOGW(LOG_TAG, "Incompatible controller, no readable info (%s)", err.c_str());
+        onSystemInfo("Legacy controller", "0.0.0", 0, false, false, false, false);
+        return;
+    }
+    String hardware = doc["hw"].as<String>();
+    String version = doc["v"].as<String>();
+    if (hardware.isEmpty())
+        hardware = "Legacy controller";
+    if (version.isEmpty())
+        version = "0.0.0";
+    onSystemInfo(hardware.c_str(), version.c_str(), 0, doc["cp"]["dm"].as<bool>(), doc["cp"]["ps"].as<bool>(),
+                 doc["cp"]["led"].as<bool>(), doc["cp"]["tof"].as<bool>());
 }
 
 void Controller::setupWifi() {

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -115,8 +115,9 @@ class Controller {
     void onSystemInfo(const char *hardware, const char *version, uint32_t protocolVersion, bool dimming, bool pressure,
                       bool ledControl, bool tof);
     // Connected to a controller too old to speak the framed protocol: drive the
-    // same path as a protocol-version mismatch (OTA recovery only).
-    void onIncompatibleController();
+    // same path as a protocol-version mismatch (OTA recovery only). infoJson is
+    // the legacy INFO characteristic contents (hardware/version/capabilities).
+    void onIncompatibleController(const String &infoJson);
     void setupWifi();
 
     // Functional methods

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -114,6 +114,9 @@ class Controller {
     void setupBluetooth();
     void onSystemInfo(const char *hardware, const char *version, uint32_t protocolVersion, bool dimming, bool pressure,
                       bool ledControl, bool tof);
+    // Connected to a controller too old to speak the framed protocol: drive the
+    // same path as a protocol-version mismatch (OTA recovery only).
+    void onIncompatibleController();
     void setupWifi();
 
     // Functional methods


### PR DESCRIPTION
## Problem

After the framed-nanopb comms protocol (#726), a **display-first** OTA update bricks the rollout:

- A new display connects to the old controller, finds the GaggiMate service, but the new TX/RX comms characteristics don't exist on the old firmware.
- `connectToServer()` then disconnects + rescans, so the display never reaches `controller:ready`, never inits `ControllerOTA`, and **can't OTA the controller** — which is the only non-USB way to update it.

(Controller-first avoids it, since the display self-updates over WiFi independently — but display-first is an easy trap, and the controller OTA path needs the BLE link.)

## Fix

Treat an old/incompatible controller exactly like a **protocol-version mismatch** (which already does the right thing):

- `BleClientTransport`: when the service is present but the comms characteristics are missing, **keep the BLE link** (the OTA DFU service lives on a separate service and stays reachable) and fire a new `onIncompatible` callback instead of disconnecting.
- `GaggiMateClient`: surface it via `onIncompatibleController(...)`.
- `Controller`: route it through the existing mismatch path — `onIncompatibleController()` calls `onSystemInfo("Legacy controller", "0.0.0", protocolVersion=0, ...)`. Since `0 != PROTOCOL_VERSION`, control + config are inhibited (`updateControl()` already bails on `protocolMismatch`) **but `controller:ready` still fires**, so `WebUIPlugin` inits `ControllerOTA` and the web UI can flash the controller. Version `0.0.0` makes the updater offer the update. The keepalive ping is also skipped while mismatched.

Once the controller is flashed it reboots, the display reconnects with full comms (`onSystemInfo` with the real version → `protocolMismatch=false`), and normal control resumes automatically.

## Result

- New display + old controller → web UI offers a controller OTA → one-click recovery (no USB needed).
- Future protocol bumps won't deadlock a display-first update.

## Testing
- Builds green: `controller`, `display`.
- On-device: needs a new-display + old-controller pair to confirm the OTA-recovery path end to end.

Follow-up to #726 / GM-82.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects controllers with legacy/incompatible firmware and routes them to a recovery/OTA path.
  * Incompatible controllers remain connected so firmware updates can be performed without losing BLE link.
* **Bug Fixes**
  * Prevents normal control actions when protocol mismatch is detected while keeping the device reachable for recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->