### PR TITLE
ProfileList -  Add active profile indicator

### DIFF
--- a/web/src/pages/ProfileList/index.jsx
+++ b/web/src/pages/ProfileList/index.jsx
@@ -65,21 +65,21 @@ const PhaseLabels = {
 const connected = computed(() => machine.value.connected);
 
 function ProfileCard({
-  data,
-  onDelete,
-  onSelect,
-  onFavorite,
-  onUnfavorite,
-  onDuplicate,
-  favoriteDisabled,
-  unfavoriteDisabled,
-  disabledDrag,
-  isDragging,
-  onMoveTop,
-  onMoveBottom,
-  isFirst,
-  isLast,
-}) {
+                       data,
+                       onDelete,
+                       onSelect,
+                       onFavorite,
+                       onUnfavorite,
+                       onDuplicate,
+                       favoriteDisabled,
+                       unfavoriteDisabled,
+                       disabledDrag,
+                       isDragging,
+                       onMoveTop,
+                       onMoveBottom,
+                       isFirst,
+                       isLast,
+                     }) {
   const { armed: confirmDelete, armOrRun: confirmOrDelete } = useConfirmAction(4000);
   const [tooltipsDisabled, setTooltipsDisabled] = useState(false);
 
@@ -658,6 +658,8 @@ export function ProfileList() {
     return profiles;
   }, [profiles, searchTerm]);
 
+  const isUtilityProfileActive = profilesToShow.filter(p => p.utility && p.selected).length > 0;
+
   const clearDropHighlights = useCallback(() => {
     if (!containerRef.current) return;
     const highlighted = containerRef.current.querySelectorAll('.drop-highlight');
@@ -999,20 +1001,22 @@ export function ProfileList() {
         <div role='tablist' className='tabs tabs-border mb-4'>
           <button
             role='tab'
-            className={`tab ${activeTab === 'extraction' ? 'tab-active' : ''}`}
+            className={`tab ${activeTab === 'extraction' ? 'tab-active' : ''} ${!isUtilityProfileActive ? 'pr-[5px]' : ''}`}
             onClick={() => setActiveTab('extraction')}
             aria-label='Switch to extraction tab'
           >
             Extraction
           </button>
+          {!isUtilityProfileActive && <div class='bg-primary mr-[7px] h-2 w-2 rounded-full' />}
           <button
             role='tab'
-            className={`tab ${activeTab === 'utility' ? 'tab-active' : ''}`}
+            className={`tab ${activeTab === 'utility' ? 'tab-active' : ''} ${isUtilityProfileActive ? 'pr-[5px]' : ''}`}
             onClick={() => setActiveTab('utility')}
             aria-label='Switch to utility tab'
           >
             Utility
           </button>
+          {isUtilityProfileActive && <div class='bg-primary mr-[7px] h-2 w-2 rounded-full' />}
         </div>
       )}
       <div


### PR DESCRIPTION
Update ProfileList: add active profile indicator for extraction and utility tabs

- Added visual indicators for selected profile to the "extraction" and "utility" tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile tabs now show clearer status indicators for Extraction and Utility profiles.
  * Tab spacing and padding adjust based on whether a visible Utility profile is active.

* **Bug Fixes**
  * Improved how profile visibility and selection are reflected in the tab UI.
  * Updated profile card formatting with no change to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="491" height="309" alt="dot" src="https://github.com/user-attachments/assets/d3338464-e186-4313-9847-eb3b81ff7913" />
