### PR TITLE
feat(web): add system theme option to ui

### DIFF
--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -404,6 +404,7 @@ export function Settings() {
                   handleThemeChange(e);
                 }}
               >
+                <option value='system'>System</option>
                 <option value='light'>Light</option>
                 <option value='dark'>Dark</option>
                 <option value='coffee'>Coffee</option>

--- a/web/src/utils/themeManager.js
+++ b/web/src/utils/themeManager.js
@@ -1,13 +1,19 @@
 const THEME_STORAGE_KEY = 'gaggimate-daisyui-theme';
-const AVAILABLE_THEMES = ['light', 'dark', 'coffee', 'nord'];
+const AVAILABLE_THEMES = ['system', 'light', 'dark', 'coffee', 'nord'];
+
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+export function getSystemTheme() {
+  return mediaQuery.matches ? 'dark' : 'light';
+}
 
 export function getStoredTheme() {
   try {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
-    return stored && AVAILABLE_THEMES.includes(stored) ? stored : 'light';
+    return stored && AVAILABLE_THEMES.includes(stored) ? stored : 'system';
   } catch (error) {
     console.warn('Failed to get stored theme:', error);
-    return 'light';
+    return 'system';
   }
 }
 
@@ -26,9 +32,11 @@ export function setStoredTheme(theme) {
 }
 
 export function applyTheme(theme) {
-  if (AVAILABLE_THEMES.includes(theme)) {
-    document.documentElement.setAttribute('data-theme', theme);
+  if (!AVAILABLE_THEMES.includes(theme)) {
+    return;
   }
+  const actualTheme = theme === 'system' ? getSystemTheme() : theme;
+  document.documentElement.setAttribute('data-theme', actualTheme);
 }
 
 export function getAvailableThemes() {
@@ -38,9 +46,16 @@ export function getAvailableThemes() {
   }));
 }
 
+function onSystemThemeChange() {
+  if (getStoredTheme() === 'system') {
+    applyTheme('system');
+  }
+}
+
 // Initialize theme on load
 export function initializeTheme() {
   const theme = getStoredTheme();
+  mediaQuery.addEventListener('change', onSystemThemeChange);
   applyTheme(theme);
 }
 


### PR DESCRIPTION
- Add `System` option to the theme dropdown setting to the UI
- Default to `System`
- Auto switch web theme on system mode change. (Doesn't require reloading page to reflect system dark/light mode  change)

Related issue: #788 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **System** option to the Settings → Theme dropdown.
  * Theme can now automatically follow the device/browser’s system preference.

* **Bug Fixes**
  * Improved theme loading: if saved theme data is missing or invalid, it now defaults to **System**.
  * Invalid theme values are no longer applied.
  * When **System** is selected, theme updates automatically when system preference changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->