### PR TITLE
fix(comms): deliver controller config reliably across BLE reconnects

### DIFF
--- a/lib/NanoPbComm/src/Endpoint.cpp
+++ b/lib/NanoPbComm/src/Endpoint.cpp
@@ -251,21 +251,27 @@ void Endpoint::handleData(const uint8_t *data, size_t length) {
 }
 
 void Endpoint::handleConnection(bool connected) {
-    lock();
-    _inFlight = false;
-    _retries = 0;
-    _txLen = 0;
-    _inFlightId = 0;
-    _lastRxId = 0;
-    _nextId = 1;
-    _rttValid = false; // latency is per-link; don't carry a stale estimate across reconnects
-    _smoothedRttMs = 0;
-    _lastRttMs = 0;
-    _queue.clear();
-    unlock();
+    // NimBLE emits "connected" more than once per link (onConnect + onSubscribe);
+    // reset the session only on a real transition, else a redundant emit's xQueueReset wipes an already-arrived burst.
+    const bool changed = connected != _connected;
+    _connected = connected;
+    if (changed) {
+        lock();
+        _inFlight = false;
+        _retries = 0;
+        _txLen = 0;
+        _inFlightId = 0;
+        _lastRxId = 0;
+        _nextId = 1;
+        _rttValid = false; // latency is per-link; don't carry a stale estimate across reconnects
+        _smoothedRttMs = 0;
+        _lastRttMs = 0;
+        _queue.clear();
+        unlock();
 
-    if (_rxQueue)
-        xQueueReset(_rxQueue); // drop any inbound payloads from a previous session
+        if (_rxQueue)
+            xQueueReset(_rxQueue); // drop any inbound payloads from a previous session
+    }
 
     if (_connHandler)
         _connHandler(connected); // e.g. push SystemInfo on connect

--- a/lib/NanoPbComm/src/Endpoint.h
+++ b/lib/NanoPbComm/src/Endpoint.h
@@ -108,6 +108,7 @@ class Endpoint {
     unsigned long _sentAt = 0;
     uint8_t _retries = 0;
     bool _inFlight = false;
+    bool _connected = false; // link state; reset the session only on a true transition (see handleConnection)
 
     // Round-trip latency from the reliability layer. Sampled only on frames
     // ACKed without a retransmit (Karn's algorithm) so an ambiguous retransmit

--- a/lib/NanoPbComm/src/GaggiMateServer.cpp
+++ b/lib/NanoPbComm/src/GaggiMateServer.cpp
@@ -10,8 +10,15 @@ void GaggiMateServer::init(const String &deviceName, const String &hardware, con
     setSystemInfo(hardware, version, capabilities);
     registerHandlers();
     _endpoint.onConnection([this](bool connected) {
-        if (connected)
-            pushSystemInfo();
+        // Don't announce mid-handshake -- the display's config burst would race link setup.
+        // pumpTask announces once the link is stable, and re-announces until config arrives.
+        _linkUp = connected;
+        if (connected) {
+            _linkSettledAt = millis();
+            _configReceived = false;
+            _lastSysInfoPush = 0;
+            _sysInfoAttempts = 0;
+        }
     });
     _endpoint.begin();
     _transport.init(deviceName);
@@ -27,6 +34,13 @@ void GaggiMateServer::pumpTask(void *arg) {
     TickType_t lastWake = xTaskGetTickCount();
     for (;;) {
         self->_endpoint.loop();
+        if (self->_linkUp && !self->_configReceived && self->_sysInfoAttempts < MAX_SYSINFO_ATTEMPTS &&
+            (millis() - self->_linkSettledAt) >= SYSINFO_STABILIZE_MS &&
+            (self->_lastSysInfoPush == 0 || (millis() - self->_lastSysInfoPush) >= SYSINFO_RETRY_MS)) {
+            self->_lastSysInfoPush = millis();
+            self->_sysInfoAttempts++;
+            self->pushSystemInfo();
+        }
         xTaskDelayUntil(&lastWake, pdMS_TO_TICKS(15));
     }
 }
@@ -149,6 +163,7 @@ void GaggiMateServer::registerHandlers() {
             _relayCb(static_cast<uint8_t>(p.content.relay.index), p.content.relay.open);
     });
     _endpoint.on(gaggimate_Payload_pid_tag, [this](const gm::Payload &p) {
+        _configReceived = true;
         if (_pidCb)
             _pidCb(p.content.pid.kp, p.content.pid.ki, p.content.pid.kd, p.content.pid.kf);
     });

--- a/lib/NanoPbComm/src/GaggiMateServer.h
+++ b/lib/NanoPbComm/src/GaggiMateServer.h
@@ -96,6 +96,16 @@ class GaggiMateServer {
     void registerHandlers();
     void pushSystemInfo();
 
+    // SystemInfo announce timing (rationale in GaggiMateServer.cpp init()):
+    static constexpr uint32_t SYSINFO_STABILIZE_MS = 600; // wait for the link to go quiet before first announce
+    static constexpr uint32_t SYSINFO_RETRY_MS = 1500;    // re-announce cadence until config arrives
+    static constexpr uint8_t MAX_SYSINFO_ATTEMPTS = 8;    // stop after this many (e.g. proto mismatch)
+    volatile bool _linkUp = false;
+    volatile bool _configReceived = false;
+    volatile uint32_t _linkSettledAt = 0;
+    volatile uint32_t _lastSysInfoPush = 0;
+    volatile uint8_t _sysInfoAttempts = 0;
+
     // Drives the endpoint send pump / retransmit independently of the
     // controller's (slow, 250ms) main loop, on the NimBLE core.
     TaskHandle_t _taskHandle = nullptr;

--- a/lib/NanoPbComm/src/ble/BleClientTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleClientTransport.cpp
@@ -87,21 +87,25 @@ bool BleClientTransport::connectToServer() {
         return true; // link intentionally kept; do not disconnect/rescan
     }
 
+    _readyForConnection = false;
+    _incompatible = false;
+    ESP_LOGI(LOG_TAG, "Connected, MTU: %d", _client->getMTU());
+
+    // Reset the endpoint session (emit) BEFORE subscribing, so the config burst isn't wiped by a late reset.
+    emitConnection(true);
+
     // Without the notify subscription we would connect but never receive data;
     // treat a failed subscribe as a failed connection.
     if (!_notifyChar->canNotify() ||
         !_notifyChar->subscribe(true, std::bind(&BleClientTransport::notifyCallback, this, std::placeholders::_1,
                                                 std::placeholders::_2, std::placeholders::_3, std::placeholders::_4))) {
         ESP_LOGE(LOG_TAG, "Failed to subscribe to TX characteristic");
+        emitConnection(false);
         _client->disconnect();
         scan();
         return false;
     }
 
-    _readyForConnection = false;
-    _incompatible = false;
-    ESP_LOGI(LOG_TAG, "Connected, MTU: %d", _client->getMTU());
-    emitConnection(true);
     return true;
 }
 


### PR DESCRIPTION
## Deliver controller config reliably across BLE reconnects

**Problem.** When the controller reboots while the display stays up, the boiler often won't heat. The controller gets its PID/pressure/pump gains from the display as a config burst sent in reply to `SystemInfo` — which is exchanged *during* the BLE connect/subscribe handshake. The session reset that runs on connection events discards the in-flight burst, so the controller keeps firmware-default gains (`Kff 0.000`) and heater output stays 0. Only bites on a reconnect.

**Relationship to `a7ff7b3b` ("fix: Send pid settings on mode change").** That commit addresses the most visible symptom (Kff=0 → no heat) by re-pushing PID gains on every mode change. It covers PID only — pressure scale and pump coefficients are still not re-sent — and only after the user changes mode. This PR fixes the lost-burst race at its source so the full config burst arrives reliably on every reconnect, no user action required. The `setMode → setPidSettings` call from `a7ff7b3b` then becomes a harmless safety net; I've kept it for now and we can drop it in a follow-up if you prefer.

**Fix.**
1. `BleClientTransport` — emit (reset the session) **before** subscribing, so the config exchange lands in a clean session.
2. `Endpoint::handleConnection` — reset only on a real connect/disconnect transition, not on every redundant connect-emit (NimBLE fires `onConnect` + `onSubscribe`).
3. `GaggiMateServer` — announce `SystemInfo` only after the link is stable (debounce), then re-announce until PID settings arrive (convergence) so a single lost burst self-heals.

**Validation.**
- `move` lineage (re-order): **VERIFIED** — HW A/B, controller-reboot config lands every cycle.
- `master` (+ debounce): direction validated (0/4 → 3/4); convergence re-announce closes the remaining gap.
- Build: `pio run -e display -e controller` clean against current `master` (post-rebase).

Full write-up + current/corrected flow diagrams: `reports/ble-reconnect-config-delivery.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection state tracking so session reset logic only triggers on genuine connection-state transitions, reducing unintended resets.
  * Enhanced system information announcements by waiting for a stable link and retrying until configuration is received or the retry limit is reached.
  * Fixed the Bluetooth client connection flow to notify readiness before subscribing to TX notifications, with clearer handling of subscription failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->