### PR TITLE
fix: SD shot parsing + HTTP throughput/fragmentation + Arduino-baseline Kconfig restore (supersedes #743)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -76,6 +76,10 @@ lib_deps_default =
 ; gaggimate.pb.{c,h} from the .proto at build time; the component_remove list
 ; strips managed components we never use to cut first-build time + flash.
 [idf_common]
+extra_scripts =
+	pre:scripts/auto_firmware_version.py
+	pre:scripts/pioarduino_env.py
+	post:scripts/assert_sdkconfig.py
 custom_nanopb_protos =
 	+<lib/NanoPbComm/proto/gaggimate.proto>
 custom_nanopb_options =
@@ -110,10 +114,7 @@ custom_nanopb_protos = ${idf_common.custom_nanopb_protos}
 custom_nanopb_options = ${idf_common.custom_nanopb_options}
 lib_ignore = ${idf_common.lib_ignore}
 custom_component_remove = ${idf_common.custom_component_remove}
-extra_scripts =
-	pre:scripts/auto_firmware_version.py
-	pre:scripts/pioarduino_env.py
-	post:scripts/assert_sdkconfig.py
+extra_scripts = ${idf_common.extra_scripts}
 lib_deps =
 	${display_common.lib_deps_default}
 	lewisxhe/SensorLib @ 0.2.3
@@ -149,10 +150,7 @@ lib_ignore = ${idf_common.lib_ignore}
 custom_component_remove =
 	${idf_common.custom_component_remove}
 	espressif/libsodium
-extra_scripts =
-	pre:scripts/auto_firmware_version.py
-	pre:scripts/pioarduino_env.py
-	post:scripts/assert_sdkconfig.py
+extra_scripts = ${idf_common.extra_scripts}
 lib_deps =
 	GaggiMateController
 	FS

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,6 +113,7 @@ custom_component_remove = ${idf_common.custom_component_remove}
 extra_scripts =
 	pre:scripts/auto_firmware_version.py
 	pre:scripts/pioarduino_env.py
+	post:scripts/assert_sdkconfig.py
 lib_deps =
 	${display_common.lib_deps_default}
 	lewisxhe/SensorLib @ 0.2.3
@@ -151,6 +152,7 @@ custom_component_remove =
 extra_scripts =
 	pre:scripts/auto_firmware_version.py
 	pre:scripts/pioarduino_env.py
+	post:scripts/assert_sdkconfig.py
 lib_deps =
 	GaggiMateController
 	FS

--- a/scripts/assert_sdkconfig.py
+++ b/scripts/assert_sdkconfig.py
@@ -25,6 +25,18 @@ REQUIRED = [
         "Set CONFIG_FATFS_LFN_HEAP=y + CONFIG_FATFS_MAX_LFN=255 in "
         "sdkconfig.common.defaults, then `pio run -e <env> -t fullclean`.",
     ),
+    (
+        "CPU at 240 MHz (IDF default 160 MHz leaks through if unpinned)",
+        lambda t: "#define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ 240" in t,
+        "Set CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y in sdkconfig.common.defaults, "
+        "delete the cached sdkconfig.<env>, then rebuild.",
+    ),
+    (
+        "Compiler optimization = SIZE (-Os), not the slower IDF default -Og",
+        lambda t: "#define CONFIG_COMPILER_OPTIMIZATION_SIZE 1" in t,
+        "Set CONFIG_COMPILER_OPTIMIZATION_SIZE=y in sdkconfig.common.defaults, "
+        "then `pio run -e <env> -t fullclean`.",
+    ),
 ]
 
 

--- a/scripts/assert_sdkconfig.py
+++ b/scripts/assert_sdkconfig.py
@@ -60,7 +60,7 @@ def assert_sdkconfig(*_args, **_kwargs):
         print(f"  (checked {sdkconfig_h})\n")
         env.Exit(1)
     else:
-        print("sdkconfig guard: OK (%d invariant(s) satisfied)" % len(REQUIRED))
+        print(f"sdkconfig guard: OK ({len(REQUIRED)} invariant(s) satisfied)")
 
 
 # Run after the firmware ELF is built, so the merged sdkconfig.h exists.

