### PR TITLE
fix(web): prevent iOS focus zoom on form controls

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -425,6 +425,35 @@ html[data-theme='coffee'] {
 
 @source inline("{,sm:,md:,lg:,xl:}col-span-{1..12}");
 
+/* iOS Safari zooms focused text controls below 16px. Keep page zoom enabled
+   and raise only editable controls on touch-based iOS devices. */
+@layer base {
+  @supports (-webkit-touch-callout: none) {
+    @media (hover: none) and (pointer: coarse) {
+      input:not(
+        :is(
+          [type='button'],
+          [type='checkbox'],
+          [type='color'],
+          [type='file'],
+          [type='hidden'],
+          [type='image'],
+          [type='radio'],
+          [type='range'],
+          [type='reset'],
+          [type='submit']
+        )
+      ),
+      textarea,
+      select,
+      [contenteditable='true'],
+      [role='textbox'] {
+        font-size: 16px !important;
+      }
+    }
+  }
+}
+
 /* Portal-based tooltip styles (used by Tooltip.jsx) */
 .tooltip-portal {
   @apply bg-neutral text-neutral-content rounded-md px-2 py-1 text-sm;


### PR DESCRIPTION
- Prevents iOS Safari from automatically zooming when focusing small form controls.
- Enforces a minimum `16px` font size for editable controls on touch-based WebKit devices.
- Applies system-wide to inputs, textareas, selects, contenteditable elements, and textbox roles.
- Excludes non-text controls such as checkboxes, sliders, buttons, and file inputs.
- Keeps pinch-to-zoom and accessibility settings fully available.