### PR TITLE
fix(comms): stop BLE client connecting to bogus addresses (GM-89)

### DIFF
--- a/lib/NanoPbComm/src/ble/BleClientTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.cpp
@@ -39,7 +39,7 @@ void BleClientTransport::maintain() {
 }
 
 bool BleClientTransport::connectToServer() {
-    if (_serverDevice == nullptr)
+    if (!_haveServerAddress)
         return false;
 
     ESP_LOGI(LOG_TAG, "Connecting to advertised device");
@@ -50,7 +50,7 @@ bool BleClientTransport::connectToServer() {
             scan();
             return false;
         }
-        if (!_client->connect(NimBLEAddress(_serverDevice->getAddress()))) {
+        if (!_client->connect(_serverAddress)) {
             ESP_LOGW(LOG_TAG, "Connect failed, retrying");
             delay(500);
         }
@@ -110,7 +110,7 @@ bool BleClientTransport::connectToServer() {
 
 void BleClientTransport::disconnect() {
     _readyForConnection = false;
-    _serverDevice = nullptr;
+    _haveServerAddress = false;
     if (_client && _client->isConnected())
         _client->disconnect();
 }
@@ -143,7 +143,10 @@ void BleClientTransport::onResult(NimBLEAdvertisedDevice *advertisedDevice) {
     if (advertisedDevice->isAdvertisingService(NimBLEUUID(gm_proto::SERVICE_UUID))) {
         ESP_LOGI(LOG_TAG, "Found controller, ready to connect");
         _scanner->stop();
-        _serverDevice = advertisedDevice;
+        // Take a value copy of the address now -- the device object is freed as
+        // soon as this callback returns (see _serverAddress note in the header).
+        _serverAddress = advertisedDevice->getAddress();
+        _haveServerAddress = true;
         _readyForConnection = true;
     }
 }

--- a/lib/NanoPbComm/src/ble/BleClientTransport.h
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.h
@@ -46,7 +46,15 @@ class BleClientTransport : public Transport, public NimBLEAdvertisedDeviceCallba
   private:
     NimBLEClient *_client = nullptr;
     NimBLEScan *_scanner = nullptr;
-    NimBLEAdvertisedDevice *_serverDevice = nullptr;
+    // Copy of the controller's address taken in onResult(). We must NOT keep the
+    // NimBLEAdvertisedDevice* itself: with setMaxResults(0) NimBLE deletes that
+    // object the moment onResult() returns (NimBLEScan erase()), so dereferencing
+    // it later in connectToServer() -- which runs on the main loop task -- is a
+    // use-after-free that reads whatever string now occupies the freed heap slot
+    // back as a bogus peer address. NimBLEAddress is a value type, so copying it
+    // while the device is still alive is safe and survives the deletion.
+    NimBLEAddress _serverAddress{};
+    bool _haveServerAddress = false;
     NimBLERemoteCharacteristic *_writeChar = nullptr;  // to server (RX_CHAR_UUID)
     NimBLERemoteCharacteristic *_notifyChar = nullptr; // from server (TX_CHAR_UUID)
     bool _readyForConnection = false;


### PR DESCRIPTION
## Summary

Fixes the display repeatedly losing its BLE link to the controller (`status=574`, "Controller not available"), where the serial log shows attempts to connect to garbage MAC addresses such as `2d:31:2e:38:2e:31`, `4d:69:67:67:61:47`, `74:70:65:63:63:41`.

## Root cause — use-after-free

`BleClientTransport` runs the scanner with `setMaxResults(0)`. In NimBLE-Arduino that means "don't retain results": the `NimBLEAdvertisedDevice` passed to `onResult()` is **deleted the moment the callback returns** (`NimBLEScan` calls `erase()` → `delete`).

`onResult()` stored that pointer (`_serverDevice = advertisedDevice`) and `connectToServer()` — invoked later from the **main loop task** — dereferenced it via `_serverDevice->getAddress()`. By then the object is freed, so the 6 address bytes come from whatever allocation reused the heap slot. Decoding the reported "MACs" (NimBLE prints addresses MSB-first, the reverse of memory order) confirms it exactly:

| Logged "MAC" | Reversed bytes | Source |
|---|---|---|
| `2d:31:2e:38:2e:31` | `1.8.1-` | firmware version string |
| `4d:69:67:67:61:47` | `GaggiM` | BLE device name `"GaggiMate"` |
| `74:70:65:63:63:41` | `Accept` | HTTP `Accept` request header (web server) |

Three unrelated subsystems landing in the freed slot is the signature of a use-after-free on the shared heap. It's intermittent because early on the freed slot often isn't reused before the connect runs (stale-but-correct address); as heap churn grows the slot is reclaimed sooner — hence "fine for ~a week, then breaks."

This same pattern existed verbatim in the pre-rewrite `NimBLEClientController` (`setMaxResults(0)` + stored `serverDevice` + `connect(serverDevice->getAddress())`), which is why it reproduces identically on **v1.8.1** and on **master**.

## Fix

`NimBLEAddress` is a plain value type (6-byte array + type). Take a value copy of the address in `onResult()` while the device is still alive, and connect with that copy instead of holding the device pointer. A `bool _haveServerAddress` replaces the old null-pointer gate.

Minimal and self-contained — independent of the larger esp-nimble-cpp migration (#681).

## Testing

- [x] `platformio run -e display` builds and links cleanly.
- [ ] On-device soak: connection stays up; no bogus-address connect attempts in serial log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Bluetooth device discovery and connection handling to prevent intermittent connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->