### PR TITLE
fix(comms): drive all LED channels in one message [GM-86]

### DIFF
--- a/lib/NanoPbComm/proto/gaggimate.options
+++ b/lib/NanoPbComm/proto/gaggimate.options
@@ -9,6 +9,9 @@ gaggimate.Frame.payloads max_count:6
 # Per-boiler readings inside SensorData (one today; room for multi-boiler).
 gaggimate.SensorData.boilers max_count:4
 
+# LED channels driven in one LedControl message (PCA9634 has 8 outputs).
+gaggimate.LedControl.channels max_count:8
+
 # Keep the system-info strings short so the Payload union (sized to its largest
 # member) stays compact -- every batched Payload slot pays for this.
 gaggimate.SystemInfo.hardware max_size:40

--- a/lib/NanoPbComm/proto/gaggimate.proto
+++ b/lib/NanoPbComm/proto/gaggimate.proto
@@ -127,9 +127,18 @@ message PressureScale {
 
 message Tare {}
 
+// One LED output's target brightness.
+message LedChannel {
+    uint32 channel = 1;    // PCA9634 output index (0..7)
+    uint32 brightness = 2; // 0..255
+}
+
+// Drive one or more LED channels in a single atomic update. Carrying every
+// changed channel in one message (instead of one message per channel) keeps the
+// outbound coalescing queue from collapsing a burst of per-channel updates into
+// a single surviving channel.
 message LedControl {
-    uint32 channel = 1;
-    uint32 brightness = 2;
+    repeated LedChannel channels = 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/NanoPbComm/src/GaggiMateClient.cpp
+++ b/lib/NanoPbComm/src/GaggiMateClient.cpp
@@ -97,11 +97,19 @@ gm::Payload GaggiMateClient::buildTare() {
     return p;
 }
 
-gm::Payload GaggiMateClient::buildLedControl(uint8_t channel, uint8_t brightness) {
+gm::Payload GaggiMateClient::buildLedControl(const LedChannelCommand *channels, size_t count) {
     gm::Payload p = gaggimate_Payload_init_zero;
     p.which_content = gaggimate_Payload_led_tag;
-    p.content.led.channel = channel;
-    p.content.led.brightness = brightness;
+    const size_t maxCount = sizeof(p.content.led.channels) / sizeof(p.content.led.channels[0]);
+    if (channels == nullptr)
+        count = 0;
+    if (count > maxCount)
+        count = maxCount;
+    p.content.led.channels_count = static_cast<pb_size_t>(count);
+    for (size_t i = 0; i < count; i++) {
+        p.content.led.channels[i].channel = channels[i].channel;
+        p.content.led.channels[i].brightness = channels[i].brightness;
+    }
     return p;
 }
 
@@ -133,8 +141,8 @@ void GaggiMateClient::sendPressureScale(float scale) { _endpoint.send(buildPress
 
 void GaggiMateClient::tare() { _endpoint.send(buildTare()); }
 
-void GaggiMateClient::sendLedControl(uint8_t channel, uint8_t brightness) {
-    _endpoint.send(buildLedControl(channel, brightness));
+void GaggiMateClient::sendLedControl(const LedChannelCommand *channels, size_t count) {
+    _endpoint.send(buildLedControl(channels, count));
 }
 
 void GaggiMateClient::registerHandlers() {

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -60,7 +60,9 @@ class GaggiMateClient {
     gm::Payload buildAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     gm::Payload buildPressureScale(float scale);
     gm::Payload buildTare();
-    gm::Payload buildLedControl(uint8_t channel, uint8_t brightness);
+    // Pack channel/brightness pairs into one LedControl payload; entries beyond
+    // the schema's per-message cap (LedControl.channels max_count) are dropped.
+    gm::Payload buildLedControl(const LedChannelCommand *channels, size_t count);
 
     // Commands (display -> controller)
     void sendPing();
@@ -72,7 +74,9 @@ class GaggiMateClient {
     void sendAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     void sendPressureScale(float scale);
     void tare();
-    void sendLedControl(uint8_t channel, uint8_t brightness);
+    // Drive several LED channels in one message (avoids per-channel sends that
+    // the outbound queue would coalesce down to a single channel).
+    void sendLedControl(const LedChannelCommand *channels, size_t count);
 
     // Send a pre-built payload / batch of payloads (one frame). Compose batches
     // from build*() helpers -- e.g. the display's delta-based control update.

--- a/lib/NanoPbComm/src/GaggiMateComm.h
+++ b/lib/NanoPbComm/src/GaggiMateComm.h
@@ -46,6 +46,15 @@ struct RelayCommand {
     bool operator==(const RelayCommand &o) const { return index == o.index && open == o.open; }
     bool operator!=(const RelayCommand &o) const { return !(*this == o); }
 };
+// One LED output's target brightness. Several are packed into a single
+// LedControl message so a multi-channel update can't be split (and coalesced)
+// into separate frames.
+struct LedChannelCommand {
+    uint8_t channel = 0;
+    uint8_t brightness = 0;
+    bool operator==(const LedChannelCommand &o) const { return channel == o.channel && brightness == o.brightness; }
+    bool operator!=(const LedChannelCommand &o) const { return !(*this == o); }
+};
 
 // Error codes. Values match the gaggimate.ErrorCode enum and the codes the old
 // string protocol used, so existing firmware comparisons keep working.

--- a/lib/NanoPbComm/src/GaggiMateServer.cpp
+++ b/lib/NanoPbComm/src/GaggiMateServer.cpp
@@ -172,7 +172,11 @@ void GaggiMateServer::registerHandlers() {
             _tareCb();
     });
     _endpoint.on(gaggimate_Payload_led_tag, [this](const gm::Payload &p) {
-        if (_ledCb)
-            _ledCb(static_cast<uint8_t>(p.content.led.channel), static_cast<uint8_t>(p.content.led.brightness));
+        if (!_ledCb)
+            return;
+        // One message carries every changed channel; apply them in order.
+        for (pb_size_t i = 0; i < p.content.led.channels_count; i++)
+            _ledCb(static_cast<uint8_t>(p.content.led.channels[i].channel),
+                   static_cast<uint8_t>(p.content.led.channels[i].brightness));
     });
 }

--- a/lib/NanoPbComm/src/Messages.h
+++ b/lib/NanoPbComm/src/Messages.h
@@ -26,6 +26,7 @@ using PumpModelCoeffs = gaggimate_PumpModelCoeffs;
 using AutotuneRequest = gaggimate_AutotuneRequest;
 using PressureScale = gaggimate_PressureScale;
 using Tare = gaggimate_Tare;
+using LedChannel = gaggimate_LedChannel;
 using LedControl = gaggimate_LedControl;
 
 using DeviceCapabilities = gaggimate_Capabilities;

--- a/lib/NanoPbComm/src/Protocol.h
+++ b/lib/NanoPbComm/src/Protocol.h
@@ -21,7 +21,7 @@ static constexpr const char *INFO_CHAR_UUID = "f8d7203b-e00c-48e2-83ba-37ff49cdb
 // Protocol/schema version. Bump on any breaking change to gaggimate.proto so a
 // display talking to an out-of-date controller (or vice versa) can detect the
 // mismatch. Carried in SystemInfo.protocol_version.
-static constexpr uint32_t PROTOCOL_VERSION = 1;
+static constexpr uint32_t PROTOCOL_VERSION = 2;
 
 // Outbound priorities (higher wins in the queue).
 enum Priority : uint8_t {

--- a/src/display/plugins/LedControlPlugin.cpp
+++ b/src/display/plugins/LedControlPlugin.cpp
@@ -42,20 +42,17 @@ void LedControlPlugin::updateControl() {
 }
 
 void LedControlPlugin::sendControl(uint8_t r, uint8_t g, uint8_t b, uint8_t w, uint8_t ext) {
-    if (r != last_r)
-        this->controller->getClientController()->sendLedControl(0, r);
-    if (g != last_g)
-        this->controller->getClientController()->sendLedControl(1, g);
-    if (b != last_b)
-        this->controller->getClientController()->sendLedControl(2, b);
-    if (w != last_w)
-        this->controller->getClientController()->sendLedControl(3, w);
-    if (ext != last_ext) {
-        this->controller->getClientController()->sendLedControl(4, 255 - ext);
-        this->controller->getClientController()->sendLedControl(5, 255 - ext);
-        this->controller->getClientController()->sendLedControl(6, 255 - ext);
-        this->controller->getClientController()->sendLedControl(7, 255 - ext);
-    }
+    if (r == last_r && g == last_g && b == last_b && w == last_w && ext == last_ext)
+        return;
+
+    // Send every channel as one snapshot. A single message keeps the outbound
+    // coalescing queue from collapsing per-channel updates down to one channel.
+    const uint8_t extInv = 255 - ext;
+    const LedChannelCommand channels[] = {
+        {0, r}, {1, g}, {2, b}, {3, w}, {4, extInv}, {5, extInv}, {6, extInv}, {7, extInv},
+    };
+    this->controller->getClientController()->sendLedControl(channels, sizeof(channels) / sizeof(channels[0]));
+
     last_r = r;
     last_g = g;
     last_b = b;


### PR DESCRIPTION
## Problem

`LedControl` carried a single `channel`+`brightness`, and `LedControlPlugin::sendControl()` sent 4–8 of them back to back (one per changed RGB/W/ext channel). `gm_proto::coalescingKey()` has no `led` case, so every `led` payload shares the `default` coalescing key (device index 0). `Endpoint`'s `CoalescingPriorityQueue::upsert()` collapsed the whole burst to the **last** payload — only one channel ever reached the controller, so the Sunrise/status LED ring showed the wrong colour.

## Fix

Make `LedControl` carry a `repeated LedChannel` list so one frame drives every channel atomically — no per-channel burst for the queue to coalesce.

- **proto** (`gaggimate.proto`/`.options`): new nested `LedChannel { channel, brightness }`; `LedControl` → `repeated LedChannel channels`, capped `max_count:8` (PCA9634 outputs).
- **client** (`GaggiMateClient`): `buildLedControl`/`sendLedControl` take `(const LedChannelCommand*, size_t)` and pack one payload (entries beyond the cap are dropped). New `LedChannelCommand` POD in `GaggiMateComm.h`.
- **server** (`GaggiMateServer`): the `led` handler iterates `channels_count` and fires the existing per-channel `LedCallback` for each entry, so `GaggiMateController`'s `ledController->setChannel(...)` wiring is unchanged.
- **plugin** (`LedControlPlugin`): `sendControl` emits all 8 channels as one snapshot whenever any value changed.
- **version**: `gm_proto::PROTOCOL_VERSION` bumped 1 → 2 (breaking schema change). The existing mismatch detection + OTA-recovery path (GM-82) handles cross-version controller/display pairs.

## Testing

`platformio run -e controller -e display` → both **SUCCESS** (nanopb regenerates `gaggimate.pb.h` at build time, so the schema change compiled end-to-end against both firmwares).

Closes GM-86.

Linear: https://linear.app/gaggimate/issue/GM-86/led-control-coalescing-drops-all-but-one-channel-per-update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling multiple LED channels in a single atomic command (up to 8 channels per control message).

* **Breaking Changes**
  * Protocol version updated to version 2. Firmware and display must be synchronized to maintain compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->