### PR TITLE
Fix profile list crash when profile has no phases (#550)

### DIFF
--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -62,6 +62,10 @@ function applyEasing(t, type) {
 }
 
 function prepareData(phases, target) {
+  if (!Array.isArray(phases) || phases.length === 0) {
+    return [];
+  }
+
   const data = [];
   let time = 0;
   let phaseTime = 0;
@@ -113,8 +117,9 @@ function prepareData(phases, target) {
 }
 
 function makeChartData(data, selectedPhase, isDarkMode = false) {
+  const phases = Array.isArray(data?.phases) ? data.phases : [];
   let duration = 0;
-  for (const phase of data.phases) {
+  for (const phase of phases) {
     duration += parseFloat(phase.duration);
   }
   const chartData = {
@@ -123,11 +128,11 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
       datasets: [
         {
           ...pressureDatasetDefaults,
-          data: prepareData(data.phases, 'pressure'),
+          data: prepareData(phases, 'pressure'),
         },
         {
           ...flowDatasetDefaults,
-          data: prepareData(data.phases, 'flow'),
+          data: prepareData(phases, 'flow'),
         },
       ],
     },
@@ -239,12 +244,12 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
   };
 
   // Add highlighting box only if a phase is selected
-  if (selectedPhase !== null) {
+  if (selectedPhase !== null && phases.length > 0) {
     let start = 0;
     for (let i = 0; i < selectedPhase; i++) {
-      start += parseFloat(data.phases[i].duration);
+      start += parseFloat(phases[i].duration);
     }
-    let end = start + parseFloat(data.phases[selectedPhase].duration);
+    let end = start + parseFloat(phases[selectedPhase].duration);
     chartData.options.plugins.annotation.annotations.push({
       id: 'box1',
       type: 'box',
@@ -261,8 +266,8 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
   const yMax = chartData.options.scales.y.max ?? 12;
 
   let phaseStart = 0;
-  for (let i = 0; i < data.phases.length; i++) {
-    const phase = data.phases[i];
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
     const phaseName = phase.name || `Phase ${i + 1}`;
 
     chartData.options.plugins.annotation.annotations.push({

--- a/web/src/components/ExtendedProfileChart.jsx
+++ b/web/src/components/ExtendedProfileChart.jsx
@@ -120,7 +120,7 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
   const phases = Array.isArray(data?.phases) ? data.phases : [];
   let duration = 0;
   for (const phase of phases) {
-    duration += parseFloat(phase.duration);
+    duration += Number.parseFloat(phase.duration);
   }
   const chartData = {
     type: 'line',
@@ -247,9 +247,9 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
   if (selectedPhase !== null && phases.length > 0) {
     let start = 0;
     for (let i = 0; i < selectedPhase; i++) {
-      start += parseFloat(phases[i].duration);
+      start += Number.parseFloat(phases[i].duration);
     }
-    let end = start + parseFloat(phases[selectedPhase].duration);
+    let end = start + Number.parseFloat(phases[selectedPhase].duration);
     chartData.options.plugins.annotation.annotations.push({
       id: 'box1',
       type: 'box',
@@ -297,7 +297,7 @@ function makeChartData(data, selectedPhase, isDarkMode = false) {
         : undefined,
     });
 
-    phaseStart += parseFloat(phase.duration);
+    phaseStart += Number.parseFloat(phase.duration);
   }
   return chartData;
 }

--- a/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
@@ -8,10 +8,11 @@ import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
+import { getProfilePhases, removePhaseAt, updatePhaseAt } from './profilePhases.js';
 
 export function ExtendedProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
-  const phases = Array.isArray(data?.phases) ? data.phases : [];
+  const phases = getProfilePhases(data);
   const [currentPhaseIndex, setCurrentPhaseIndex] = useState(0);
 
   const onFieldChange = (field, value) => {
@@ -22,11 +23,9 @@ export function ExtendedProfileForm(props) {
   };
 
   const onPhaseChange = (index, value) => {
-    const newPhases = [...phases];
-    newPhases[index] = value;
     onChange({
       ...data,
-      phases: newPhases,
+      phases: updatePhaseAt(phases, index, value),
     });
   };
 
@@ -54,16 +53,10 @@ export function ExtendedProfileForm(props) {
   };
 
   const onPhaseRemove = index => {
-    const newData = {
+    onChange({
       ...data,
-      phases: [],
-    };
-    for (let i = 0; i < phases.length; i++) {
-      if (i !== index) {
-        newData.phases.push(phases[i]);
-      }
-    }
-    onChange(newData);
+      phases: removePhaseAt(phases, index),
+    });
     setCurrentPhaseIndex(0);
   };
 

--- a/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/ExtendedProfileForm.jsx
@@ -11,6 +11,7 @@ import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 
 export function ExtendedProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
+  const phases = Array.isArray(data?.phases) ? data.phases : [];
   const [currentPhaseIndex, setCurrentPhaseIndex] = useState(0);
 
   const onFieldChange = (field, value) => {
@@ -21,18 +22,19 @@ export function ExtendedProfileForm(props) {
   };
 
   const onPhaseChange = (index, value) => {
-    const newData = {
+    const newPhases = [...phases];
+    newPhases[index] = value;
+    onChange({
       ...data,
-    };
-    newData.phases[index] = value;
-    onChange(newData);
+      phases: newPhases,
+    });
   };
 
   const onPhaseAdd = () => {
     onChange({
       ...data,
       phases: [
-        ...data.phases,
+        ...phases,
         {
           phase: 'brew',
           name: 'New Phase',
@@ -48,7 +50,7 @@ export function ExtendedProfileForm(props) {
         },
       ],
     });
-    setCurrentPhaseIndex(data.phases.length);
+    setCurrentPhaseIndex(phases.length);
   };
 
   const onPhaseRemove = index => {
@@ -56,16 +58,16 @@ export function ExtendedProfileForm(props) {
       ...data,
       phases: [],
     };
-    for (let i = 0; i < data.phases.length; i++) {
+    for (let i = 0; i < phases.length; i++) {
       if (i !== index) {
-        newData.phases.push(data.phases[i]);
+        newData.phases.push(phases[i]);
       }
     }
     onChange(newData);
     setCurrentPhaseIndex(0);
   };
 
-  const currentPhase = data.phases[currentPhaseIndex];
+  const currentPhase = phases[currentPhaseIndex];
 
   return (
     <form
@@ -128,7 +130,7 @@ export function ExtendedProfileForm(props) {
         </Card>
         <Card sm={10}>
           <ExtendedProfileChart
-            data={data}
+            data={{ ...data, phases }}
             selectedPhase={currentPhaseIndex}
             className='max-h-72 w-full'
           />
@@ -137,7 +139,7 @@ export function ExtendedProfileForm(props) {
           <div className='card-header flex items-center gap-4'>
             <h2 className='card-title flex-grow text-lg sm:text-xl'>Phases</h2>
             <h5 className='card-subtitle text-sm sm:text-base'>
-              {currentPhaseIndex + 1} / {data.phases.length}
+              {phases.length > 0 ? `${currentPhaseIndex + 1} / ${phases.length}` : '0 / 0'}
             </h5>
             <div>
               <div className='join' role='group' aria-label='Phase navigation'>
@@ -154,7 +156,7 @@ export function ExtendedProfileForm(props) {
                   type='button'
                   className={`join-item btn btn-outline max-sm:btn-sm`}
                   aria-label='Next'
-                  disabled={currentPhaseIndex === data.phases.length - 1}
+                  disabled={phases.length === 0 || currentPhaseIndex === phases.length - 1}
                   onClick={() => setCurrentPhaseIndex(currentPhaseIndex + 1)}
                 >
                   <FontAwesomeIcon icon={faChevronRight} />
@@ -173,19 +175,24 @@ export function ExtendedProfileForm(props) {
               type='button'
               className={`join-item btn btn-outline text-error max-sm:btn-sm`}
               aria-label='Remove phase'
+              disabled={phases.length === 0}
               onClick={() => onPhaseRemove(currentPhaseIndex)}
             >
               <FontAwesomeIcon icon={faTrashCan} />
             </button>
           </div>
           <div className='space-y-4' role='group' aria-label='Brew phases configuration'>
-            <ExtendedPhase
-              phase={currentPhase}
-              index={currentPhaseIndex}
-              onChange={phase => onPhaseChange(currentPhaseIndex, phase)}
-              onRemove={() => onPhaseRemove(currentPhaseIndex)}
-              pressureAvailable={pressureAvailable}
-            />
+            {currentPhase ? (
+              <ExtendedPhase
+                phase={currentPhase}
+                index={currentPhaseIndex}
+                onChange={phase => onPhaseChange(currentPhaseIndex, phase)}
+                onRemove={() => onPhaseRemove(currentPhaseIndex)}
+                pressureAvailable={pressureAvailable}
+              />
+            ) : (
+              <p className='text-base-content/60 text-sm'>No phases yet. Add a phase to configure brewing.</p>
+            )}
           </div>
         </Card>
       </div>

--- a/web/src/pages/ProfileEdit/StandardProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/StandardProfileForm.jsx
@@ -6,10 +6,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan';
 import { Tooltip } from '../../components/Tooltip.jsx';
+import { getProfilePhases, removePhaseAt, updatePhaseAt } from './profilePhases.js';
 
 export function StandardProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
-  const phases = Array.isArray(data?.phases) ? data.phases : [];
+  const phases = getProfilePhases(data);
 
   const onFieldChange = (field, value) => {
     onChange({
@@ -19,11 +20,9 @@ export function StandardProfileForm(props) {
   };
 
   const onPhaseChange = (index, value) => {
-    const newPhases = [...phases];
-    newPhases[index] = value;
     onChange({
       ...data,
-      phases: newPhases,
+      phases: updatePhaseAt(phases, index, value),
     });
   };
 
@@ -45,16 +44,10 @@ export function StandardProfileForm(props) {
   };
 
   const onPhaseRemove = index => {
-    const newData = {
+    onChange({
       ...data,
-      phases: [],
-    };
-    for (let i = 0; i < phases.length; i++) {
-      if (i !== index) {
-        newData.phases.push(phases[i]);
-      }
-    }
-    onChange(newData);
+      phases: removePhaseAt(phases, index),
+    });
   };
 
   return (

--- a/web/src/pages/ProfileEdit/StandardProfileForm.jsx
+++ b/web/src/pages/ProfileEdit/StandardProfileForm.jsx
@@ -9,6 +9,7 @@ import { Tooltip } from '../../components/Tooltip.jsx';
 
 export function StandardProfileForm(props) {
   const { data, onChange, onSave, saving = true, pressureAvailable = false } = props;
+  const phases = Array.isArray(data?.phases) ? data.phases : [];
 
   const onFieldChange = (field, value) => {
     onChange({
@@ -18,18 +19,19 @@ export function StandardProfileForm(props) {
   };
 
   const onPhaseChange = (index, value) => {
-    const newData = {
+    const newPhases = [...phases];
+    newPhases[index] = value;
+    onChange({
       ...data,
-    };
-    newData.phases[index] = value;
-    onChange(newData);
+      phases: newPhases,
+    });
   };
 
   const onPhaseAdd = () => {
     onChange({
       ...data,
       phases: [
-        ...data.phases,
+        ...phases,
         {
           phase: 'brew',
           name: 'New Phase',
@@ -47,9 +49,9 @@ export function StandardProfileForm(props) {
       ...data,
       phases: [],
     };
-    for (let i = 0; i < data.phases.length; i++) {
+    for (let i = 0; i < phases.length; i++) {
       if (i !== index) {
-        newData.phases.push(data.phases[i]);
+        newData.phases.push(phases[i]);
       }
     }
     onChange(newData);
@@ -117,7 +119,7 @@ export function StandardProfileForm(props) {
 
         <Card sm={10} title='Brew Phases'>
           <div className='space-y-4' role='group' aria-label='Brew phases configuration'>
-            {data.phases.map((value, index) => (
+            {phases.map((value, index) => (
               <div key={index}>
                 {index > 0 && (
                   <div className='flex flex-col items-center py-2' aria-hidden='true'>

--- a/web/src/pages/ProfileEdit/index.jsx
+++ b/web/src/pages/ProfileEdit/index.jsx
@@ -76,7 +76,10 @@ export function ProfileEdit() {
         setLoading(false);
       } else if (connected.value) {
         const response = await apiService.request({ tp: 'req:profiles:load', id: params.id });
-        setData(response.profile);
+        setData({
+          ...response.profile,
+          phases: Array.isArray(response.profile?.phases) ? response.profile.phases : [],
+        });
         setLoading(false);
       }
     }

--- a/web/src/pages/ProfileEdit/profilePhases.js
+++ b/web/src/pages/ProfileEdit/profilePhases.js
@@ -1,0 +1,13 @@
+export function getProfilePhases(data) {
+  return Array.isArray(data?.phases) ? data.phases : [];
+}
+
+export function updatePhaseAt(phases, index, value) {
+  const next = [...phases];
+  next[index] = value;
+  return next;
+}
+
+export function removePhaseAt(phases, index) {
+  return phases.filter((_, i) => i !== index);
+}

--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -124,10 +124,13 @@ function ProfileCard({
   const chevronRotation = detailsCollapsed ? '' : 'rotate-90';
   const detailsSectionId = `profile-${data.id}-summary`;
 
+  const phases = Array.isArray(data?.phases) ? data.phases : [];
+
   // Sum total duration from phases (in seconds)
-  const totalDurationSeconds = Array.isArray(data?.phases)
-    ? data.phases.reduce((sum, p) => sum + (Number.isFinite(p?.duration) ? p.duration : 0), 0)
-    : 0;
+  const totalDurationSeconds = phases.reduce(
+    (sum, p) => sum + (Number.isFinite(p?.duration) ? p.duration : 0),
+    0,
+  );
 
   // Mobile actions menu — state-driven (was using the Popover API which isn't
   // supported in Safari <17 / Firefox <125, leaving the menu broken on most
@@ -462,18 +465,16 @@ function ProfileCard({
                     <FontAwesomeIcon icon={faClock} />
                     {totalDurationSeconds}s
                   </span>
-                  {data.phases.length > 0 &&
-                    data.phases[data.phases.length - 1]?.targets?.some(
-                      t => t.type === 'volumetric',
-                    ) && (
+                  {phases.length > 0 &&
+                    phases[phases.length - 1]?.targets?.some(t => t.type === 'volumetric') && (
                       <span className='text-base-content/60 badge badge-xs md:badge-sm badge-outline'>
                         <FontAwesomeIcon icon={faScaleBalanced} />
-                        {`${data.phases[data.phases.length - 1].targets.find(t => t.type === 'volumetric').value}g`}
+                        {`${phases[phases.length - 1].targets.find(t => t.type === 'volumetric').value}g`}
                       </span>
                     )}
-                  {data.phases.length > 0 && (
+                  {phases.length > 0 && (
                     <span className='text-base-content/60 badge badge-xs md:badge-sm badge-outline'>
-                      {data.phases.length} phase{data.phases.length === 1 ? '' : 's'}
+                      {phases.length} phase{phases.length === 1 ? '' : 's'}
                     </span>
                   )}
                 </div>
@@ -519,9 +520,9 @@ function ProfileCard({
               </div>
               <div className='flex-grow overflow-x-auto'>
                 {data.type === 'pro' ? (
-                  <ExtendedProfileChart data={data} className='max-h-36' />
+                  <ExtendedProfileChart data={{ ...data, phases }} className='max-h-36' />
                 ) : (
-                  <SimpleContent data={data} />
+                  <SimpleContent phases={phases} />
                 )}
               </div>
             </div>
@@ -532,10 +533,14 @@ function ProfileCard({
   );
 }
 
-function SimpleContent({ data }) {
+function SimpleContent({ phases }) {
+  if (phases.length === 0) {
+    return <div className='text-base-content/60 text-sm'>No phases</div>;
+  }
+
   return (
     <div className='flex flex-row items-center gap-2' role='list' aria-label='Brew phases'>
-      {data.phases.map((phase, i) => (
+      {phases.map((phase, i) => (
         <div key={i} className='flex flex-row items-center gap-2' role='listitem'>
           {i > 0 && <SimpleDivider />}
           <SimpleStep


### PR DESCRIPTION
## Summary
- Fixes #550: Profile list and editor no longer crash when a profile has no phases
- Normalizes missing or empty `phases` arrays across list, chart, and editor views

## Test plan
- [x] `npm run lint:check` and `npm run build` in `web/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of profiles with missing or empty phase data across edit, list, and chart views.
  * Fixed phase-counts, total duration, and volumetric badge calculations when phases are absent.
  * Navigation buttons (Next, Remove) correctly enable/disable based on phase availability.

* **UI Improvements**
  * Explicit empty-state messaging ("No phases yet…") shown where phase editor would be.
  * Charts and phase highlights render consistently with normalized phase data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->