### PR TITLE
fix(sdkconfig): restore Arduino-baseline Kconfig defaults dropped on the dual-framework move

### DIFF
--- a/sdkconfig.common.defaults
+++ b/sdkconfig.common.defaults
@@ -46,17 +46,68 @@ CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_RSA_PSK=y
 
+# --- CPU clock ---
+# Arduino's precompiled libs default to 240 MHz; the IDF default that the
+# dual-framework build otherwise inherits is 160 MHz — a 33% perf regression
+# across every CPU-bound path (web UI, BLE handshake, JSON parsing, TLS,
+# profile load, LVGL render). Confirmed in boot log on the unfixed build:
+# `cpu freq: 160000000 Hz`. Restore the 240 MHz baseline.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
+
 # --- Task WDT ---
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=n
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n
+# Arduino sets PANIC=y so WDT trips invoke the panic handler -> clean reboot
+# + coredump. IDF default is n: WDT silently logs and the offending task can
+# soft-wedge until manual power-cycle. Prefer auto-reboot for async_tcp WDT
+# (Bug #3 hot path) and any other task that misses its deadline.
+CONFIG_ESP_TASK_WDT_PANIC=y
 
 # --- FreeRTOS ---
 CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=y
 CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH=y
+# Hardware watchpoint on the bottom of each task stack — traps overflow at
+# the moment it happens instead of letting it corrupt the next allocation.
+# Arduino-prebuilt has this on; IDF default is n.
+CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y
+# FreeRTOS software-timer task stack. Arduino: 3120. IDF default: 2048 (the
+# Kconfig minimum). Restore Arduino's headroom — anything dispatched via
+# xTimerCreate runs on this stack.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3120
 
 # --- Stacks ---
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+# esp_timer high-resolution timer task dispatches every esp_timer_create
+# callback (Wi-Fi, BT, our brew/grind state machines). Arduino: 8192. IDF
+# default: 3584 (right at the Kconfig minimum). Restore Arduino's value.
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=8192
+
+# --- Stack-overflow + heap diagnostics ---
+# GCC -fstack-protector. Arduino has it on; IDF default is none. Cheap
+# overflow detection at function entry.
+CONFIG_COMPILER_STACK_CHECK_MODE_NORM=y
+CONFIG_COMPILER_STACK_CHECK=y
+# Canary bytes around each heap allocation; small overflows / use-after-free
+# trap at free() with a clean abort + trace instead of silently corrupting
+# downstream allocations. Negligible cost.
+CONFIG_HEAP_POISONING_LIGHT=y
+
+# --- lwIP TCP/IP task ---
+# Arduino: pinned to CPU0 (0x0). IDF default: NO_AFFINITY (any core), which
+# lets the task drift across cores and pay cross-core IPC on every callback,
+# or contend with NimBLE for core 0 cycles. We pin AsyncTCP + NimBLE to core
+# 0 via build_flags; make lwIP match.
+CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU0=y
+# Stack of the lwIP TCP/IP task. Arduino: 4096. IDF default: 3072. The IDF
+# Kconfig itself notes that at LOG_DEFAULT_LEVEL >= INFO (we use INFO) the
+# stack needs more headroom: "esp_netif API calls can end up a few calls
+# deep and logging there can trigger a stack overflow."
+CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=4096
+# Hard cap on simultaneous sockets. Arduino: 16. IDF default: 10. AsyncWebServer
+# (HTTP+WS) + HomeKit + MQTT + mDNS + OTA can hit 10 under load.
+CONFIG_LWIP_MAX_SOCKETS=16
 
 # --- Logging ---
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y

--- a/sdkconfig.gaggimate.defaults
+++ b/sdkconfig.gaggimate.defaults
@@ -54,3 +54,15 @@ CONFIG_LIBC_NEWLIB_NANO_FORMAT=n
 # with exceptions on, so the display class enables them here. Controller env
 # does not link the scales lib and stays -fno-exceptions.
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
+
+# --- RGB LCD: restart GDMA at every VBlank ---
+# Arduino's precompiled libs set this implicitly; the dual-framework build
+# would otherwise inherit the IDF default (n) and lose the protection.
+# Without it, a single PSRAM-bus contention event (WiFi/BT alloc, TLS
+# handshake, big WS payload) can desync LCD_CAM's pixel pointer from the
+# panel's HSYNC and PERMANENTLY shift the image until reboot — IDF docs
+# call this out as "permanently shifted image". Resetting the GDMA channel
+# at VSYNC_END (the start of VBlank) restarts the DMA stream from the
+# framebuffer head every frame, so any desync clears on the next refresh.
+# See components/esp_lcd/rgb/esp_lcd_panel_rgb.c — lcd_rgb_panel_try_restart_transmission().
+CONFIG_LCD_RGB_RESTART_IN_VSYNC=y

