### PR TITLE
fix(webui): prevent intermittent OOM hang from the OTA update check

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -36,15 +36,17 @@ static WebUIPlugin *g_webUIPlugin = nullptr;
 // (esp-sha/esp-aes "Failed to allocate"). mbedTLS is built with MBEDTLS_PLATFORM_MEMORY
 // (function-pointer allocator), so this runtime override moves those buffers to the 8 MB
 // PSRAM. Falls back to internal DRAM if PSRAM is exhausted so TLS still functions;
-// heap_caps_free handles pointers from either heap.
-static void *mbedtlsPsramCalloc(size_t n, size_t size) {
+// heap_caps_free handles pointers from either heap. The void* parameter/return types below are
+// dictated by the mbedtls_platform_set_calloc_free() callback contract and cannot be narrowed
+// (cpp:S5008 is a false positive here; retyping or casting the function pointers would be UB).
+static void *mbedtlsPsramCalloc(size_t n, size_t size) { // NOSONAR
     void *p = heap_caps_calloc(n, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (p == nullptr) {
         p = heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     }
     return p;
 }
-static void mbedtlsPsramFree(void *p) { heap_caps_free(p); }
+static void mbedtlsPsramFree(void *p) { heap_caps_free(p); } // NOSONAR
 
 WebUIPlugin::WebUIPlugin() : server(80), ws("/ws") { g_webUIPlugin = this; }
 
@@ -115,11 +117,12 @@ void WebUIPlugin::loop() {
     if (!serverRunning) {
         return;
     }
-    const long now = millis();
+    const unsigned long now = millis();
     // Skip the (blocking, TLS) update check while a process is active: a brew/steam/grind
     // must not have the control loop stalled for the duration of the handshake, nor compete
-    // with it for memory. isActive() is the reliable "a process is running" signal.
-    if (!controller->isActive() && (lastUpdateCheck == 0 || now > lastUpdateCheck + UPDATE_CHECK_INTERVAL)) {
+    // with it for memory. isActive() is the reliable "a process is running" signal. Subtraction
+    // (not now > last + interval) keeps the interval check millis()-rollover-safe.
+    if (!controller->isActive() && (lastUpdateCheck == 0 || now - lastUpdateCheck > UPDATE_CHECK_INTERVAL)) {
         ota->checkForUpdates();
         pluginManager->trigger("ota:update:status", "value", ota->isUpdateAvailable());
         lastUpdateCheck = now;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -15,6 +15,7 @@
 #include <esp_err.h>
 #include <esp_heap_caps.h>
 #include <esp_partition.h>
+#include <mbedtls/platform.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -28,9 +29,29 @@ using PsramString = std::basic_string<char, std::char_traits<char>, PsramStlAllo
 static std::unordered_map<uint32_t, PsramString> rxBuffers;
 static WebUIPlugin *g_webUIPlugin = nullptr;
 
+// Route mbedTLS allocations to PSRAM. The Arduino-ESP32 sdkconfig sets
+// CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y, pinning TLS handshake buffers (~32 KB) to the
+// scarce internal DRAM that WiFi + BLE already leave near ~60 KB free. A CA-verified OTA
+// update check then drives internal free toward zero and crypto allocations start failing
+// (esp-sha/esp-aes "Failed to allocate"). mbedTLS is built with MBEDTLS_PLATFORM_MEMORY
+// (function-pointer allocator), so this runtime override moves those buffers to the 8 MB
+// PSRAM. Falls back to internal DRAM if PSRAM is exhausted so TLS still functions;
+// heap_caps_free handles pointers from either heap.
+static void *mbedtlsPsramCalloc(size_t n, size_t size) {
+    void *p = heap_caps_calloc(n, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (p == nullptr) {
+        p = heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    }
+    return p;
+}
+static void mbedtlsPsramFree(void *p) { heap_caps_free(p); }
+
 WebUIPlugin::WebUIPlugin() : server(80), ws("/ws") { g_webUIPlugin = this; }
 
 void WebUIPlugin::setup(Controller *_controller, PluginManager *_pluginManager) {
+    // Redirect mbedTLS allocations to PSRAM before any TLS (OTA) handshake runs, so the
+    // ~32 KB handshake buffers don't exhaust the scarce internal-DRAM pool. See mbedtlsPsramCalloc.
+    (void)mbedtls_platform_set_calloc_free(mbedtlsPsramCalloc, mbedtlsPsramFree);
     this->controller = _controller;
     this->profileManager = _controller->getProfileManager();
     this->pluginManager = _pluginManager;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -116,7 +116,10 @@ void WebUIPlugin::loop() {
         return;
     }
     const long now = millis();
-    if ((lastUpdateCheck == 0 || now > lastUpdateCheck + UPDATE_CHECK_INTERVAL)) {
+    // Skip the (blocking, TLS) update check while a process is active: a brew/steam/grind
+    // must not have the control loop stalled for the duration of the handshake, nor compete
+    // with it for memory. isActive() is the reliable "a process is running" signal.
+    if (!controller->isActive() && (lastUpdateCheck == 0 || now > lastUpdateCheck + UPDATE_CHECK_INTERVAL)) {
         ota->checkForUpdates();
         pluginManager->trigger("ota:update:status", "value", ota->isUpdateAvailable());
         lastUpdateCheck = now;


### PR DESCRIPTION

## Problem

The display firmware can intermittently wedge — usually noticed as the web UI going
unresponsive while the touchscreen still works, recoverable only by a power cycle. It affects
every display target (all ESP32-S3): WiFi + BLE leave only ~60 KB of internal DRAM free, and
the periodic update check's TLS handshake needs ~32 KB of it. Logs around the event show
crypto/BLE allocation failures:

```
E esp-sha:   Failed to allocate buf memory
E esp-aes:   Failed to allocate memory
E BLE_INIT:  Malloc failed
```

## Root cause

`WebUIPlugin::loop()` runs a periodic update check (`ota->checkForUpdates()`), which performs
a CA-verified TLS handshake to github.com. With `CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y` (the
Arduino-ESP32 default), mbedTLS allocates its ~32 KB of handshake buffers from internal DRAM.
Against the ~60 KB internal floor that drives free internal memory to single-digit KB; any
concurrent allocation at that instant (a BLE scale reconnecting, etc.) tips it into allocation
failures and the device can hang. The full-UI `display` build is the most exposed (least
internal headroom); the headless variants strip LVGL and have a little more, but carry the
same spike.

Measured on a LilyGo T-RGB: a single update check drove internal free from ~57 KB down to
~6.6 KB.

## Changes

Two small, independent commits, `WebUIPlugin.cpp` only (+25/−1):

1. **Route mbedTLS allocations to PSRAM.** mbedTLS is built with `MBEDTLS_PLATFORM_MEMORY`
   (a function-pointer allocator), so `mbedtls_platform_set_calloc_free()` installs a
   PSRAM-backed allocator at runtime, with an internal-DRAM fallback. This keeps the
   handshake's bulk buffers off the scarce internal heap; only the small DMA-capable crypto
   buffers stay internal.

2. **Skip the update check while a process is active.** `checkForUpdates()` runs synchronously
   on the control loop and blocks for the whole handshake; gate it on `!controller->isActive()`
   so it never stalls the loop or competes for memory during a brew/steam/grind. The next idle
   iteration picks it up.

## Validation

- Measured on a LilyGo T-RGB (ESP32-S3, 8 MB PSRAM) via heap instrumentation: the update
  check's internal-DRAM low-water rose from ~6.6 KB → ~55.8 KB free, and a real github
  handshake still completes.
- `pio run -e display` builds clean.
- **Idle soak:** ~22 h continuous (single boot, no reboot) on the fork build carrying this exact
  fix. The 6 h OTA update checks each left ~39 KB internal DRAM free (vs ~6–15 KB pre-fix), the
  `minheap` floor held flat at ~39 KB overnight, `loop_age` stayed ≤ 2 ms, and no
  `esp-sha`/`esp-aes`/`Malloc` failures were logged. The subsequent standby→brew wake (scale
  reconnect — the exact transition that previously triggered the hang) was handled cleanly:
  `minheap` dipped only to ~26.5 KB, no loop stall, no hang.

## Notes / scope

- Applies to every current display target — all are ESP32-S3 with PSRAM (LilyGo T-RGB 8 MB,
  XIAO-S3 8 MB, S3-SuperMini 2 MB). The internal-DRAM fallback in the allocator is a defensive
  safety net should a future board ship without PSRAM; it preserves current behavior rather
  than failing.
- The allocator is global, set once at init before any TLS use.
- Scope is intentionally limited to the OTA-check OOM — it doesn't touch the update cadence or
  other memory paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for secure connections and OTA updates via optimized memory handling.
  * Update checks now pause during active brewing, steaming, or grinding to avoid interruptions.
  * Fixed edge-case timing so update checks remain reliable across device uptime/clock rollover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->