### PR TITLE
perf(web): serve content-hashed assets with immutable cache headers [GM-83]

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -242,7 +242,13 @@ void WebUIPlugin::setupServer() {
     });
     server.on("/api/core-dump", HTTP_GET, [this](AsyncWebServerRequest *request) { handleCoreDumpDownload(request); });
     server.onNotFound([](AsyncWebServerRequest *request) { request->send(SPIFFS, "/w/index.html"); });
-    server.serveStatic("/", SPIFFS, "/w").setDefaultFile("index.html").setCacheControl("max-age=0");
+    // Content-hashed build assets (Vite emits them under /assets/ with a hash in the filename) never change for a
+    // given URL, so let the browser cache them forever and skip the revalidation round-trip entirely. This must be
+    // registered before the catch-all "/" handler so it wins for /assets/* requests. [GM-83]
+    server.serveStatic("/assets/", SPIFFS, "/w/assets/").setCacheControl("public, max-age=31536000, immutable");
+    // index.html and other unhashed root files must stay revalidated so a new build (which references freshly
+    // hashed assets) is always picked up after an OTA/filesystem update.
+    server.serveStatic("/", SPIFFS, "/w").setDefaultFile("index.html").setCacheControl("no-cache");
     ws.onEvent(
         [this](AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len) {
             if (type == WS_EVT_CONNECT) {


### PR DESCRIPTION
## Problem

All static assets (JS/CSS) are served with `Cache-Control: max-age=0`, so the browser must revalidate every file on each load. ETag support avoids re-transmitting the ~300 KB bundle (a 304 instead of a full body), but each validation still costs a round-trip to the ESP32 — reported at ~700 ms total. (Fixes #727 / GM-83.)

## Change

Split the static handler in `WebUIPlugin::setupServer()`:

- **`/assets/*`** → `Cache-Control: public, max-age=31536000, immutable`. Vite emits every bundle file under `/assets/` with a content hash in the filename (`assets/[hash].js|css|...`, see `web/vite.config.js`), so the URL changes whenever the content changes. The browser can cache these forever and skip the validation round-trip entirely.
- **`/` (index.html + unhashed root files like `app.webmanifest`, `gm.svg`)** → `Cache-Control: no-cache` (revalidate), so a new build that references freshly hashed assets is always picked up after an OTA/filesystem update.

The `/assets/` handler is registered before the catch-all `/` handler so it takes precedence (AsyncStaticWebHandler matches in registration order). Cache-busting is safe because hashed filenames change per build.

## Validation

- `platformio run -e display` — succeeds (exit 0).
- Expected runtime behavior: `/assets/*` returns `200 (from disk/memory cache)` with no network request after first load; `index.html` still revalidates (304 when unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized web asset caching strategy for improved performance and faster loading times.
  * Ensured system updates are properly applied by maintaining cache revalidation for critical files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jniebuhr/gaggimate/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->