### PR TITLE
feat(display): show protocol-version mismatch on standby screen [GM-87]

### DIFF
--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -159,7 +159,9 @@ void DefaultUI::init() {
         waitingForController = false;
         rerender = true;
         initialized = true;
-        if (lv_scr_act() == ui_StandbyScreen) {
+        // Stay on the standby screen when the controller is incompatible so the
+        // mismatch message remains visible instead of jumping into brew.
+        if (lv_scr_act() == ui_StandbyScreen && !controller->getSystemInfo().protocolMismatch) {
             Settings &settings = controller->getSettings();
             if (settings.getStartupMode() == MODE_BREW) {
                 changeScreen(&ui_BrewScreen, &ui_BrewScreen_screen_init);
@@ -192,6 +194,12 @@ void DefaultUI::init() {
         updateAvailable = event.getInt("value");
     });
     pluginManager->on("controller:error", [this](Event const &) {
+        rerender = true;
+        changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init);
+    });
+    pluginManager->on("controller:protocol:mismatch", [this](Event const &) {
+        // Incompatible firmware on the other end: control is inhibited (OTA only),
+        // so surface it on the standby screen like a runaway error.
         rerender = true;
         changeScreen(&ui_StandbyScreen, &ui_StandbyScreen_screen_init);
     });
@@ -249,6 +257,7 @@ void DefaultUI::loop() {
         rerender = false;
         lastRender = now;
         error = controller->isErrorState();
+        protocolMismatch = controller->getSystemInfo().protocolMismatch;
         autotuning = controller->isAutotuning();
         const Settings &settings = controller->getSettings();
         volumetricAvailable = controller->isVolumetricAvailable();
@@ -354,6 +363,7 @@ void DefaultUI::setupPanel() {
 
 void DefaultUI::setupState() {
     error = controller->isErrorState();
+    protocolMismatch = controller->getSystemInfo().protocolMismatch;
     autotuning = controller->isAutotuning();
     const Settings &settings = controller->getSettings();
     volumetricAvailable = controller->isVolumetricAvailable();
@@ -515,6 +525,8 @@ void DefaultUI::setupReactive() {
                               bool deactivated = true;
                               if (updateActive) {
                                   lv_label_set_text_fmt(ui_StandbyScreen_mainLabel, "Updating...");
+                              } else if (protocolMismatch) {
+                                  lv_label_set_text_fmt(ui_StandbyScreen_mainLabel, "Controller incompatible, please update");
                               } else if (error) {
                                   if (controller->getError() == ERROR_CODE_RUNAWAY) {
                                       lv_label_set_text_fmt(ui_StandbyScreen_mainLabel, "Temperature error, please restart");
@@ -530,7 +542,7 @@ void DefaultUI::setupReactive() {
                               _ui_flag_modify(ui_StandbyScreen_touchIcon, LV_OBJ_FLAG_HIDDEN, !deactivated);
                               _ui_flag_modify(ui_StandbyScreen_statusContainer, LV_OBJ_FLAG_HIDDEN, !deactivated);
                           },
-                          &updateAvailable, &error, &autotuning, &waitingForController, &initialized);
+                          &updateAvailable, &error, &protocolMismatch, &autotuning, &waitingForController, &initialized);
     effect_mgr.use_effect([=] { return currentScreen == ui_BrewScreen; },
                           [=]() {
                               if (brewVolumetric) {
@@ -724,8 +736,8 @@ void DefaultUI::updateStandbyScreen() {
         }
     }
 
-    if (!apActive && WiFi.status() == WL_CONNECTED && !updateActive && !error && !autotuning && !waitingForController &&
-        initialized) {
+    if (!apActive && WiFi.status() == WL_CONNECTED && !updateActive && !error && !protocolMismatch && !autotuning &&
+        !waitingForController && initialized) {
         time_t now;
         struct tm timeinfo;
 

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -94,6 +94,7 @@ class DefaultUI {
     int updateActive = false;
     int apActive = false;
     int error = false;
+    int protocolMismatch = false;
     int autotuning = false;
     int waitingForController = false;
     int volumetricAvailable = false;


### PR DESCRIPTION
## Problem

When the controller and display run incompatible protocol versions, `Controller::onSystemInfo()` sets `systemInfo.protocolMismatch`, inhibits control (OTA-only recovery — see GM-82), and fires `controller:protocol:mismatch`. But the display gave **no** indication: the standby screen showed the normal idle state, so the machine silently refused to run with no explanation.

## Fix

Surface the mismatch on the standby screen the same way thermal runaway already shows "Temperature error, please restart".

- New `protocolMismatch` UI flag mirrors `controller->getSystemInfo().protocolMismatch`, synced in the rerender block and `setupState()` — so it clears automatically once a compatible controller reconnects (e.g. after OTA recovery).
- Subscribe to `controller:protocol:mismatch` → force the standby screen + rerender (like the `controller:error` handler).
- Guard the `controller:bluetooth:connect` screen switch so a mismatch keeps the user on standby instead of jumping into brew.
- Standby effect shows **"Controller incompatible, please update"**, placed after `updateActive` ("Updating..." OTA recovery keeps priority) and before the runaway-error branch. Added `&protocolMismatch` to the effect's dependency list and to the standby-clock gate.

These edits are in `DefaultUI.cpp`/`.h` — the hand-written runtime UI glue where the existing error message lives, not SquareLine-generated output.

## Testing

`platformio run -e display` → **SUCCESS**.

Closes GM-87.

Linear: https://linear.app/gaggimate/issue/GM-87/show-protocol-version-mismatch-on-the-display-standby-screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added detection and messaging for controller protocol incompatibility. The system now displays an "incompatible, please update" message on the standby screen when a protocol mismatch is detected and prevents automatic transitions to brew mode until resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->