--- a/sdkconfig.gaggimate.defaults
+++ b/sdkconfig.gaggimate.defaults
@@ -66,3 +66,9 @@ CONFIG_COMPILER_CXX_EXCEPTIONS=y
 # framebuffer head every frame, so any desync clears on the next refresh.
 # See components/esp_lcd/rgb/esp_lcd_panel_rgb.c — lcd_rgb_panel_try_restart_transmission().
 CONFIG_LCD_RGB_RESTART_IN_VSYNC=y
+
+# --- NimBLE bond persistence ---
+# IDF Kconfig help: "Enable this flag to make bonding persistent across
+# device reboots." Arduino-prebuilt has it on; IDF default is n. Without
+# it, every paired BLE peer (scale, HomeKit phone) re-pairs on every boot.
+CONFIG_BT_NIMBLE_NVS_PERSIST=y


### PR DESCRIPTION
## Summary

The dual-framework move replaced the precompiled `framework-arduinoespressif32-libs` with our own sdkconfig defaults, where the IDF Kconfig defaults take over for any flag we didn't explicitly carry forward. Several of those flips are silently user-visible. This PR restores the Arduino-baseline values.

Two commits:

1. `CONFIG_LCD_RGB_RESTART_IN_VSYNC=y` — fixes the "permanently shifted image" failure mode HW-observed on a Pro after ~16 h uptime ([ESP-IDF docs](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/peripherals/lcd/rgb_lcd.html); IDF source `components/esp_lcd/rgb/esp_lcd_panel_rgb.c → lcd_rgb_panel_try_restart_transmission()`).

2. `sdkconfig.common.defaults` and `sdkconfig.gaggimate.defaults` — the rest of the Arduino-baseline defaults:

| Kconfig | Arduino | IDF default | Impact of the dual-fw drop |
|---|---|---|---|
| `ESP_DEFAULT_CPU_FREQ_MHZ` / `ESP32S3_DEFAULT_CPU_FREQ_MHZ` | 240 | 160 | **33% perf regression across CPU-bound paths.** Confirmed in boot log: `cpu freq: 160000000 Hz`. |
| `ESP_TASK_WDT_PANIC` | y | n | WDT trips silently log instead of clean-rebooting + coredumping. Affects async_tcp WDT, SPIFFS-stat-starvation, etc. |
| `FREERTOS_WATCHPOINT_END_OF_STACK` + `COMPILER_STACK_CHECK_MODE_NORM` | y | n / NONE | Stack overflows undetected → surface as random data corruption. |
| `HEAP_POISONING_LIGHT` | y | NONE | Small heap overflows / use-after-free silently propagate. |
| `ESP_TIMER_TASK_STACK_SIZE` | 8192 | 3584 | esp_timer dispatch task at the Kconfig minimum. |
| `FREERTOS_TIMER_TASK_STACK_DEPTH` | 3120 | 2048 | FreeRTOS sw-timer task at the Kconfig minimum. |
| `LWIP_TCPIP_TASK_STACK_SIZE` | 4096 | 3072 | At our INFO log level the IDF Kconfig itself warns this can overflow. |
| `LWIP_MAX_SOCKETS` | 16 | 10 | AsyncWebServer + HomeKit + MQTT + mDNS + OTA can hit 10 under load. |
| `LWIP_TCPIP_TASK_AFFINITY` | CPU0 | NO_AFFINITY | We pin AsyncTCP + NimBLE to core 0; lwIP drifting off core 0 means cross-core IPC on every callback. |
| `BT_NIMBLE_NVS_PERSIST` (display only) | y | n | BLE bond keys lost on every reboot — scale + HomeKit re-pair each boot. |

## Symptom (HW)

The LCD shift symptom is documented in the original commit. The CPU freq regression is confirmed at boot: every dual-framework GaggiMate display has been running at 160 MHz instead of 240 since the merge. The remaining items are latent quality / diagnostic regressions.

## Excluded intentionally

- `APP_ROLLBACK_ENABLE` / `BOOTLOADER_APP_ROLLBACK_ENABLE` — needs an app-side `esp_ota_mark_app_valid_cancel_rollback()` call on first good boot, otherwise every OTA cycles back. Worth doing, but it's a code change + Kconfig pair; separate PR.
- `ARDUHAL_ESP_LOG` — flipping this redirects all `ESP_LOGx` output back through Arduino's `log_v/i/d` → `HardwareSerial`. Entangled with our remote-syslog plugin (which already has known coverage gaps in the dual-fw setup). Needs a design pass.
- `ESPTOOLPY_FLASHMODE_QIO` — flash mode is set per-board via `board.json` / `board_build.flash_mode`; not appropriate to force from sdkconfig.

## Test plan

- [x] Build-verify on `display` env: clean rebuild (`rm sdkconfig.display && rm -rf .pio/build/display && pio run -e display`).
- [x] HW-validate `LCD_RGB_RESTART_IN_VSYNC` on a Pro (the LCD shift was reproducible after long uptime and disappears with the fix).
- [ ] HW-validate `cpu freq: 240000000 Hz` in the post-flash boot log.
- [ ] Soak-test `ESP_TASK_WDT_PANIC=y` — confirm WDT now reboots-and-recovers under load instead of soft-wedging.