### PR TITLE
fix(display/core/plugins): Fixed issue #583 with the weight of the currently brewed shot being displayed incorrectly if shot history were to be opened

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -465,7 +465,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
                         o["samples"] = hdr.sampleCount;
                         o["duration"] = hdr.durationMs;
 
-                        if (recording && currentBluetoothWeight > 0 && (id == currentId)) {
+                        if ((recording || extendedRecording) && currentBluetoothWeight > 0 && (id == currentId)) {
                             finalWeight = currentBluetoothWeight;
                         }
 
@@ -481,7 +481,8 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
                 file = root.openNextFile();
             }
         }
-        if (root) root.close();
+        if (root)
+            root.close();
     } else if (type == "req:history:get") {
         // Return error: binary must be fetched via HTTP endpoint
         response["error"] = "use HTTP /api/history?id=<id>";
@@ -792,7 +793,8 @@ void ShotHistoryPlugin::rebuildIndex() {
     File directory = fs->open("/h");
     if (!directory || !directory.isDirectory()) {
         ESP_LOGW("ShotHistoryPlugin", "No history directory found");
-        if (directory) directory.close();
+        if (directory)
+            directory.close();
         // Emit completion event even if no directory exists
         if (pluginManager) {
             Event completedEvent;

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -464,6 +464,11 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
                         o["profileId"] = hdr.profileId;
                         o["samples"] = hdr.sampleCount;
                         o["duration"] = hdr.durationMs;
+
+                        if (recording && currentBluetoothWeight > 0 && (id == currentId)) {
+                            finalWeight = currentBluetoothWeight;
+                        }
+
                         if (finalWeight > 0.0f) {
                             o["volume"] = finalWeight;
                         }


### PR DESCRIPTION
## Summary

Fixes issue #583 
The ShotHistoryPlugin::handleRequest() method contains a loop, that updates contents of documents containing historical shots. Previously, even during brewing, if the shot history were to be opened, the current shot's weight would be displayed incorrectly. To address this, I added an additional check that verifies whether the current document being modified corresponds to the currently brewed shot. If so, and the current bluetooth wait is greater than 0, then update finalWeight which in the end updates o["volume"]. If one of those checks fail, then leave the finalWeight as it was. 

## Testing
 platformio run -e display succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shot history now shows live weight and volume for shots actively being recorded. Previously the history list could display outdated static values for the current recording; it now reflects accurate, real-time measurements so users see up-to-date information for active shots in the history view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->