### PR TITLE
fix(web): fix steam pump assist field snap back to previous value

### DIFF
--- a/web/src/pages/Settings/tabs/MachineTab.jsx
+++ b/web/src/pages/Settings/tabs/MachineTab.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'preact/hooks';
 import { computed } from '@preact/signals';
 import { machine } from '../../../services/ApiService.js';
 import Section from '../../../components/Card.jsx';
@@ -58,6 +59,8 @@ function TankDistanceField({ id, label, value, onChange, onUseCurrent }) {
 }
 
 export function MachineTab({ formData, onChange, setField }) {
+  const [steamPumpDraft, setSteamPumpDraft] = useState(null);
+
   return (
     <div className='space-y-4 sm:space-y-6'>
       {/* Temperature Settings */}
@@ -216,13 +219,18 @@ export function MachineTab({ formData, onChange, setField }) {
               step='0.1'
               className='grow'
               placeholder={pressureAvailable.value ? '0.0' : '0.0 %'}
-              value={String(formData.steamPumpPercentage * (pressureAvailable.value ? 0.1 : 1))}
-              onBlur={e =>
+              value={
+                steamPumpDraft ??
+                String(formData.steamPumpPercentage / (pressureAvailable.value ? 10 : 1))
+              }
+              onChange={e => setSteamPumpDraft(e.target.value)}
+              onBlur={e => {
+                setSteamPumpDraft(null);
                 setField(
                   'steamPumpPercentage',
                   (parseFloat(e.target.value) * (pressureAvailable.value ? 10 : 1)).toFixed(0),
-                )
-              }
+                );
+              }}
             />
           </InputGroupField>
           {pressureAvailable.value && (


### PR DESCRIPTION
- This PR fix the issue where Steam Pump assist field is not working properly; when the value changes, it keeps snapping back to the old value.
- Fix by introducing a temporary variable that holds the value while changing, and set the actual value on blur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved steam pump percentage editing in Machine Settings.
  * Values now stay stable while typing, and are converted correctly when saved after leaving the field, based on the selected pressure unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->