### PR TITLE
feat: add water level indicator dot to display and web UI

### DIFF
--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -157,6 +157,9 @@ void WebUIPlugin::loop() {
         statusDoc["gact"] = controller->isGrindActive() ? 1 : 0;
         statusDoc["wl"] = controller->getWaterLevel();
         statusDoc["tof"] = controller->getTofDistance();
+        statusDoc["tof_cap"] = controller->getSystemInfo().capabilities.tof;
+        statusDoc["sr_idle"] = controller->getSettings().getSunriseIdle();
+        statusDoc["sr_err"] = controller->getSettings().getSunriseError();
         statusDoc["rssi"] = 0;
         statusDoc["lat"] = -1; // BLE round-trip latency (ms); -1 = not yet measured
 

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -266,6 +266,8 @@ void DefaultUI::loop() {
         currentScreen = static_cast<ScreensEnum>(eez_flow_get_current_screen());
         effect_mgr.evaluate_all();
 
+        updateWaterDot();
+
         if (currentScreen == SCREEN_ID_STANDBY_SCREEN) {
             if (standbyEnterTime > 0) {
                 const Settings &settings = controller->getSettings();
@@ -507,6 +509,8 @@ void DefaultUI::updateState() {
     currentTemp = static_cast<int>(controller->getCurrentTemp());
     targetTemp = static_cast<int>(controller->getTargetTemp());
     pressureAvailable = controller->getSystemInfo().capabilities.pressure ? 1 : 0;
+    tofAvailable = controller->getSystemInfo().capabilities.tof;
+    waterLevel = tofAvailable ? controller->getWaterLevel() : 0;
     wifiConnected = WiFi.status() == WL_CONNECTED;
     grindAvailable = settings.isSmartGrindActive() || settings.getAltRelayFunction() == ALT_RELAY_GRIND;
 
@@ -689,6 +693,57 @@ void DefaultUI::updateBrewProcess() {
 }
 
 void DefaultUI::updateMenuScreen() {}
+
+static uint32_t parseHexColor(const String &hex) { return strtol(hex.c_str() + 1, nullptr, 16); }
+
+static lv_obj_t *createWaterDot(lv_obj_t *parent, int y) {
+    lv_obj_t *dot = lv_obj_create(parent);
+    lv_obj_set_size(dot, 14, 14);
+    lv_obj_set_style_align(dot, LV_ALIGN_CENTER, 0);
+    lv_obj_set_pos(dot, 0, y);
+    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(dot, 1, 0);
+    lv_obj_set_style_border_color(dot, lv_color_make(128, 128, 128), 0);
+    lv_obj_set_style_pad_all(dot, 0, 0);
+    lv_obj_clear_flag(dot, LV_OBJ_FLAG_SCROLLABLE);
+    return dot;
+}
+
+void DefaultUI::updateWaterDot() {
+    if (!tofAvailable) {
+        waterDot = nullptr;
+        waterDotMenu = nullptr;
+        return;
+    }
+
+    lv_obj_t *scr = lv_scr_act();
+
+    if (currentScreen == SCREEN_ID_MENU_SCREEN_NEW) {
+        waterDot = nullptr;
+        if (waterDotMenu == nullptr || !lv_obj_is_valid(waterDotMenu)) {
+            waterDotMenu = createWaterDot(scr, -230);
+        }
+        lv_color_t color =
+            lv_color_hex(controller->isLowWaterLevel() ? parseHexColor(controller->getSettings().getSunriseError())
+                                                       : parseHexColor(controller->getSettings().getSunriseIdle()));
+        lv_obj_set_style_bg_color(waterDotMenu, color, 0);
+        lv_obj_set_style_bg_opa(waterDotMenu, LV_OPA_COVER, 0);
+    } else if (currentScreen == SCREEN_ID_BREW_SCREEN || currentScreen == SCREEN_ID_STEAM_SCREEN ||
+               currentScreen == SCREEN_ID_WATER_SCREEN) {
+        waterDotMenu = nullptr;
+        if (waterDot == nullptr || !lv_obj_is_valid(waterDot)) {
+            waterDot = createWaterDot(scr, -230);
+        }
+        lv_color_t color =
+            lv_color_hex(controller->isLowWaterLevel() ? parseHexColor(controller->getSettings().getSunriseError())
+                                                       : parseHexColor(controller->getSettings().getSunriseIdle()));
+        lv_obj_set_style_bg_color(waterDot, color, 0);
+        lv_obj_set_style_bg_opa(waterDot, LV_OPA_COVER, 0);
+    } else {
+        waterDot = nullptr;
+        waterDotMenu = nullptr;
+    }
+}
 
 String DefaultUI::getErrorMessage() {
     if (controller->isUpdating()) {

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -77,6 +77,7 @@ class DefaultUI {
     void updateBoiler();
     void updateBrewProcess();
     void updateMenuScreen();
+    void updateWaterDot();
     String getErrorMessage();
 
     void adjustDials(lv_obj_t *dials);
@@ -132,6 +133,11 @@ class DefaultUI {
     Value steamReady = BooleanValue(false);
     Value grindWeightTarget = FloatValue(18.0);
     Value grindTimeTarget = StringValue("0:15");
+
+    int waterLevel = 0;
+    bool tofAvailable = false;
+    lv_obj_t *waterDot = nullptr;
+    lv_obj_t *waterDotMenu = nullptr;
 
     int profileDirty = 0;
     int currentProfileIdx = 0;

--- a/web/src/components/WaterDot.jsx
+++ b/web/src/components/WaterDot.jsx
@@ -1,0 +1,28 @@
+import { machine } from '../services/ApiService.js';
+
+export function WaterDot({ className = '' }) {
+  const state = machine.value;
+  if (!state.capabilities.tof) return null;
+
+  const wl = state.status.waterLevel;
+  if (wl < 0) return null;
+
+  const ok = wl >= 20;
+  const color = ok ? state.status.sunriseIdle || '#00FFFF' : state.status.sunriseError || '#FF0000';
+
+  return (
+    <div
+      className={className}
+      style={{
+        width: 12,
+        height: 12,
+        borderRadius: '50%',
+        backgroundColor: color,
+        border: '1px solid rgba(128,128,128,0.5)',
+        display: 'inline-block',
+        flexShrink: 0,
+      }}
+      title={`Water level: ${wl}%`}
+    />
+  );
+}

--- a/web/src/pages/Home/CompactProcessControls.jsx
+++ b/web/src/pages/Home/CompactProcessControls.jsx
@@ -21,6 +21,7 @@ import { useQuery } from 'preact-fetching';
 import PropTypes from 'prop-types';
 import { ApiServiceContext, machine } from '../../services/ApiService.js';
 import { ModeTab } from './ModeTab.jsx';
+import { WaterDot } from '../../components/WaterDot.jsx';
 import {
   fmtElapsed,
   fmtPhaseTarget,
@@ -251,16 +252,19 @@ export default function CompactProcessControls({ brew, mode, changeMode }) {
 
   return (
     <div className='flex h-full min-h-0 w-full min-w-0 flex-col gap-2 overflow-hidden'>
-      <div className='bg-base-200/70 flex h-9 w-full shrink-0 gap-0.5 rounded-full p-0.5'>
-        {MODES.filter(m => m.id !== 4 || showGrindTab).map(m => (
-          <ModeTab
-            key={m.id}
-            mode={m}
-            active={mode === m.id}
-            onClick={() => changeMode(m.id)}
-            rotation={m.iconRotation}
-          />
-        ))}
+      <div className='flex h-9 w-full shrink-0 items-center gap-1.5'>
+        <div className='bg-base-200/70 flex flex-1 gap-0.5 rounded-full p-0.5'>
+          {MODES.filter(m => m.id !== 4 || showGrindTab).map(m => (
+            <ModeTab
+              key={m.id}
+              mode={m}
+              active={mode === m.id}
+              onClick={() => changeMode(m.id)}
+              rotation={m.iconRotation}
+            />
+          ))}
+        </div>
+        <WaterDot />
       </div>
 
       <div className='flex shrink-0 items-center justify-between gap-3 text-[0.65rem]'>

--- a/web/src/pages/Home/ProcessControls.jsx
+++ b/web/src/pages/Home/ProcessControls.jsx
@@ -19,6 +19,7 @@ import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { Tooltip } from '../../components/Tooltip.jsx';
 import { MODES } from './utils.js';
 import { ModeTab } from './ModeTab.jsx';
+import { WaterDot } from '../../components/WaterDot.jsx';
 
 const status = computed(() => machine.value.status);
 
@@ -300,8 +301,8 @@ const ProcessControls = props => {
 
   return (
     <div className={`flex h-full min-h-[250px] flex-col justify-between lg:min-h-[350px]`}>
-      <div className='mb-2 flex justify-center'>
-        <div className='bg-base-200/70 flex h-9 w-full shrink-0 gap-0.5 rounded-full p-0.5'>
+      <div className='mb-2 flex items-center justify-center gap-2'>
+        <div className='bg-base-200/70 flex h-9 shrink-0 gap-0.5 rounded-full p-0.5'>
           {MODES.filter(m => m.id !== 4 || showGrindTab).map(m => (
             <ModeTab
               key={m.id}
@@ -312,6 +313,7 @@ const ProcessControls = props => {
             />
           ))}
         </div>
+        <WaterDot />
       </div>
 
       <div className='mt-1 mb-2 flex flex-col items-center justify-between space-y-2 sm:flex-row sm:space-y-0'>

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -187,6 +187,9 @@ export default class ApiService {
       rssi: message.rssi || 0,
       lat: message.lat || 0,
       tofDistance: message.tof || 0,
+      waterLevel: message.wl ?? -1,
+      sunriseIdle: message.sr_idle || '#00FFFF',
+      sunriseError: message.sr_err || '#FF0000',
     };
     const historyEntry = { ...newStatus };
     delete historyEntry.process;
@@ -202,6 +205,7 @@ export default class ApiService {
         dimming: message.cd,
         pressure: message.cp,
         ledControl: message.led,
+        tof: !!message.tof_cap,
         gearpumpAddon: !!message.gp,
       },
       history: [...machine.value.history, historyEntry],
@@ -228,10 +232,12 @@ export const machine = signal({
     grindTarget: 0,
     grindActive: false,
     process: null,
+    waterLevel: -1,
   },
   capabilities: {
     pressure: false,
     dimming: false,
+    tof: false,
   },
   history: [],
 });


### PR DESCRIPTION
Adds a small colored dot to the display and web UI that mirrors the sunrise LED colors based on the water level from the ToF/alba sensor. For Rancilio users this should be an improvement, as no further mods etc. are needed.

**Display**
- Shows a 14px centered dot on the menu screen, brew screen, steam screen, and water screen
- Only visible when a ToF water sensor is connected (capabilities.tof)
- Color: sunriseIdle (cyan by default) when water level ≥ 20%, sunriseError (red by default) when low
- Matches the LED control plugin's binary threshold (isLowWaterLevel())

**Web UI**
- New WaterDot component renders a 12px circle next to the mode tab bar on both ProcessControls and CompactProcessControls
- Same binary color logic, using the sunriseIdle / sunriseError colors from the device settings (with #00FFFF / #FF0000 fallbacks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added water-level indicators to the device display and web controls.
  * Indicators show whether water is at an acceptable level and use configured status colors.
  * Water-level status now updates in real time when supported by the device.
  * Added a tooltip displaying the current water level percentage.

* **Bug Fixes**
  * Water indicators are hidden when water-level sensing is unavailable or no valid reading exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->