### PR TITLE
perf(backend): cache pre-serialized profile JSON to improve load times

### DIFF
--- a/scripts/auto_firmware_version.py
+++ b/scripts/auto_firmware_version.py
@@ -11,7 +11,7 @@ def get_firmware_specifier_build_flag():
     return build_flag
 
 def get_time_specifier_build_flag():
-    build_timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    build_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     build_flag = "#define BUILD_TIMESTAMP \"" + build_timestamp + "\""
     print ("Build date: " + build_timestamp)
     return build_flag

--- a/src/display/core/ProfileManager.cpp
+++ b/src/display/core/ProfileManager.cpp
@@ -110,6 +110,7 @@ void ProfileManager::migrate(const std::vector<String> &existingProfiles) {
     for (const String &id : existingProfiles) {
         addFavoritedProfile(id);
     }
+    invalidateCache();
 }
 
 std::vector<String> ProfileManager::listProfiles() {
@@ -205,6 +206,7 @@ bool ProfileManager::saveProfile(Profile &profile) {
     if (isNew) {
         addFavoritedProfile(profile.id);
     }
+    invalidateCache();
     return ok;
 }
 
@@ -213,7 +215,9 @@ bool ProfileManager::deleteProfile(const String &uuid) {
     if (_settings.getStartupProfile() == uuid) {
         _settings.setStartupProfile("");
     }
-    return _fs->remove(profilePath(uuid));
+    bool ok = _fs->remove(profilePath(uuid));
+    if (ok) invalidateCache();
+    return ok;
 }
 
 bool ProfileManager::profileExists(const String &uuid) { return _fs->exists(profilePath(uuid)); }
@@ -224,6 +228,7 @@ void ProfileManager::selectProfile(const String &uuid) {
     selectedProfile = Profile{};
     loadSelectedProfile(selectedProfile);
     _plugin_manager->trigger("profiles:profile:select", "id", uuid);
+    invalidateCache();
 }
 
 Profile &ProfileManager::getSelectedProfile() { return selectedProfile; }
@@ -267,9 +272,41 @@ std::vector<String> ProfileManager::getFavoritedProfiles(bool validate) {
 void ProfileManager::removeFavoritedProfile(String id) {
     _settings.removeFavoritedProfile(id);
     _plugin_manager->trigger("profiles:profile:unfavorite", "id", id);
+    invalidateCache();
 }
 
 void ProfileManager::addFavoritedProfile(String id) {
     _settings.addFavoritedProfile(id);
     _plugin_manager->trigger("profiles:profile:favorite", "id", id);
+    invalidateCache();
+}
+
+String ProfileManager::getProfilesJsonCache(bool minimal) {
+    if (minimal && !_minimalProfilesCache.isEmpty()) return _minimalProfilesCache;
+    if (!minimal && !_profilesCache.isEmpty()) return _profilesCache;
+
+    JsonDocument doc(&psramAllocator);
+    JsonArray arr = doc.to<JsonArray>();
+    for (auto const &id : listProfiles()) {
+        Profile profile{};
+        if (!loadProfile(id, profile)) continue;
+        auto p = arr.add<JsonObject>();
+        if (minimal) {
+            p["id"] = profile.id;
+            p["label"] = profile.label;
+        } else {
+            writeProfile(p, profile);
+        }
+    }
+
+    String out;
+    serializeJson(arr, out);
+    if (minimal) _minimalProfilesCache = out;
+    else _profilesCache = out;
+    return out;
+}
+
+void ProfileManager::invalidateCache() {
+    _profilesCache = "";
+    _minimalProfilesCache = "";
 }

--- a/src/display/core/ProfileManager.h
+++ b/src/display/core/ProfileManager.h
@@ -25,12 +25,17 @@ class ProfileManager {
     void addFavoritedProfile(String id);
     void removeFavoritedProfile(String id);
 
+    String getProfilesJsonCache(bool minimal);
+    void invalidateCache();
+
   private:
     Profile selectedProfile{};
     PluginManager *_plugin_manager;
     Settings &_settings;
     fs::FS *_fs;
     String _dir;
+    String _profilesCache;
+    String _minimalProfilesCache;
     bool ensureDirectory() const;
     String profilePath(const String &uuid) const;
     void migrate(const std::vector<String> &existingProfiles);

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -528,25 +528,8 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
     response["rid"] = request["rid"].as<String>();
 
     if (type == "req:profiles:list") {
-        auto arr = response["profiles"].to<JsonArray>();
-        for (auto const &id : profileManager->listProfiles()) {
-            Profile profile{};
-            // Skip entries whose JSON couldn't be opened or failed validation
-            // (parseProfile returns false for missing label/type/phases). Without
-            // this, corrupt or partial profile files surface as blank cards in
-            // the UI — the user reported "blank Simple cards" originating here.
-            if (!profileManager->loadProfile(id, profile)) {
-                ESP_LOGW("WebUIPlugin", "Skipping unreadable profile %s in list response", id.c_str());
-                continue;
-            }
-            auto p = arr.add<JsonObject>();
-            if (request["minimal"].as<bool>()) {
-                p["id"] = profile.id;
-                p["label"] = profile.label;
-            } else {
-                writeProfile(p, profile);
-            }
-        }
+        bool minimal = request["minimal"].as<bool>();
+        response["profiles"] = serialized(profileManager->getProfilesJsonCache(minimal));
     } else if (type == "req:profiles:load") {
         auto id = request["id"].as<String>();
         Profile profile;
@@ -592,6 +575,7 @@ void WebUIPlugin::handleProfileRequest(uint32_t clientId, JsonDocument &request)
                 }
             }
             controller->getSettings().setProfileOrder(order);
+            profileManager->invalidateCache();
         }
     }
 


### PR DESCRIPTION
### Summary
This PR introduces server-side profile list JSON caching on the C++ backend. Pre-serialization of profiles reduces JSON formatting overhead on request, yielding faster load times and smoother WebSocket response handling.

### What's Changed
- **ProfileManager**: Added `getProfilesJsonCache()` and `invalidateCache()` to manage caching and invalidation of the pre-serialized profile data.
- **WebUIPlugin**: Integrates the cache in the `req:profiles:list` WebSocket responder and invalidates the cache when profiles are created, updated, or reordered.

This change is transparent to the frontend and provides immediate backend optimizations. It is part of a series of independent, story-driven PRs split from the larger frontend modernization effort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cached profile JSON payloads to speed up profile listing.
* **Changes**
  * Web UI profile listing now uses the cached payload, and the cache is refreshed after profile reordering.
* **Bug Fixes**
  * Improved profile cache consistency by invalidating cached data after profile saves, deletions, selection changes, and favorite updates.
* **Chores**
  * Updated firmware build timestamp generation to use an explicit UTC timezone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->