### PR TITLE
fix(comms): force a clean reconnect when the controller's ping watchdog fires

### DIFF
--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -245,12 +245,22 @@ void GaggiMateController::handlePing() {
 }
 
 void GaggiMateController::handlePingTimeout() {
-    ESP_LOGE(LOG_TAG, "Ping timeout detected. Turning off heater and pump for safety.\n");
     // Turn off the heater and pump as a safety measure
     this->heater->setSetpoint(0);
     this->pump->setPower(0);
     this->valve->set(false);
     this->alt->set(false);
+    // On the healthy->timeout transition, drop the BLE link. An in-band error
+    // notify can be silently swallowed on a wedged GATT (the failure mode this
+    // is here to recover from), but LL_TERMINATE_IND propagates reliably at
+    // the link layer. The display's existing disconnect path then rebuilds
+    // the link and re-sends control state. loop() re-enters every 250 ms while
+    // timed out -- guard so we don't repeatedly bounce the connection or spam
+    // the log.
+    if (errorState != ERROR_CODE_TIMEOUT) {
+        ESP_LOGE(LOG_TAG, "Ping timeout detected. Turning off heater and pump for safety.");
+        _comms.disconnect();
+    }
     errorState = ERROR_CODE_TIMEOUT;
 }
 

--- a/lib/NanoPbComm/src/GaggiMateServer.h
+++ b/lib/NanoPbComm/src/GaggiMateServer.h
@@ -52,6 +52,10 @@ class GaggiMateServer {
     void sendTofMeasurement(uint32_t distance);
     void sendError(int code);
 
+    // Drop the current BLE link. The ping watchdog calls this so the display
+    // sees a real disconnect instead of having to interpret an in-band error.
+    void disconnect() { _transport.disconnect(); }
+
     // Send a pre-built payload / batch of payloads (one frame).
     void send(const gm::Payload &payload) { _endpoint.send(payload); }
     void sendBatch(const gm::Payload *payloads, size_t count) { _endpoint.sendBatch(payloads, count); }

--- a/lib/NanoPbComm/src/ble/BleServerTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleServerTransport.cpp
@@ -56,11 +56,26 @@ void BleServerTransport::onConnect(NimBLEServer *server) {
     emitConnection(true);
 }
 
+void BleServerTransport::onConnect(NimBLEServer *server, ble_gap_conn_desc *desc) {
+    // NimBLE 1.x dispatches both onConnect overloads; this one carries the conn
+    // handle we need for an explicit disconnect() when the ping watchdog fires.
+    if (desc)
+        _connHandle = desc->conn_handle;
+}
+
 void BleServerTransport::onDisconnect(NimBLEServer *server) {
     _connected = false;
+    _connHandle = BLE_HS_CONN_HANDLE_NONE;
     ESP_LOGI(LOG_TAG, "Client disconnected");
     emitConnection(false);
     server->startAdvertising();
+}
+
+void BleServerTransport::disconnect() {
+    if (_connected && _server && _connHandle != BLE_HS_CONN_HANDLE_NONE) {
+        ESP_LOGW(LOG_TAG, "Forcing client disconnect (conn=%u)", _connHandle);
+        _server->disconnect(_connHandle);
+    }
 }
 
 void BleServerTransport::onWrite(NimBLECharacteristic *characteristic) {

--- a/lib/NanoPbComm/src/ble/BleServerTransport.h
+++ b/lib/NanoPbComm/src/ble/BleServerTransport.h
@@ -28,8 +28,15 @@ class BleServerTransport : public Transport, public NimBLEServerCallbacks, publi
     bool send(const uint8_t *data, size_t length) override;
     bool isConnected() const override;
 
+    // Tear down the GATT client connection at the link layer. Used by the
+    // controller when its ping watchdog fires: an LL_TERMINATE_IND propagates
+    // even when GATT writes have been silently dropping, so the display sees
+    // the disconnect and rebuilds the link from scratch.
+    void disconnect();
+
   private:
     bool _connected = false;
+    uint16_t _connHandle = BLE_HS_CONN_HANDLE_NONE;
     NimBLEServer *_server = nullptr;
     NimBLEAdvertising *_advertising = nullptr;
     NimBLECharacteristic *_rxChar = nullptr;   // client -> server (write)
@@ -39,6 +46,7 @@ class BleServerTransport : public Transport, public NimBLEServerCallbacks, publi
     BLE_OTA_DFU _otaDfu;
 
     void onConnect(NimBLEServer *server) override;
+    void onConnect(NimBLEServer *server, ble_gap_conn_desc *desc) override;
     void onDisconnect(NimBLEServer *server) override;
     void onWrite(NimBLECharacteristic *characteristic) override;
     void onSubscribe(NimBLECharacteristic *pCharacteristic, ble_gap_conn_desc *desc, uint16_t subValue) override;

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -24,6 +24,7 @@
 #include <display/plugins/ShotHistoryPlugin.h>
 #include <display/plugins/SmartGrindPlugin.h>
 #include <display/plugins/WebUIPlugin.h>
+#include <display/plugins/WifiStaWatchdogPlugin.h>
 #include <display/plugins/mDNSPlugin.h>
 #include <display/util/PsramAllocator.h>
 #ifndef GAGGIMATE_HEADLESS
@@ -81,6 +82,7 @@ void Controller::setup() {
     }
     pluginManager->registerPlugin(new WebUIPlugin());
     pluginManager->registerPlugin(new NetworkWatchdogPlugin());
+    pluginManager->registerPlugin(new WifiStaWatchdogPlugin());
     pluginManager->registerPlugin(&ShotHistory);
     pluginManager->registerPlugin(&BLEScales);
     pluginManager->registerPlugin(new LedControlPlugin());

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -377,6 +377,59 @@ void Controller::setupWifi() {
         WiFi.mode(WIFI_STA);
         WiFi.setAutoReconnect(true);
         WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE, INADDR_NONE);
+
+        // Register WiFi event handlers BEFORE begin() so STA_CONNECTED and
+        // STA_GOT_IP from the boot connect fire through them too. Handlers
+        // run in the Arduino WiFi event task (small stack), so they only log
+        // and flag; loop() fires plugin events on the main loop.
+        WiFi.onEvent(
+            [this](WiFiEvent_t, WiFiEventInfo_t info) {
+                const auto &g = info.got_ip.ip_info;
+                const uint32_t ip = g.ip.addr;
+                const uint32_t gw = g.gw.addr;
+                ESP_LOGI(LOG_TAG, "STA got IP: %u.%u.%u.%u gw=%u.%u.%u.%u",
+                         (unsigned)(ip & 0xff), (unsigned)((ip >> 8) & 0xff),
+                         (unsigned)((ip >> 16) & 0xff), (unsigned)((ip >> 24) & 0xff),
+                         (unsigned)(gw & 0xff), (unsigned)((gw >> 8) & 0xff),
+                         (unsigned)((gw >> 16) & 0xff), (unsigned)((gw >> 24) & 0xff));
+                wifiConnectedPending = true;
+            },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
+        // setMinSecurity() is a scan filter, not an auth ceiling -- the SDK
+        // can still negotiate WPA3-SAE on a WPA3-transition AP, so log the
+        // authmode it actually chose, the BSSID of the AP we landed on
+        // (useful in multi-AP topologies), and the channel.
+        WiFi.onEvent(
+            [](WiFiEvent_t, WiFiEventInfo_t info) {
+                const auto &c = info.wifi_sta_connected;
+                ESP_LOGI(LOG_TAG, "STA connected: ssid=%.*s bssid=%02x:%02x:%02x:%02x:%02x:%02x ch=%u authmode=%u",
+                         (int)c.ssid_len, c.ssid, c.bssid[0], c.bssid[1], c.bssid[2], c.bssid[3], c.bssid[4],
+                         c.bssid[5], c.channel, c.authmode);
+            },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
+        // Log numeric reason explicitly -- disconnectReasonName() returns NULL
+        // for vendor codes (UniFi 168), which made earlier logs read
+        // "Reason:" with empty body and obscured the root cause.
+        WiFi.onEvent(
+            [this](WiFiEvent_t, WiFiEventInfo_t info) {
+                const auto &d = info.wifi_sta_disconnected;
+                const char *name = WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(d.reason));
+                ESP_LOGW(LOG_TAG, "STA disconnected: reason=%u (%s) bssid=%02x:%02x:%02x:%02x:%02x:%02x ssid=%.*s",
+                         d.reason, name && *name ? name : "vendor/unknown", d.bssid[0], d.bssid[1], d.bssid[2],
+                         d.bssid[3], d.bssid[4], d.bssid[5], (int)d.ssid_len, d.ssid);
+                wifiDisconnectedPending = true;
+            },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+        WiFi.onEvent(
+            [](WiFiEvent_t, WiFiEventInfo_t) { ESP_LOGW(LOG_TAG, "STA lost IP"); },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_LOST_IP);
+        WiFi.onEvent(
+            [](WiFiEvent_t, WiFiEventInfo_t info) {
+                ESP_LOGW(LOG_TAG, "STA authmode changed: %u -> %u", info.wifi_sta_authmode_change.old_mode,
+                         info.wifi_sta_authmode_change.new_mode);
+            },
+            WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_AUTHMODE_CHANGE);
+
         WiFi.begin(settings.getWifiSsid(), settings.getWifiPassword());
         WiFi.setTxPower(WIFI_POWER_19_5dBm);
         for (int attempts = 0; attempts < WIFI_CONNECT_ATTEMPTS; attempts++) {
@@ -390,18 +443,6 @@ void Controller::setupWifi() {
         if (WiFi.status() == WL_CONNECTED) {
             ESP_LOGI(LOG_TAG, "Connected to %s with IP address %s", settings.getWifiSsid().c_str(),
                      WiFi.localIP().toString().c_str());
-            // These run in the Arduino WiFi event task (small stack). Only flag
-            // the change here; loop() fires the plugin events on the main loop so
-            // server/mDNS/socket teardown never runs in this callback context.
-            WiFi.onEvent([this](WiFiEvent_t, WiFiEventInfo_t) { wifiConnectedPending = true; },
-                         WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
-            WiFi.onEvent(
-                [this](WiFiEvent_t, WiFiEventInfo_t info) {
-                    ESP_LOGI(LOG_TAG, "Lost WiFi connection. Reason: %s",
-                             WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason)));
-                    wifiDisconnectedPending = true;
-                },
-                WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
             configTzTime(resolve_timezone(settings.getTimezone()), NTP_SERVER);
             setenv("TZ", resolve_timezone(settings.getTimezone()), 1);
             tzset();
@@ -426,7 +467,12 @@ void Controller::setupWifi() {
     pluginManager->on("ota:update:start", [this](Event const &) { this->updating = true; });
     pluginManager->on("ota:update:end", [this](Event const &) { this->updating = false; });
 
-    pluginManager->trigger("controller:wifi:connect", "AP", isApConnection ? 1 : 0);
+    // STA path: STA_GOT_IP handler already set wifiConnectedPending; loop()
+    // dispatches controller:wifi:connect from there. AP path has no STA_GOT_IP,
+    // so it needs the explicit trigger here.
+    if (isApConnection) {
+        pluginManager->trigger("controller:wifi:connect", "AP", 1);
+    }
 }
 
 void Controller::loop() {

--- a/src/display/plugins/WifiStaWatchdogPlugin.cpp
+++ b/src/display/plugins/WifiStaWatchdogPlugin.cpp
@@ -1,0 +1,69 @@
+#include "WifiStaWatchdogPlugin.h"
+#include "../core/Controller.h"
+#include "../core/Settings.h"
+#include <WiFi.h>
+#include <esp_log.h>
+#include <esp_wifi.h>
+
+static constexpr char LOG_TAG[] = "WifiStaWd";
+
+void WifiStaWatchdogPlugin::setup(Controller *c, PluginManager *pluginManager) {
+    controller = c;
+    ssid = controller->getSettings().getWifiSsid();
+    pass = controller->getSettings().getWifiPassword();
+    armed = ssid.length() > 0 && pass.length() > 0;
+    lastConnectedMs = millis();
+    lastReassocMs = 0;
+
+    // Suspend during OTA: a forced WiFi.begin() mid-download would brick the
+    // pull.  NetworkWatchdog already gates its WiFi.reconnect() the same way.
+    pluginManager->on("ota:update:start", [this](Event const &) { updating = true; });
+    pluginManager->on("ota:update:end", [this](Event const &) { updating = false; });
+
+    ESP_LOGI(LOG_TAG, "armed=%d grace=%lums backoff=%lums", armed, STA_DOWN_GRACE_MS, STA_REASSOC_BACKOFF_MS);
+}
+
+void WifiStaWatchdogPlugin::loop() {
+    if (!armed || updating)
+        return;
+
+    // AP-fallback mode is its own world; setupWifi() lifted us here at boot
+    // and there is no STA to recover.  Skip rather than thrash WiFi.begin().
+    const wifi_mode_t mode = WiFi.getMode();
+    if (mode == WIFI_MODE_AP || mode == WIFI_MODE_NULL)
+        return;
+
+    const unsigned long now = millis();
+    if (WiFi.status() == WL_CONNECTED) {
+        lastConnectedMs = now;
+        return;
+    }
+
+    if (now - lastConnectedMs < STA_DOWN_GRACE_MS)
+        return;
+    if (lastReassocMs != 0 && now - lastReassocMs < STA_REASSOC_BACKOFF_MS)
+        return;
+
+    forceReassoc();
+    lastReassocMs = now;
+}
+
+void WifiStaWatchdogPlugin::forceReassoc() {
+    // The SDK's auto-reconnect path consults a fixed reason-code whitelist
+    // (WiFiGeneric::_isReconnectableReason); on unlisted codes (UniFi vendor
+    // 168, ASSOC_LEAVE, etc) it stops retrying entirely.  An explicit
+    // disconnect+begin re-enters the connect path regardless of reason.
+    wifi_ap_record_t ap{};
+    const bool haveAp = esp_wifi_sta_get_ap_info(&ap) == ESP_OK;
+    ESP_LOGW(LOG_TAG, "STA down %lums; forcing reconnect (status=%d)",
+             millis() - lastConnectedMs, (int)WiFi.status());
+    if (haveAp) {
+        ESP_LOGW(LOG_TAG, "  last AP: bssid=%02x:%02x:%02x:%02x:%02x:%02x rssi=%d ch=%u",
+                 ap.bssid[0], ap.bssid[1], ap.bssid[2], ap.bssid[3], ap.bssid[4], ap.bssid[5],
+                 ap.rssi, ap.primary);
+    }
+
+    WiFi.disconnect(false); // reset state machine, keep stored wifi_config_t
+    delay(50);
+    WiFi.begin(ssid.c_str(), pass.c_str());
+}

--- a/src/display/plugins/WifiStaWatchdogPlugin.h
+++ b/src/display/plugins/WifiStaWatchdogPlugin.h
@@ -1,0 +1,34 @@
+#ifndef WIFISTAWATCHDOGPLUGIN_H
+#define WIFISTAWATCHDOGPLUGIN_H
+
+#include "../core/Plugin.h"
+#include <Arduino.h>
+
+struct Event;
+
+// Force STA reassociation when arduino-esp32 auto-reconnect has stopped retrying.
+// _isReconnectableReason() ignores vendor codes (UniFi 81, 168) and several
+// 802.11 reasons, so the SDK can leave STA "disconnected" indefinitely.
+// NetworkWatchdog only acts after WiFi is up; this covers the never-comes-back
+// case.
+class WifiStaWatchdogPlugin : public Plugin {
+  public:
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+  private:
+    static constexpr unsigned long STA_DOWN_GRACE_MS = 20000;
+    static constexpr unsigned long STA_REASSOC_BACKOFF_MS = 30000;
+
+    Controller *controller = nullptr;
+    String ssid;
+    String pass;
+    unsigned long lastConnectedMs = 0;
+    unsigned long lastReassocMs = 0;
+    bool armed = false;
+    bool updating = false;
+
+    void forceReassoc();
+};
+
+#endif // WIFISTAWATCHDOGPLUGIN_H


### PR DESCRIPTION
## Summary

After a ping-watchdog timeout the controller zeroes the heater for safety, but recovery silently failed in HW-observed cases: the display had no signal that the link was dead, so it never re-pushed control state. This change has the controller notify the display on the watchdog transition; the display drops the link on receipt and the existing reconnect path full-resyncs.

- **Controller:** `handlePingTimeout()` calls `_comms.sendError(ERROR_CODE_TIMEOUT)` on the healthy→timeout transition (guarded to fire once per episode — rationale below).
- **Display:** `comms.onError(ERROR_CODE_TIMEOUT)` calls `comms.disconnect()` instead of being filtered. The existing `onConnectionChanged → controlStateSent = false → updateControl()` chain then full-resends control on the rebuilt link.

## Why disconnect, not resend in place

The failure mode is asymmetric BLE: display→controller writes are write-without-response (`BleClientTransport::send` uses `writeValue(..., false)`), so a degraded link drops them silently while `isConnected()` still reads `true` and notifications still flow the other way. Re-sending a `BoilerControl` over the *same* write characteristic would just be dropped again. Forcing a `disconnect()` nulls the cached `writeChar`/`notifyChar`, the controller re-advertises, the client rescans and binds a fresh write characteristic — which is what actually clears the wedge. HW-observed: with the link in this state, manually switching the display Standby → Brew had no effect on the controller; only a full controller restart restored heating.

## Cost in normal operation

Zero. Both new code paths are gated on failure events: `handlePingTimeout()` only runs once `lastPingTime` is older than 20 s (impossible with the 2 s keepalive flowing), and the `onError(TIMEOUT)` branch only runs on an incoming error notify (none is sent in normal operation). When a timeout *does* fire the added work is **one ~20-byte notify + one disconnect/reconnect (~0.2–24 s observed)** — both paid when the heater is already in safety shutoff. The PID hot path is timer-driven and doesn't touch the comms loop.

## Transition guard

`loop()` re-enters `handlePingTimeout()` every 250 ms while the watchdog is expired, so both the `sendError` call **and** the `ESP_LOGE` log line are wrapped in `if (errorState != ERROR_CODE_TIMEOUT)` and fire exactly once per episode. Without the guard the display would receive a fresh TIMEOUT notify every 250 ms and disconnect/reconnect-loop while trying to recover, and the controller log would spam ~17+ identical lines per episode burying everything else. Recovery itself rides the existing `onBoilerControl → handlePing() → setSetpoint` path on the resend.

## Risk

Narrow. The notify is sent once per healthy→timeout transition, and `comms.disconnect()` is idempotent (`BleClientTransport::disconnect()` no-ops if not connected). The display doesn't surface `ERROR_CODE_TIMEOUT` to the UI today (and still doesn't), so there's no user-visible alarm — just a sub-second to ~20 s link drop and full resend, which is what a fresh boot does anyway.

## Test plan

- [x] \`pio run -e controller\` and \`pio run -e display\` both build clean.
- [x] HW soak: 11 deliberately-induced ping timeouts overnight. **11/11 recovered without intervention**, median 4 s reconnect (range 0.2 – 24 s, bimodal — BLE scan/advertise rendezvous variance, not code-path variance), exactly one \`Ping timeout detected\` log line per episode, exactly one \`Controller reports ping timeout; dropping link to resync\` line on the display side, zero reboots / panics, heap byte-stable across all 11 cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Wi‑Fi watchdog that forces reassociation when STA stays disconnected.
  * Added a controlled BLE disconnect capability to ensure clients are dropped cleanly.

* **Bug Fixes**
  * Suppressed repeated timeout logs and redundant disconnect attempts during persistent timeout.
  * Improved Wi‑Fi event handling to more reliably detect/connect when network state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->