--- a/scripts/assert_sdkconfig.py
+++ b/scripts/assert_sdkconfig.py
@@ -1,0 +1,55 @@
+# ruff: noqa: F821 — `env` is injected by PlatformIO/SCons at runtime
+#
+# Post-build guard against silent sdkconfig drift.
+#
+# The dual-framework (pioarduino) build compiles ESP-IDF from source, so any
+# config we don't pin in sdkconfig.*.defaults falls back to IDF's Kconfig
+# default — which differs from the prebuilt sdkconfig the old pure-Arduino build
+# used. That bit us once already: IDF 5.5 defaults FATFS to LFN_NONE (8.3 names
+# only), which made SD-card files with 4-char extensions (".slog"/".json")
+# unreadable and broke shot loading in the web UI ("Bad magic"). This guard
+# fails the build if a required invariant regresses, so the class can't ship
+# again unnoticed. Add new invariants to REQUIRED below as they're discovered.
+import os
+
+Import("env")
+
+# Each entry: (human description, predicate(text) -> bool, remediation hint).
+# `text` is the merged sdkconfig.h emitted into the build's config/ dir.
+REQUIRED = [
+    (
+        "FATFS long filenames enabled (LFN_HEAP or LFN_STACK; NOT LFN_NONE)",
+        lambda t: ("#define CONFIG_FATFS_LFN_HEAP 1" in t
+                   or "#define CONFIG_FATFS_LFN_STACK 1" in t)
+        and "#define CONFIG_FATFS_LFN_NONE 1" not in t,
+        "Set CONFIG_FATFS_LFN_HEAP=y + CONFIG_FATFS_MAX_LFN=255 in "
+        "sdkconfig.common.defaults, then `pio run -e <env> -t fullclean`.",
+    ),
+]
+
+
+def assert_sdkconfig(*_args, **_kwargs):
+    sdkconfig_h = os.path.join(env.subst("$BUILD_DIR"), "config", "sdkconfig.h")
+    if not os.path.isfile(sdkconfig_h):
+        # No merged config (e.g. native env) — nothing to assert.
+        return
+    with open(sdkconfig_h, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+
+    failures = []
+    for desc, predicate, hint in REQUIRED:
+        if not predicate(text):
+            failures.append((desc, hint))
+
+    if failures:
+        print("\n*** sdkconfig guard FAILED — merged config violates required invariants:")
+        for desc, hint in failures:
+            print(f"  - {desc}\n      fix: {hint}")
+        print(f"  (checked {sdkconfig_h})\n")
+        env.Exit(1)
+    else:
+        print("sdkconfig guard: OK (%d invariant(s) satisfied)" % len(REQUIRED))
+
+
+# Run after the firmware ELF is built, so the merged sdkconfig.h exists.
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", assert_sdkconfig)

--- a/sdkconfig.common.defaults
+++ b/sdkconfig.common.defaults
@@ -66,14 +66,56 @@ CONFIG_MBEDTLS_KEY_EXCHANGE_RSA_PSK=y
 # --- Task WDT ---
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=n
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n
+# Arduino sets PANIC=y so WDT trips invoke the panic handler -> clean reboot
+# + coredump. IDF default is n: WDT silently logs and the offending task can
+# soft-wedge until manual power-cycle. Prefer auto-reboot for async_tcp WDT
+# (Bug #3 hot path) and any other task that misses its deadline.
+CONFIG_ESP_TASK_WDT_PANIC=y
 
 # --- FreeRTOS ---
 CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=y
 CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH=y
+# Hardware watchpoint on the bottom of each task stack — traps overflow at
+# the moment it happens instead of letting it corrupt the next allocation.
+# Arduino-prebuilt has this on; IDF default is n.
+CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y
+# FreeRTOS software-timer task stack. Arduino: 3120. IDF default: 2048 (the
+# Kconfig minimum). Restore Arduino's headroom — anything dispatched via
+# xTimerCreate runs on this stack.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3120
 
 # --- Stacks ---
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+# esp_timer high-resolution timer task dispatches every esp_timer_create
+# callback (Wi-Fi, BT, our brew/grind state machines). Arduino: 8192. IDF
+# default: 3584 (right at the Kconfig minimum). Restore Arduino's value.
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=8192
+
+# --- Stack-overflow + heap diagnostics ---
+# GCC -fstack-protector. Arduino has it on; IDF default is none. Cheap
+# overflow detection at function entry.
+CONFIG_COMPILER_STACK_CHECK_MODE_NORM=y
+CONFIG_COMPILER_STACK_CHECK=y
+# Canary bytes around each heap allocation; small overflows / use-after-free
+# trap at free() with a clean abort + trace instead of silently corrupting
+# downstream allocations. Negligible cost.
+CONFIG_HEAP_POISONING_LIGHT=y
+
+# --- lwIP TCP/IP task ---
+# Arduino: pinned to CPU0 (0x0). IDF default: NO_AFFINITY (any core), which
+# lets the task drift across cores and pay cross-core IPC on every callback,
+# or contend with NimBLE for core 0 cycles. We pin AsyncTCP + NimBLE to core
+# 0 via build_flags; make lwIP match.
+CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU0=y
+# Stack of the lwIP TCP/IP task. Arduino: 4096. IDF default: 3072. The IDF
+# Kconfig itself notes that at LOG_DEFAULT_LEVEL >= INFO (we use INFO) the
+# stack needs more headroom: "esp_netif API calls can end up a few calls
+# deep and logging there can trigger a stack overflow."
+CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=4096
+# Hard cap on simultaneous sockets. Arduino: 16. IDF default: 10. AsyncWebServer
+# (HTTP+WS) + HomeKit + MQTT + mDNS + OTA can hit 10 under load.
+CONFIG_LWIP_MAX_SOCKETS=16
 
 # --- Logging ---
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y

--- a/sdkconfig.common.defaults
+++ b/sdkconfig.common.defaults
@@ -2,13 +2,30 @@
 # Applied as the first entry in SDKCONFIG_DEFAULTS; env-specific files follow
 # and override only what differs (MAX_CONNECTIONS, LWIP, nano-newlib).
 #
-# Workflow: pioarduino caches a merged sdkconfig.<env> at project root and
-# reuses it on subsequent builds. Edits to any .defaults file don't propagate
-# until that per-env file is regenerated. After editing, run:
-#   pio run -e <env> -t fullclean
+# Workflow: pioarduino caches a merged sdkconfig.<env> at project root (it is
+# gitignored). ESP-IDF applies these .defaults ONLY when generating a fresh
+# sdkconfig.<env>; if the cache already exists it is reused verbatim and your
+# .defaults edits are silently ignored. `-t fullclean` does NOT regenerate it.
+# After editing any .defaults file you MUST delete the cache, then rebuild:
+#   rm -f sdkconfig.<env> && pio run -e <env>
 # else the build ignores your change and you will chase ghosts.
 
 CONFIG_IDF_TARGET="esp32s3"
+
+# --- CPU clock ---
+# Run at full 240 MHz. board.json declares f_cpu=240 MHz, but that does NOT set
+# the IDF Kconfig CPU freq in a dual-framework build — so the unpinned default
+# (160 MHz) was leaking through, a ~33% clock cut behind the uniform HTTP
+# slowdown (all endpoints ~-34% req/s vs the arduino build). 240 MHz is the
+# ESP32-S3 rated max and what arduino Nightly 77 ran on this exact board.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
+
+# --- Compiler optimization ---
+# Optimize for size (-Os), matching arduino-esp32. IDF's default is -Og (debug),
+# which is slower across the board. SIZE (not PERF/-O2) keeps flash/IRAM in
+# budget while restoring baseline performance.
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 
 # PSRAM config lives in sdkconfig.gaggimate.defaults — only the display-class
 # boards (LilyGo-T-RGB, seeed_xiao_esp32s3) have PSRAM. The Gaggimate-Controller

--- a/sdkconfig.common.defaults
+++ b/sdkconfig.common.defaults
@@ -78,3 +78,18 @@ CONFIG_ARDUINO_SELECTIVE_OpenThread=n
 CONFIG_ARDUINO_SELECTIVE_SimpleBLE=n
 # Arduino's cores/esp32/main.cpp only defines app_main when =y; src/ has no app_main.
 CONFIG_AUTOSTART_ARDUINO=y
+
+# --- FATFS (SD card) long filenames ---
+# IDF 5.5's Kconfig default is LFN_NONE (8.3 names only). Under that default,
+# 4-char extensions like ".slog"/".json" cannot be opened or listed on the SD
+# card, so /api/history/<id>.slog GETs miss serveStatic and fall through to the
+# SPA catch-all that returns index.html — the web UI then fails parsing with
+# "Bad magic: ... got 0x6f64213c" (the bytes "<!do"). The old pure-Arduino build
+# inherited arduino-esp32's prebuilt sdkconfig where LFN was enabled; the
+# dual-framework build compiles IDF from source and lost it. Restore it.
+# HEAP allocation keeps the LFN work buffer off the async webserver task stack
+# (internal DRAM is tight). UTF-8 + codepage 850 match the arduino-esp32 config.
+CONFIG_FATFS_LFN_HEAP=y
+CONFIG_FATFS_MAX_LFN=255
+CONFIG_FATFS_API_ENCODING_UTF_8=y
+CONFIG_FATFS_CODEPAGE_850=y

--- a/sdkconfig.gaggimate.defaults
+++ b/sdkconfig.gaggimate.defaults
@@ -14,7 +14,12 @@ CONFIG_SPIRAM_TYPE_AUTO=y
 CONFIG_SPIRAM_BOOT_INIT=y
 CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y
 CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y
-CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=512
+# Threshold below which allocations are forced into internal DRAM. arduino-esp32
+# baseline is 4096; we had dropped it to 512, which pushed mid-size (512-4096 B)
+# allocations to PSRAM and left internal DRAM shattered into tiny blocks —
+# startup fragmentation (1 - largest_free/total_free) ballooned 15% -> 64%,
+# starving contiguous internal allocs AsyncTCP needs to serve. Restore 4096.
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096
 CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=16384
 
 # Route NimBLE host + mbedTLS allocations to PSRAM (reclaims ~40 KB internal).

--- a/sdkconfig.gaggimate.defaults
+++ b/sdkconfig.gaggimate.defaults
@@ -71,3 +71,9 @@ CONFIG_COMPILER_CXX_EXCEPTIONS=y
 # framebuffer head every frame, so any desync clears on the next refresh.
 # See components/esp_lcd/rgb/esp_lcd_panel_rgb.c — lcd_rgb_panel_try_restart_transmission().
 CONFIG_LCD_RGB_RESTART_IN_VSYNC=y
+
+# --- NimBLE bond persistence ---
+# IDF Kconfig help: "Enable this flag to make bonding persistent across
+# device reboots." Arduino-prebuilt has it on; IDF default is n. Without
+# it, every paired BLE peer (scale, HomeKit phone) re-pairs on every boot.
+CONFIG_BT_NIMBLE_NVS_PERSIST=y

--- a/sdkconfig.gaggimate.defaults
+++ b/sdkconfig.gaggimate.defaults
@@ -59,3 +59,15 @@ CONFIG_LIBC_NEWLIB_NANO_FORMAT=n
 # with exceptions on, so the display class enables them here. Controller env
 # does not link the scales lib and stays -fno-exceptions.
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
+
+# --- RGB LCD: restart GDMA at every VBlank ---
+# Arduino's precompiled libs set this implicitly; the dual-framework build
+# would otherwise inherit the IDF default (n) and lose the protection.
+# Without it, a single PSRAM-bus contention event (WiFi/BT alloc, TLS
+# handshake, big WS payload) can desync LCD_CAM's pixel pointer from the
+# panel's HSYNC and PERMANENTLY shift the image until reboot — IDF docs
+# call this out as "permanently shifted image". Resetting the GDMA channel
+# at VSYNC_END (the start of VBlank) restarts the DMA stream from the
+# framebuffer head every frame, so any desync clears on the next refresh.
+# See components/esp_lcd/rgb/esp_lcd_panel_rgb.c — lcd_rgb_panel_try_restart_transmission().
+CONFIG_LCD_RGB_RESTART_IN_VSYNC=y


### PR DESCRIPTION
Fixes a cluster of regressions on `feature/pioarduino-move` vs the old pure-Arduino build. Common root cause: the **dual-framework pioarduino build compiles ESP-IDF from source and inherits IDF Kconfig defaults for anything not pinned in our `sdkconfig.*.defaults`** — which differ from the prebuilt sdkconfig arduino-esp32 shipped. Confirmed by diffing the merged `sdkconfig.h` against `framework-arduinoespressif32-libs/esp32s3/sdkconfig`.

> **Now includes #743.** The two commits from #743 (Dave / @centercirclesolutions) are cherry-picked in here with his authorship preserved, and the duplicate `CPU_FREQ_MHZ_240` pin resolved. #743's author is OK with folding it in; **#743 can be closed in favor of this PR.** See the "Folded in from #743" section below.

## How these were diagnosed (vs `master`)

`master` builds pure-Arduino (`platform = espressif32@6.12.0`), so its effective config is **arduino-esp32's prebuilt** `framework-arduinoespressif32-libs/esp32s3/sdkconfig`. This branch builds dual-framework pioarduino, which **compiles ESP-IDF from source and re-derives sdkconfig from Kconfig defaults**, only overlaying our `sdkconfig.*.defaults`. Every bug here is a value that master got from the prebuilt config but that we never pinned — so IDF's default silently won.

| Kconfig symbol | `master` (arduino prebuilt, good) | this branch before fix (IDF default) |
|---|---|---|
| FATFS long filenames | `LFN_STACK` + `MAX_LFN=255` | **`LFN_NONE`** |
| `ESP_DEFAULT_CPU_FREQ_MHZ` | `240` | **`160`** |
| Compiler optimization | `OPTIMIZATION_SIZE` (`-Os`) | **`OPTIMIZATION_DEBUG`** (`-Og`) |
| `SPIRAM_MALLOC_ALWAYSINTERNAL` | `4096` | **`512`** (our own override) |

## Bug 1 — shot files won't parse (`Bad magic: ... got 0x6f64213c`)

`0x6f64213c` LE = `<!do` → the server returned `index.html` instead of the binary shot. IDF defaults FATFS to **`LFN_NONE`** (8.3 names only); arduino had LFN enabled. `.slog`/`.json` are 4-char extensions → need VFAT long names. `index.bin` (8.3) worked, so the shot *list* loaded but individual shots fell through to the SPA catch-all.

**Fix:** `CONFIG_FATFS_LFN_HEAP=y` + `MAX_LFN=255` + UTF-8/codepage 850 (matches arduino).

## Bug 2 — HTTP ~34% slower + heap fragmentation 15% → 64%

`wrk` (pioarduino vs Nightly 77):

| Metric | Nightly 77 (good) | pioarduino (broken) |
|---|---|---|
| Startup internal-heap fragmentation | 15.4 % | 64 % |
| `GET /` (SPIFFS) | 44 req/s | 29 req/s |
| `GET /api/settings` | 40 req/s | 24–27 req/s |
| `GET /api/history/<id>.slog` | 8.6 req/s | ~0.4 req/s, all timeouts |

- **CPU @ 160 MHz, not 240.** `board.json`'s `f_cpu` does not set the IDF Kconfig in a dual-framework build; the unpinned default (160) leaked through — a -33 % clock cut ≈ the uniform throughput loss. **Fix:** `CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y`.
- **Compiler `-Og` (IDF debug default), not `-Os`.** **Fix:** `CONFIG_COMPILER_OPTIMIZATION_SIZE=y` (matches arduino).
- **`SPIRAM_MALLOC_ALWAYSINTERNAL=512`** (arduino baseline 4096) shattered internal DRAM into tiny blocks → 64 % fragmentation, starving the contiguous internal allocs AsyncTCP needs to serve. **Fix:** restore `4096`.
- The `.slog` timeouts under load are Bug 1 — resolved by the LFN fix.

**Ruled out:** `SPIRAM_MODE_OCT` is correct (board is `psram_type: opi`); `ASYNC_TCP_RUNNING_CORE=0` identical on master; `WIFI_LWIP`-in-PSRAM already A/B'd (no effect).

## Folded in from #743 (Dave / @centercirclesolutions)

Same root cause — Arduino-baseline Kconfig flags the dual-framework move dropped. Cherry-picked verbatim (authorship preserved); the duplicate CPU-240 pin was de-duped during the cherry-pick.

- **`CONFIG_LCD_RGB_RESTART_IN_VSYNC=y`** — fixes the HW-observed "permanently shifted image" on a Pro after ~16 h uptime (RGB panel desync on a PSRAM-bus contention event). Restarts GDMA at VBlank so any desync clears next refresh.
- **`ESP_TASK_WDT_PANIC=y`** — WDT trips reboot+coredump instead of soft-wedging.
- **Stack-overflow + heap diagnostics** — `FREERTOS_WATCHPOINT_END_OF_STACK`, `COMPILER_STACK_CHECK_MODE_NORM`, `HEAP_POISONING_LIGHT`.
- **Task stacks** — `ESP_TIMER_TASK_STACK_SIZE=8192`, `FREERTOS_TIMER_TASK_STACK_DEPTH=3120`.
- **lwIP** — `LWIP_TCPIP_TASK_STACK_SIZE=4096`, `LWIP_MAX_SOCKETS=16`, `LWIP_TCPIP_TASK_AFFINITY_CPU0`.
- **`BT_NIMBLE_NVS_PERSIST=y`** (display) — BLE bonds survive reboot (scale + HomeKit no longer re-pair each boot).

## Hardware soak — #743-derived flags (Pro Rev 1.0, LilyGo T-RGB)

A two-phase soak on a **Pro Rev 1.0 (LilyGo T-RGB)** validated the **#743-derived flag set plus the shared 240 MHz pin**. Note the build under test did **not** include this PR's FATFS-LFN, `-Os`, or `ALWAYSINTERNAL=4096` fixes — scope is called out below.

- **15.5 h idle + 2 h active UI** (12 cron-fired full page sweeps): **0 reboots, 0 panics/WDT, 0 ping timeouts, 0 controller error-states**; 4 benign BLE re-associations (~1 / 4 h, all recovered).
- **CPU 240 MHz confirmed** — boot banner `cpu_start: cpu freq: 240000000 Hz`; prior boots in the same log read 160 MHz, isolating the regression to the Kconfig drop and the fix to the explicit pin.
- **LCD VSYNC fix confirmed** — beat the original ~16 h image-shift window with all failure conditions present (PSRAM framebuffer, no bounce buffer, live WiFi/BT); dial centred, no shift/clipping (visual).
- **Heap flat** — idle samples bit-identical across 10 h; under active sweep `min` (23,679 B) and `largest` (18,420 B) byte-stable across all 12 iterations → no leak, no fragmentation creep.
- Heap/stack diagnostics (light poisoning + canaries + FreeRTOS watchpoint) active in the merged config; no corruption surfaced.

**Corroborates Bug 2's premise:** the soak independently measured internal-heap fragmentation (`1 - largest/total`) at **0.56 idle / 0.68 active** on the **unfixed `ALWAYSINTERNAL=512`** build — same metric and same ballpark as this PR's "~64 %". Stable-but-high; this PR's `ALWAYSINTERNAL=4096` fix targets lowering it and remains to be measured on HW.

**Soak scope — NOT covered:** this PR's FATFS-LFN ("Bad magic"), `-Os`, and `ALWAYSINTERNAL=4096` fixes (absent from the build); HTTP throughput under `wrk`; brew/steam/grind, OTA, and BLE bond-persistence-across-reboot (config-present, not exercised). `ESP_TASK_WDT_PANIC=y` is wired and visible at boot but never fired (no task hung).

## Regression guard

`scripts/assert_sdkconfig.py` — a post-build assertion (wired into `display` + `controller`) that **fails the build** if the merged config drifts back to IDF defaults. Asserts: LFN enabled (not `LFN_NONE`), CPU 240 MHz, `-Os`. (Note: the merged `sdkconfig.<env>` is gitignored; `-t fullclean` does NOT regenerate it — delete it to re-merge `.defaults` edits.)

## Local verification (both envs, fresh merge of all 4 commits)
- `display` ✅ SUCCESS, guard OK (3 invariants).
- `controller` ✅ SUCCESS, guard OK (3 invariants).

## Hardware verification

**Confirmed by the soak** (#743-derived flags + the shared 240 MHz pin):
- [x] 240 MHz boots clean on the T-RGB display (Pro Rev 1.0; stable 15.5 h idle + 2 h active). Controller flashed from the same tree — 0 ping timeouts / error-states across the window.
- [x] (#743) `LCD_RGB_RESTART_IN_VSYNC` clears the long-uptime image-shift (beat ~16 h with all failure conditions present; visual clean).
- [x] Stack/heap diagnostics active and no corruption over the full window.
- `ESP_TASK_WDT_PANIC=y` — wired and visible at boot, but **not triggered** (no task hung during the soak).

**Still open — this PR's own fixes were NOT in the soak build:**
- [ ] Open a shot → graph loads, **no "Bad magic"**. `curl .../api/history/<id>.slog | xxd | head` → first bytes `53 48 4f 54` (`SHOT`). *(FATFS LFN)*
- [ ] Re-run `wrk -t1 -c3 -d60s` on `/`, `/api/settings`, `/api/history/<id>.slog`; expect `/` and `/api/settings` near Nightly-77 (~44 / ~40 req/s), `.slog` serving (no timeouts). *(`-Os` + CPU)*
- [ ] Report **fragmentation %** (expect below the soak's 0.56 idle) and **free internal heap** — confirm `ALWAYSINTERNAL=4096` lowers fragmentation without reintroducing BLE_INIT / low-heap failures.

Co-Authored-By: Claude Code <noreply@anthropic.com>

