### PR TITLE
Refactor Boiler refill plugin

### DIFF
--- a/src/display/plugins/BoilerFillPlugin.cpp
+++ b/src/display/plugins/BoilerFillPlugin.cpp
@@ -15,4 +15,11 @@ void BoilerFillPlugin::setup(Controller *controller, PluginManager *pluginManage
             this->controller->startProcess(new PumpProcess(this->controller->getSettings().getSteamFillTime()));
         }
     });
+    // Main Menu load event handler
+    pluginManager->on("ui:screen:menu", [this](Event const &) {
+        // If mode is STEAM and refill on startup is 0 start refill on main menu to avoid starting with empty boiler
+        if (this->controller->getSettings().getStartupFillTime() == 0 && this->controller->getMode() == MODE_STEAM) {
+             this->controller->startProcess(new PumpProcess(this->controller->getSettings().getSteamFillTime()));
+        }
+    });
 }

--- a/src/display/plugins/BoilerFillPlugin.cpp
+++ b/src/display/plugins/BoilerFillPlugin.cpp
@@ -10,8 +10,7 @@ void BoilerFillPlugin::setup(Controller *controller, PluginManager *pluginManage
         this->controller->startProcess(new PumpProcess(this->controller->getSettings().getStartupFillTime()));
     });
     pluginManager->on("controller:mode:change", [this](Event const &event) {
-        int newMode = event.getInt("value");
-        if (newMode == MODE_BREW && this->controller->getMode() == MODE_STEAM) {
+        if (this->controller->getMode() == MODE_STEAM) {
             this->controller->startProcess(new PumpProcess(this->controller->getSettings().getSteamFillTime()));
         }
     });

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -463,6 +463,12 @@ void DefaultUI::handleScreenChange() {
             setBrightness(settings.getMainBrightness());
         }
         eez_flow_set_screen(targetScreen, LV_SCR_LOAD_ANIM_NONE, 0, 0);
+
+        // Trigger an event for main menu load
+        if (targetScreen == SCREEN_ID_MENU_SCREEN_NEW) {
+            pluginManager->trigger("ui:screen:menu");
+        }
+
         animateGaugeTicks(currentScreen, targetScreen);
         rerender = true;
     }


### PR DESCRIPTION
- Added boiler refill logic when going from STEAM mode to the main menu to avoid starting with empty boiler if startup fill time is zero.
- Removed redundant mode check when transitioning from STEAM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved steam boiler refilling when switching modes.
  * Added an automatic refill when entering the main menu with an empty boiler under applicable settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->