### PR TITLE
Hardware Scales

### DIFF
--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -256,6 +256,17 @@ void GaggiMateController::setup() {
 
 void GaggiMateController::loop() {
     unsigned long now = millis();
+
+    // Keep zero tracking and idle display quantization out of the measurement
+    // path whenever the brew valve or pump can be adding liquid to the cup.
+    if (hardwareScale != nullptr) {
+        const float pumpPower =
+            pump != nullptr && pump->getPumpPowerPtr() != nullptr ? *pump->getPumpPowerPtr() : 0.0f;
+        const bool scaleActivity =
+            (valve != nullptr && valve->getState()) || pumpPower > 0.01f;
+        hardwareScale->setBrewingActive(scaleActivity);
+    }
+
     if (lastPingTime < now && (now - lastPingTime) / 1000 > PING_TIMEOUT_SECONDS) {
         handlePingTimeout();
     }

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -49,9 +49,9 @@ void GaggiMateController::setup() {
     this->steamBtn = new DigitalInput(_config.steamButtonPin, [this](const bool state) { _comms.sendButtonState(1, state); });
     this->hardwareScale = new HardwareScale(
         _config.scaleSdaPin, _config.scaleSda1Pin, _config.scaleSclPin,
-        [this](float weight) {
+        [this](float weight, float cell1Weight, float cell2Weight, bool cell1Valid, bool cell2Valid) {
             if (_comms.isConnected()) {
-                _comms.sendScaleMeasurement(weight);
+                _comms.sendScaleMeasurement(weight, cell1Weight, cell2Weight, cell1Valid, cell2Valid);
             }
         },
         [](float, float) {});
@@ -70,7 +70,6 @@ void GaggiMateController::setup() {
         _config.capabilites.tof = true;
         _comms.onLedControl([this](uint8_t channel, uint8_t brightness) { ledController->setChannel(channel, brightness); });
     }
-
     gm::DeviceCapabilities capabilities = gaggimate_Capabilities_init_zero;
     capabilities.dimming = _config.capabilites.dimming;
     capabilities.pressure = _config.capabilites.pressure;
@@ -245,11 +244,13 @@ void GaggiMateController::setup() {
         auto dimmedPump = static_cast<DimmedPump *>(pump);
         dimmedPump->tare();
     });
-    _comms.onScaleFactors([this](float scaleFactor1, float scaleFactor2) {
+    _comms.onScaleFactors([this](float scaleFactor1, float scaleFactor2, uint16_t sampleRateSps,
+                                float idleFilterAlpha, float activeFilterAlpha) {
         if (hardwareScale == nullptr || !hardwareScale->isAvailable()) {
             return;
         }
-        hardwareScale->setScaleFactors(scaleFactor1, scaleFactor2);
+        hardwareScale->setConfiguration(scaleFactor1, scaleFactor2, sampleRateSps, idleFilterAlpha,
+                                        activeFilterAlpha);
     });
     ESP_LOGI(LOG_TAG, "Initialization done");
 }

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -7,6 +7,9 @@
 
 #include <utility>
 
+constexpr uint32_t ADDON_GEARPUMP = 7;
+constexpr uint32_t ADDON_HW_SCALE = 8;
+
 GaggiMateController::GaggiMateController(String version) : _version(std::move(version)) {
     configs.push_back(GM_STANDARD_REV_1X);
     configs.push_back(GM_STANDARD_REV_2X);
@@ -44,6 +47,14 @@ void GaggiMateController::setup() {
     }
     this->brewBtn = new DigitalInput(_config.brewButtonPin, [this](const bool state) { _comms.sendButtonState(0, state); });
     this->steamBtn = new DigitalInput(_config.steamButtonPin, [this](const bool state) { _comms.sendButtonState(1, state); });
+    this->hardwareScale = new HardwareScale(
+        _config.scaleSdaPin, _config.scaleSda1Pin, _config.scaleSclPin,
+        [this](float weight) {
+            if (_comms.isConnected()) {
+                _comms.sendVolumetricMeasurement(weight);
+            }
+        },
+        [](float, float) {});
 
     // 4-Pin peripheral port
     albaComms = new SoftWire(_config.sunriseSdaPin, _config.sunriseSclPin);
@@ -65,11 +76,25 @@ void GaggiMateController::setup() {
     capabilities.pressure = _config.capabilites.pressure;
     capabilities.tof = _config.capabilites.tof;
     capabilities.led_control = _config.capabilites.ledControls;
+
+    this->hardwareScale->setup();
+
+    auto addAddon = [&capabilities](uint32_t type) {
+        const auto maxAddons = sizeof(capabilities.addons) / sizeof(capabilities.addons[0]);
+        if (capabilities.addons_count >= maxAddons) {
+            return;
+        }
+        capabilities.addons[capabilities.addons_count] = gaggimate_Addon_init_zero;
+        capabilities.addons[capabilities.addons_count].type = type;
+        capabilities.addons_count++;
+    };
     if (this->gearpumpAddon != nullptr) {
-        capabilities.addons_count = 1;
-        capabilities.addons[0] = gaggimate_Addon_init_zero;
-        capabilities.addons[0].type = 7;
+        addAddon(ADDON_GEARPUMP);
     }
+    if (this->hardwareScale->isAvailable()) {
+        addAddon(ADDON_HW_SCALE);
+    }
+
     _comms.init("GPBLS", _config.name.c_str(), _version, capabilities);
 
     if (_config.capabilites.ledControls) {
@@ -211,11 +236,20 @@ void GaggiMateController::setup() {
         this->heater->autotune(static_cast<int>(testTimeSec), static_cast<int>(windowSize), static_cast<int>(heaterWattage));
     });
     _comms.onTare([this]() {
+        if (hardwareScale != nullptr && hardwareScale->isAvailable()) {
+            hardwareScale->tare();
+        }
         if (!_config.capabilites.dimming) {
             return;
         }
         auto dimmedPump = static_cast<DimmedPump *>(pump);
         dimmedPump->tare();
+    });
+    _comms.onScaleFactors([this](float scaleFactor1, float scaleFactor2) {
+        if (hardwareScale == nullptr || !hardwareScale->isAvailable()) {
+            return;
+        }
+        hardwareScale->setScaleFactors(scaleFactor1, scaleFactor2);
     });
     ESP_LOGI(LOG_TAG, "Initialization done");
 }

--- a/lib/GaggiMateController/src/GaggiMateController.cpp
+++ b/lib/GaggiMateController/src/GaggiMateController.cpp
@@ -51,7 +51,7 @@ void GaggiMateController::setup() {
         _config.scaleSdaPin, _config.scaleSda1Pin, _config.scaleSclPin,
         [this](float weight) {
             if (_comms.isConnected()) {
-                _comms.sendVolumetricMeasurement(weight);
+                _comms.sendScaleMeasurement(weight);
             }
         },
         [](float, float) {});

--- a/lib/GaggiMateController/src/GaggiMateController.h
+++ b/lib/GaggiMateController/src/GaggiMateController.h
@@ -5,6 +5,7 @@
 #include <peripherals/DigitalInput.h>
 #include <peripherals/DistanceSensor.h>
 #include <peripherals/FlowSensor.h>
+#include <peripherals/HardwareScale.h>
 #include <peripherals/Heater.h>
 #include <peripherals/LedController.h>
 #include <peripherals/Max31855Thermocouple.h>
@@ -53,6 +54,7 @@ class GaggiMateController {
     DistanceSensor *distanceSensor = nullptr;
     ADSAdc *adc = nullptr;
     FlowSensor *flowSensor = nullptr;
+    HardwareScale *hardwareScale = nullptr;
 
     GearpumpAddon *gearpumpAddon = nullptr;
 

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 #define HX711_GAIN 128
-#define MAX_SCALE_GRAMS 750.0f
+#define MAX_SCALE_GRAMS 2000.0f
 #define MAX_WAIT_READ_MS 250
 #define MAX_STARTUP_WAIT_MS 1200
 

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -1,5 +1,7 @@
-#include "HardwareScale.h"
+// filepath: /Users/eric/Developer/gaggimate/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
 
+#include "HardwareScale.h"
+#include <Arduino.h>
 #include <algorithm>
 #include <cmath>
 
@@ -7,92 +9,144 @@
 #define MAX_SCALE_GRAMS 750.0f
 #define MAX_WAIT_READ_MS 250
 #define MAX_STARTUP_WAIT_MS 1200
-#define SCALE_FACTOR_TIMEOUT_MS 10000
-#define SCALE_FILTER_ALPHA 0.5f
-#define SCALE_TARE_SAMPLES 3
+
+namespace {
+constexpr float MIN_ABS_SCALE_FACTOR = 1.0f;
+constexpr float TARE_MAX_SPREAD_GRAMS = 0.50f;
+constexpr uint8_t TARE_MAX_ATTEMPTS = 2;
+constexpr uint8_t READ_FAILURES_BEFORE_FAULT = 3;
+constexpr unsigned long ACTIVE_FILTER_LINGER_MS = 5000;
+constexpr float ACTIVE_OUTLIER_THRESHOLD_GRAMS = 0.75f;
+
+bool validScaleFactor(float factor) { return std::isfinite(factor) && std::fabs(factor) >= MIN_ABS_SCALE_FACTOR; }
+
+bool saturatedReading(long value) { return value == 0x7FFFFF || value == -0x800000; }
+} // namespace
 
 HardwareScale::HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin,
-                             const scale_reading_callback_t &reading_callback,
-                             const scale_configuration_callback_t &config_callback)
-    : _dataPin1(data_pin1), _dataPin2(data_pin2), _clockPin(clock_pin), _scaleFactor1(-2500.0f), _scaleFactor2(2500.0f),
-      _offset1(0.0f), _offset2(0.0f), _readingCallback(reading_callback), _configurationCallback(config_callback),
-      taskHandle(nullptr), _operationMutex(nullptr) {
-    _rawWeight = {0, 0};
+    const scale_reading_callback_t &reading_callback,
+    const scale_configuration_callback_t &config_callback)
+    : is_initialized(false), _scale_factors_ready(false),
+    _data_pin1(data_pin1), _data_pin2(data_pin2), _clock_pin(clock_pin),
+    _scale_factor1(-2500.0f), _scale_factor2(2500.0f),
+    _offset1(0.0f), _offset2(0.0f),
+    _reading_callback(reading_callback),
+    _configuration_callback(config_callback),
+    taskHandle(nullptr), _operation_mutex(nullptr) {
+    _raw_weight = {0, 0};
 }
 
 void HardwareScale::setup() {
-    _operationMutex = xSemaphoreCreateMutex();
-    if (_operationMutex == nullptr) {
+    _operation_mutex = xSemaphoreCreateMutex();
+    if (_operation_mutex == nullptr) {
         ESP_LOGE(LOG_TAG, "Unable to create scale operation mutex");
-        _initialized = false;
+        is_initialized = false;
         return;
     }
 
-    pinMode(_dataPin1, INPUT);
-    pinMode(_dataPin2, INPUT);
-    pinMode(_clockPin, OUTPUT);
-    digitalWrite(_clockPin, LOW);
+    pinMode(_data_pin1, INPUT);
+    pinMode(_data_pin2, INPUT);
+    pinMode(_clock_pin, OUTPUT);
+    digitalWrite(_clock_pin, LOW);
+    ESP_LOGV(LOG_TAG, "Initializing hardware scale on DATA1: %d, DATA2: %d, CLOCK: %d", _data_pin1, _data_pin2, _clock_pin);
 
-    unsigned long start = millis();
+    long start = millis();
     while (!isReady() && (millis() - start) < MAX_STARTUP_WAIT_MS) {
-        delay(10);
+            delay(10);
     }
     if (!isReady()) {
-        ESP_LOGW(LOG_TAG, "HX711 not ready at boot, hardware scale disabled");
-        _initialized = false;
+        ESP_LOGE(LOG_TAG, "HX711 modules (%d, %d) not ready after max wait time, aborting setup", digitalRead(_data_pin1), digitalRead(_data_pin2));
+        is_initialized = false;
         return;
+    } else {
+        ESP_LOGI(LOG_TAG, "HX711 modules are ready after %d ms", millis() - start);
     }
 
+    // do a warm-up of 5 readings
     for (int i = 0; i < 5; i++) {
-        unsigned long readStart = millis();
-        while (!isReady() && (millis() - readStart) < MAX_WAIT_READ_MS) {
+        long start = millis();
+        while (!isReady() && (millis() - start) < MAX_WAIT_READ_MS) {
             delay(10);
         }
         if (!isReady()) {
-            ESP_LOGW(LOG_TAG, "HX711 warmup failed, hardware scale disabled");
-            _initialized = false;
+            ESP_LOGE(LOG_TAG, "HX711 modules (%d, %d) not ready after max wait time, aborting setup", digitalRead(_data_pin1), digitalRead(_data_pin2));
+            is_initialized = false;
             return;
         }
         readRaw();
     }
+    if (!tare()) {
+        ESP_LOGE(LOG_TAG, "Unable to obtain a stable initial tare");
+        is_initialized = false;
+        return;
+    }
+    is_initialized = true;
+    ESP_LOGI(LOG_TAG, "Hardware scale initialized successfully");
 
-    tare();
-    _initialized = true;
-    ESP_LOGI(LOG_TAG, "Hardware scale initialized");
+    // ensure we setup an initial value for the scale factors in the BLE server
+    _configuration_callback(_scale_factor1, _scale_factor2);
 
-    _configurationCallback(_scaleFactor1, _scaleFactor2);
-    xTaskCreate(loopTask, "HardwareScale::loop", configMINIMAL_STACK_SIZE * 3, this, 0, &taskHandle);
+    // Add small delay to ensure system stability before starting scale task
+    delay(500);
+
+    // Create task with lower priority (0 instead of 1) to not interfere with Bluetooth
+    if (xTaskCreate(loopTask, "HardwareScale::loop", configMINIMAL_STACK_SIZE * 3, this, 0, &taskHandle) != pdPASS) {
+        ESP_LOGE(LOG_TAG, "Unable to create hardware scale task");
+        is_initialized = false;
+        taskHandle = nullptr;
+    }
 }
 
-bool HardwareScale::isReady() { return digitalRead(_dataPin1) == LOW && digitalRead(_dataPin2) == LOW; }
+bool HardwareScale::isReady() { return digitalRead(_data_pin1) == LOW && digitalRead(_data_pin2) == LOW; }
+
+bool HardwareScale::waitUntilReady(unsigned long timeoutMs) const {
+    const unsigned long started = millis();
+    while (digitalRead(_data_pin1) != LOW || digitalRead(_data_pin2) != LOW) {
+        if (millis() - started >= timeoutMs) {
+            return false;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    return true;
+}
 
 HardwareScale::RawReading HardwareScale::readRaw() {
     unsigned long value1 = 0;
     unsigned long value2 = 0;
 
-    portENTER_CRITICAL(&_readMux);
+    // Ensure that the read process is not interrupted. The timing of the SCK signal is critical for the HX711.
+    // If an interrupt occurs during the read, and the pulse time exceeds 60 microseconds, the HX711 may enter power-down mode.
+    // This can lead to corrupted readings.
 
+    // The shared mux also prevents tare/calibration callbacks running on the
+    // other core from clocking the HX711s at the same time as the scale task.
+    portENTER_CRITICAL(&_read_mux);
+
+    // Read 24 bits
     for (int8_t i = 23; i >= 0; i--) {
-        digitalWrite(_clockPin, HIGH);
+        digitalWrite(_clock_pin, HIGH);
         delayMicroseconds(1);
-        value1 |= (digitalRead(_dataPin1) << i);
-        value2 |= (digitalRead(_dataPin2) << i);
-        digitalWrite(_clockPin, LOW);
+        value1 |= (digitalRead(_data_pin1) << i);
+        value2 |= (digitalRead(_data_pin2) << i);
+        digitalWrite(_clock_pin, LOW);
         delayMicroseconds(1);
     }
 
+    // Set gain for next reading
     for (uint8_t i = 0; i < (HX711_GAIN == 128 ? 1 : (HX711_GAIN == 64 ? 3 : 2)); ++i) {
-        digitalWrite(_clockPin, HIGH);
+        digitalWrite(_clock_pin, HIGH);
         delayMicroseconds(1);
-        digitalWrite(_clockPin, LOW);
+        digitalWrite(_clock_pin, LOW);
         delayMicroseconds(1);
     }
 
-    portEXIT_CRITICAL(&_readMux);
+    portEXIT_CRITICAL(&_read_mux);
 
+    // Convert to signed 24-bit
     if (value1 & 0x800000) {
         value1 |= 0xFF000000;
     }
+
     if (value2 & 0x800000) {
         value2 |= 0xFF000000;
     }
@@ -100,105 +154,363 @@ HardwareScale::RawReading HardwareScale::readRaw() {
     return {static_cast<long>(value1), static_cast<long>(value2)};
 }
 
-float HardwareScale::convertRawToWeight(const RawReading &raw) const {
-    const float weight1 = (static_cast<float>(raw.value1) - _offset1) / _scaleFactor1;
-    const float weight2 = (static_cast<float>(raw.value2) - _offset2) / _scaleFactor2;
-    return std::clamp(weight1 + weight2, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
+bool HardwareScale::convertRawToWeight(const RawReading &raw, float &weight) const {
+    if (saturatedReading(raw.value1) || saturatedReading(raw.value2) || !validScaleFactor(_scale_factor1) ||
+        !validScaleFactor(_scale_factor2)) {
+        return false;
+    }
+
+    const float weight1 = (static_cast<float>(raw.value1) - _offset1) / _scale_factor1;
+    const float weight2 = (static_cast<float>(raw.value2) - _offset2) / _scale_factor2;
+    if (!std::isfinite(weight1) || !std::isfinite(weight2) || std::fabs(weight1) > MAX_SCALE_GRAMS ||
+        std::fabs(weight2) > MAX_SCALE_GRAMS) {
+        return false;
+    }
+
+    const float combined = weight1 + weight2;
+    if (!std::isfinite(combined) || std::fabs(combined) > MAX_SCALE_GRAMS) {
+        return false;
+    }
+    weight = combined;
+    return true;
 }
 
-float HardwareScale::getWeight() const { return _weight.load(); }
+bool HardwareScale::isResponsive() const {
+    return static_cast<int32_t>(_responsive_until.load() - millis()) > 0;
+}
+
+void HardwareScale::setBrewingActive(bool active) {
+    if (active) {
+        _responsive_until.store(millis() + ACTIVE_FILTER_LINGER_MS);
+    }
+}
+
+void HardwareScale::resetFilterState() {
+    _has_accepted_reading = false;
+    _has_pending_outlier = false;
+    _previous_accepted_reading = 0.0f;
+    _last_accepted_reading = 0.0f;
+    _pending_outlier = 0.0f;
+    _published_weight = 0.0f;
+    _zero_bias = 0.0f;
+    resetZeroTrackingHistory();
+}
+
+void HardwareScale::resetZeroTrackingHistory() {
+    _zero_median_count = 0;
+    _zero_median_index = 0;
+    _zero_stability_count = 0;
+    _zero_stability_index = 0;
+}
+
+bool HardwareScale::acceptReading(float reading, float &accepted) {
+    if (!_has_accepted_reading) {
+        _has_accepted_reading = true;
+        _previous_accepted_reading = reading;
+        _last_accepted_reading = reading;
+        accepted = reading;
+        return true;
+    }
+
+    const bool responsive = isResponsive();
+    if (!responsive) {
+        // Outside a brew, responsiveness is more useful than holding a genuine
+        // cup/weight change while waiting for two closely matching samples. The
+        // EMA still damps noise; brew-time spike rejection remains enabled.
+        _has_pending_outlier = false;
+        _previous_accepted_reading = _last_accepted_reading;
+        _last_accepted_reading = reading;
+        accepted = reading;
+        return true;
+    }
+
+    const float threshold = ACTIVE_OUTLIER_THRESHOLD_GRAMS;
+    const float maxTrend = ACTIVE_OUTLIER_THRESHOLD_GRAMS;
+    const float trend = std::clamp(_last_accepted_reading - _previous_accepted_reading, -maxTrend, maxTrend);
+    const float predicted = _last_accepted_reading + trend;
+
+    if (std::fabs(reading - predicted) <= threshold) {
+        _has_pending_outlier = false;
+    } else if (_has_pending_outlier && std::fabs(reading - _pending_outlier) <= threshold) {
+        // A second reading near the first confirms a real step (for example a
+        // cup being placed) rather than an isolated electrical/mechanical spike.
+        _has_pending_outlier = false;
+    } else {
+        _pending_outlier = reading;
+        _has_pending_outlier = true;
+        return false;
+    }
+
+    _previous_accepted_reading = _last_accepted_reading;
+    _last_accepted_reading = reading;
+    accepted = reading;
+    return true;
+}
+
+float HardwareScale::getWeight() const {
+    return _weight.load();
+}
 
 void HardwareScale::loop() {
-    if (!_initialized) {
-        _readingCallback(HARDWARE_SCALE_UNAVAILABLE);
+    // Send sentinel value if scale is not initialized
+    if (!is_initialized) {
+        _reading_callback(HARDWARE_SCALE_UNAVAILABLE); // Sentinel value to signal scale unavailable
         return;
     }
 
-    const unsigned long startWait = millis();
-    while (!_scaleFactorsReady) {
+    // Wait for scale factors to be properly set before starting weight calculations
+    // Use a reasonable timeout to prevent indefinite waiting
+    unsigned long startWait = millis();
+    const unsigned long SCALE_FACTOR_TIMEOUT_MS = 10000; // 10 seconds should be enough for BLE connection
+
+    ESP_LOGV(LOG_TAG, "Waiting for scale factors from display controller...");
+
+    while (!_scale_factors_ready) {
         if (millis() - startWait > SCALE_FACTOR_TIMEOUT_MS) {
-            ESP_LOGW(LOG_TAG, "Scale factor timeout, continuing with defaults");
-            _scaleFactorsReady = true;
+            ESP_LOGW(LOG_TAG, "⚠️ Timeout waiting for scale factors after %lu ms, proceeding with defaults (readings will be inaccurate until calibrated)", SCALE_FACTOR_TIMEOUT_MS);
+            _scale_factors_ready = true; // Allow operation with default factors
             break;
         }
-        vTaskDelay(pdMS_TO_TICKS(250));
+        vTaskDelay(pdMS_TO_TICKS(250)); // Check every 250ms for scale factors
     }
 
-    xSemaphoreTake(_operationMutex, portMAX_DELAY);
-    while (!isReady()) {
-        vTaskDelay(1);
+    xSemaphoreTake(_operation_mutex, portMAX_DELAY);
+    if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+        xSemaphoreGive(_operation_mutex);
+        _consecutive_read_failures++;
+        if (_consecutive_read_failures >= READ_FAILURES_BEFORE_FAULT && !_read_fault_reported) {
+            ESP_LOGE(LOG_TAG, "HX711 runtime timeout (%d, %d); marking scale unavailable until readings recover",
+                     digitalRead(_data_pin1), digitalRead(_data_pin2));
+            _read_fault_reported = true;
+            _reading_callback(HARDWARE_SCALE_UNAVAILABLE);
+        }
+        return;
     }
 
-    _rawWeight = readRaw();
-    const float reading = convertRawToWeight(_rawWeight);
-    // Always advance the filter state. A deadband here caused small changes to
-    // be discarded until a larger reading produced a visible jump.
-    float filteredWeight = SCALE_FILTER_ALPHA * reading + (1.0f - SCALE_FILTER_ALPHA) * _weight.load();
-    filteredWeight = std::clamp(filteredWeight, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
-    _weight.store(filteredWeight);
-    xSemaphoreGive(_operationMutex);
+    _raw_weight = readRaw();
+    ESP_LOGV(LOG_TAG, "Raw Scale Reading: %ld, %ld", _raw_weight.value1, _raw_weight.value2);
+    float reading = 0.0f;
+    float accepted = 0.0f;
+    if (!convertRawToWeight(_raw_weight, reading)) {
+        xSemaphoreGive(_operation_mutex);
+        _consecutive_read_failures++;
+        if (_consecutive_read_failures == 1 || _consecutive_read_failures == READ_FAILURES_BEFORE_FAULT) {
+            ESP_LOGW(LOG_TAG, "Rejected invalid HX711 sample: %ld, %ld", _raw_weight.value1, _raw_weight.value2);
+        }
+        if (_consecutive_read_failures >= READ_FAILURES_BEFORE_FAULT && !_read_fault_reported) {
+            _read_fault_reported = true;
+            _reading_callback(HARDWARE_SCALE_UNAVAILABLE);
+        }
+        return;
+    }
 
-    _readingCallback(filteredWeight);
+    if (!acceptReading(reading, accepted)) {
+        xSemaphoreGive(_operation_mutex);
+        ESP_LOGD(LOG_TAG, "Holding possible scale outlier: %.2fg", reading);
+        return;
+    }
+
+    const bool responsive = isResponsive();
+    float corrected = accepted - _zero_bias;
+
+    // Qualify slow zero correction using a median-filtered rolling range. This
+    // rejects both individual spikes and gradual movement that would pass a
+    // consecutive-sample delta test. It runs only in the idle path and does not
+    // add latency to the reported scale measurement.
+    if (responsive) {
+        resetZeroTrackingHistory();
+    } else {
+        _zero_median_samples[_zero_median_index] = accepted;
+        _zero_median_index = (_zero_median_index + 1) % SCALE_ZERO_TRACK_MEDIAN_SAMPLES;
+        if (_zero_median_count < SCALE_ZERO_TRACK_MEDIAN_SAMPLES) {
+            _zero_median_count++;
+        }
+
+        if (_zero_median_count == SCALE_ZERO_TRACK_MEDIAN_SAMPLES) {
+            float sortedMedianSamples[SCALE_ZERO_TRACK_MEDIAN_SAMPLES];
+            std::copy(_zero_median_samples,
+                      _zero_median_samples + SCALE_ZERO_TRACK_MEDIAN_SAMPLES,
+                      sortedMedianSamples);
+            std::sort(sortedMedianSamples, sortedMedianSamples + SCALE_ZERO_TRACK_MEDIAN_SAMPLES);
+            const float medianAccepted = sortedMedianSamples[SCALE_ZERO_TRACK_MEDIAN_SAMPLES / 2];
+
+            if (std::fabs(medianAccepted - _zero_bias) <= SCALE_ZERO_TRACK_WINDOW_GRAMS) {
+                _zero_stability_samples[_zero_stability_index] = medianAccepted;
+                _zero_stability_index =
+                    (_zero_stability_index + 1) % SCALE_ZERO_TRACK_STABILITY_SAMPLES;
+                if (_zero_stability_count < SCALE_ZERO_TRACK_STABILITY_SAMPLES) {
+                    _zero_stability_count++;
+                }
+
+                if (_zero_stability_count == SCALE_ZERO_TRACK_STABILITY_SAMPLES) {
+                    const auto [minimum, maximum] = std::minmax_element(
+                        _zero_stability_samples,
+                        _zero_stability_samples + SCALE_ZERO_TRACK_STABILITY_SAMPLES);
+                    const bool allNearZero = std::all_of(
+                        _zero_stability_samples,
+                        _zero_stability_samples + SCALE_ZERO_TRACK_STABILITY_SAMPLES,
+                        [this](float sample) {
+                            return std::fabs(sample - _zero_bias) <= SCALE_ZERO_TRACK_WINDOW_GRAMS;
+                        });
+
+                    if (allNearZero && *maximum - *minimum <= SCALE_ZERO_TRACK_MAX_RANGE_GRAMS) {
+                        float mean = 0.0f;
+                        for (float sample : _zero_stability_samples) {
+                            mean += sample;
+                        }
+                        mean /= SCALE_ZERO_TRACK_STABILITY_SAMPLES;
+                        _zero_bias = std::clamp(
+                            _zero_bias + SCALE_ZERO_TRACK_ALPHA * (mean - _zero_bias),
+                            -SCALE_ZERO_TRACK_MAX_BIAS_GRAMS,
+                            SCALE_ZERO_TRACK_MAX_BIAS_GRAMS);
+                        corrected = accepted - _zero_bias;
+                    }
+                }
+            } else {
+                resetZeroTrackingHistory();
+            }
+        }
+    }
+
+    const float alpha = responsive ? SCALE_FILTER_ALPHA_ACTIVE : SCALE_FILTER_ALPHA_IDLE;
+    const float filtered_weight = alpha * corrected + (1.0f - alpha) * _weight.load();
+    _weight.store(filtered_weight);
+
+    // The UI renders tenths of a gram. Publishing with hysteresis prevents a
+    // stable value near a rounding boundary (for example 0.049/0.051g) from
+    // alternating between adjacent digits. This does not affect the internal
+    // fast filter, and is bypassed completely during scale-responsive activity.
+    float output_weight = filtered_weight;
+    if (!responsive) {
+        if (std::fabs(filtered_weight - _published_weight) >= SCALE_DISPLAY_SWITCH_GRAMS) {
+            _published_weight =
+                std::round(filtered_weight / SCALE_DISPLAY_STEP_GRAMS) * SCALE_DISPLAY_STEP_GRAMS;
+            if (std::fabs(_published_weight) < SCALE_DISPLAY_STEP_GRAMS * 0.5f) {
+                _published_weight = 0.0f;
+            }
+        }
+        output_weight = _published_weight;
+    }
+    xSemaphoreGive(_operation_mutex);
+
+    if (_read_fault_reported) {
+        ESP_LOGI(LOG_TAG, "HX711 readings recovered");
+    }
+    _consecutive_read_failures = 0;
+    _read_fault_reported = false;
+    ESP_LOGV(LOG_TAG, "Scale Reading: %0.2f, Corrected: %0.2f, Filtered: %0.2f, Published: %0.2f, alpha: %.2f",
+             reading, corrected, filtered_weight, output_weight, alpha);
+    _reading_callback(output_weight);
 }
 
 void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
-    if (!std::isfinite(scale_factor1) || !std::isfinite(scale_factor2) || std::abs(scale_factor1) < 0.001f ||
-        std::abs(scale_factor2) < 0.001f) {
-        ESP_LOGW(LOG_TAG, "Ignoring invalid scale factors: %.3f, %.3f", scale_factor1, scale_factor2);
+    if (!validScaleFactor(scale_factor1) || !validScaleFactor(scale_factor2)) {
+        ESP_LOGE(LOG_TAG, "Rejected invalid scale factors: %.3f, %.3f", scale_factor1, scale_factor2);
         return;
     }
-    xSemaphoreTake(_operationMutex, portMAX_DELAY);
-    _scaleFactor1 = scale_factor1;
-    _scaleFactor2 = scale_factor2;
-    xSemaphoreGive(_operationMutex);
-    _scaleFactorsReady = true;
-    ESP_LOGI(LOG_TAG, "Scale factors applied: %.3f, %.3f", _scaleFactor1, _scaleFactor2);
+    xSemaphoreTake(_operation_mutex, portMAX_DELAY);
+    _scale_factor1 = scale_factor1;
+    _scale_factor2 = scale_factor2;
+    // Zero correction is expressed in grams and is no longer valid after the
+    // raw-counts-per-gram calibration changes.
+    _zero_bias = 0.0f;
+    resetZeroTrackingHistory();
+    xSemaphoreGive(_operation_mutex);
+    _scale_factors_ready = true;
+    ESP_LOGI(LOG_TAG, "✓ Scale factors received and applied: %.3f, %.3f - scale readings now calibrated", _scale_factor1, _scale_factor2);
 }
 
-void HardwareScale::tare() {
-    xSemaphoreTake(_operationMutex, portMAX_DELAY);
+bool HardwareScale::tare() {
+    xSemaphoreTake(_operation_mutex, portMAX_DELAY);
 
-    int64_t sum1 = 0;
-    int64_t sum2 = 0;
-    for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
-        while (!isReady()) {
-            delay(1);
+    RawReading samples[SCALE_TARE_SAMPLES]{};
+    bool stable = false;
+    for (uint8_t attempt = 0; attempt < TARE_MAX_ATTEMPTS && !stable; ++attempt) {
+        bool complete = true;
+        for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
+            if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+                complete = false;
+                break;
+            }
+            samples[i] = readRaw();
         }
-        const auto raw = readRaw();
-        sum1 += raw.value1;
-        sum2 += raw.value2;
+        if (!complete) {
+            ESP_LOGW(LOG_TAG, "Tare attempt %u timed out waiting for HX711 data", attempt + 1);
+            continue;
+        }
+
+        const auto [min1, max1] = std::minmax_element(
+            samples, samples + SCALE_TARE_SAMPLES, [](const RawReading &a, const RawReading &b) { return a.value1 < b.value1; });
+        const auto [min2, max2] = std::minmax_element(
+            samples, samples + SCALE_TARE_SAMPLES, [](const RawReading &a, const RawReading &b) { return a.value2 < b.value2; });
+        const float spread = std::fabs(static_cast<float>(max1->value1 - min1->value1) / _scale_factor1) +
+                             std::fabs(static_cast<float>(max2->value2 - min2->value2) / _scale_factor2);
+        stable = std::isfinite(spread) && spread <= TARE_MAX_SPREAD_GRAMS;
+        if (!stable) {
+            ESP_LOGW(LOG_TAG, "Tare attempt %u unstable (%.3fg spread)", attempt + 1, spread);
+        }
     }
 
-    _offset1 = static_cast<float>(sum1) / SCALE_TARE_SAMPLES;
-    _offset2 = static_cast<float>(sum2) / SCALE_TARE_SAMPLES;
-    _weight.store(0.0f);
-    xSemaphoreGive(_operationMutex);
-    ESP_LOGI(LOG_TAG, "Tared scale offsets from %u samples: %.3f, %.3f", SCALE_TARE_SAMPLES, _offset1, _offset2);
+    if (!stable) {
+        xSemaphoreGive(_operation_mutex);
+        ESP_LOGE(LOG_TAG, "Tare rejected after %u unstable/timeout attempts; preserving previous offsets", TARE_MAX_ATTEMPTS);
+        return false;
+    }
+
+    long values1[SCALE_TARE_SAMPLES];
+    long values2[SCALE_TARE_SAMPLES];
+    for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
+        values1[i] = samples[i].value1;
+        values2[i] = samples[i].value2;
+    }
+    std::sort(values1, values1 + SCALE_TARE_SAMPLES);
+    std::sort(values2, values2 + SCALE_TARE_SAMPLES);
+    // Trim the high and low sample from each cell, then average the middle three.
+    _offset1 = static_cast<float>(static_cast<int64_t>(values1[1]) + values1[2] + values1[3]) / 3.0f;
+    _offset2 = static_cast<float>(static_cast<int64_t>(values2[1]) + values2[2] + values2[3]) / 3.0f;
+    _weight.store(0.0f); // Reset weight to zero after tare
+    resetFilterState();
+    xSemaphoreGive(_operation_mutex);
+    ESP_LOGI(LOG_TAG, "Tared scale offsets from %u stable samples: %.3f, %.3f", SCALE_TARE_SAMPLES, _offset1, _offset2);
+    return true;
 }
 
 void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
-    xSemaphoreTake(_operationMutex, portMAX_DELAY);
+    if (scale > 1 || !std::isfinite(calibrationWeight) || calibrationWeight <= 0.0f || calibrationWeight > MAX_SCALE_GRAMS) {
+        ESP_LOGE(LOG_TAG, "Rejected invalid calibration request: cell=%u weight=%.3f", scale, calibrationWeight);
+        return;
+    }
+    xSemaphoreTake(_operation_mutex, portMAX_DELAY);
 
     int64_t value = 0;
     for (int i = 0; i < 10; i++) {
-        while (!isReady()) {
-            delay(10);
+        if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+            xSemaphoreGive(_operation_mutex);
+            ESP_LOGE(LOG_TAG, "Calibration timed out waiting for HX711 data");
+            return;
         }
-        value += (scale == 0) ? readRaw().value1 : readRaw().value2;
+        value += (scale == 0) ? readRaw().value1 : readRaw().value2; // Read from the first scale
     }
     value /= 10;
 
+    const float factor = (static_cast<float>(value) - (scale == 0 ? _offset1 : _offset2)) / calibrationWeight;
+    if (!validScaleFactor(factor)) {
+        xSemaphoreGive(_operation_mutex);
+        ESP_LOGE(LOG_TAG, "Rejected invalid calculated scale factor: %.3f", factor);
+        return;
+    }
     if (scale == 0) {
-        _scaleFactor1 = (static_cast<float>(value) - _offset1) / calibrationWeight;
-    } else if (scale == 1) {
-        _scaleFactor2 = (static_cast<float>(value) - _offset2) / calibrationWeight;
+        _scale_factor1 = factor;
+    } else {
+        _scale_factor2 = factor;
     }
 
-    xSemaphoreGive(_operationMutex);
-    _configurationCallback(_scaleFactor1, _scaleFactor2);
+    xSemaphoreGive(_operation_mutex);
+    ESP_LOGI(LOG_TAG, "Calibrated scale %d with factor: %.3f", scale, (scale == 0 ? _scale_factor1 : _scale_factor2));
+    _configuration_callback(_scale_factor1, _scale_factor2);
 }
 
-void HardwareScale::loopTask(void *arg) {
+[[noreturn]] void HardwareScale::loopTask(void *arg) {
     TickType_t lastWake = xTaskGetTickCount();
     auto *scale = static_cast<HardwareScale *>(arg);
     while (true) {

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -7,20 +7,30 @@
 
 #define HX711_GAIN 128
 #define MAX_SCALE_GRAMS 2000.0f
-#define MAX_WAIT_READ_MS 250
 #define MAX_STARTUP_WAIT_MS 1200
 
 namespace {
 constexpr float MIN_ABS_SCALE_FACTOR = 1.0f;
 constexpr float TARE_MAX_SPREAD_GRAMS = 0.50f;
 constexpr uint8_t TARE_MAX_ATTEMPTS = 2;
-constexpr uint8_t READ_FAILURES_BEFORE_FAULT = 3;
+constexpr uint8_t MAX_TARE_SAMPLES = 20;
+constexpr uint8_t MAX_CALIBRATION_SAMPLES = 40;
+constexpr unsigned long READ_FAULT_DELAY_MS = 750;
+// Slightly below 100 ms so a nominal 10-SPS converter whose millis() spacing
+// occasionally rounds to 99 ms is not accidentally published at only 5 SPS.
+constexpr unsigned long SCALE_PUBLICATION_INTERVAL_MS = 90;
+constexpr unsigned long ZERO_TRACKING_OBSERVATION_INTERVAL_MS = 100;
+constexpr unsigned long INTERVAL_DIAGNOSTIC_PERIOD_MS = 5000;
 constexpr unsigned long ACTIVE_FILTER_LINGER_MS = 5000;
 constexpr float ACTIVE_OUTLIER_THRESHOLD_GRAMS = 0.75f;
 
 bool validScaleFactor(float factor) { return std::isfinite(factor) && std::fabs(factor) >= MIN_ABS_SCALE_FACTOR; }
 
 bool saturatedReading(long value) { return value == 0x7FFFFF || value == -0x800000; }
+
+bool validSampleRate(uint16_t sampleRateSps) { return sampleRateSps == 10 || sampleRateSps == 80; }
+
+bool validAlpha(float alpha) { return std::isfinite(alpha) && alpha > 0.0f && alpha <= 1.0f; }
 } // namespace
 
 HardwareScale::HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin,
@@ -65,7 +75,7 @@ void HardwareScale::setup() {
     // do a warm-up of 5 readings
     for (int i = 0; i < 5; i++) {
         long start = millis();
-        while (!isReady() && (millis() - start) < MAX_WAIT_READ_MS) {
+        while (!isReady() && (millis() - start) < readyTimeoutMs()) {
             delay(10);
         }
         if (!isReady()) {
@@ -75,8 +85,11 @@ void HardwareScale::setup() {
         }
         readRaw();
     }
-    if (!tare()) {
-        ESP_LOGE(LOG_TAG, "Unable to obtain a stable initial tare");
+    // A noisy boot window must not make otherwise responsive HX711 hardware
+    // unavailable. Unlike a user-requested tare, startup may use a trimmed-mean
+    // fallback from a complete sample set when the stability check fails.
+    if (!tareInternal(true)) {
+        ESP_LOGE(LOG_TAG, "Unable to read enough samples for the initial tare");
         is_initialized = false;
         return;
     }
@@ -154,20 +167,21 @@ HardwareScale::RawReading HardwareScale::readRaw() {
     return {static_cast<long>(value1), static_cast<long>(value2)};
 }
 
-bool HardwareScale::convertRawToWeight(const RawReading &raw, float &weight) const {
+bool HardwareScale::convertRawToWeight(const RawReading &raw, float &weight, float &cell1Weight,
+                                       float &cell2Weight) const {
     if (saturatedReading(raw.value1) || saturatedReading(raw.value2) || !validScaleFactor(_scale_factor1) ||
         !validScaleFactor(_scale_factor2)) {
         return false;
     }
 
-    const float weight1 = (static_cast<float>(raw.value1) - _offset1) / _scale_factor1;
-    const float weight2 = (static_cast<float>(raw.value2) - _offset2) / _scale_factor2;
-    if (!std::isfinite(weight1) || !std::isfinite(weight2) || std::fabs(weight1) > MAX_SCALE_GRAMS ||
-        std::fabs(weight2) > MAX_SCALE_GRAMS) {
+    cell1Weight = (static_cast<float>(raw.value1) - _offset1) / _scale_factor1;
+    cell2Weight = (static_cast<float>(raw.value2) - _offset2) / _scale_factor2;
+    if (!std::isfinite(cell1Weight) || !std::isfinite(cell2Weight) || std::fabs(cell1Weight) > MAX_SCALE_GRAMS ||
+        std::fabs(cell2Weight) > MAX_SCALE_GRAMS) {
         return false;
     }
 
-    const float combined = weight1 + weight2;
+    const float combined = cell1Weight + cell2Weight;
     if (!std::isfinite(combined) || std::fabs(combined) > MAX_SCALE_GRAMS) {
         return false;
     }
@@ -201,6 +215,47 @@ void HardwareScale::resetZeroTrackingHistory() {
     _zero_median_index = 0;
     _zero_stability_count = 0;
     _zero_stability_index = 0;
+    _last_zero_tracking_observation_ms = 0;
+}
+
+unsigned long HardwareScale::readyTimeoutMs() const {
+    // Allow several expected conversion periods while still detecting a dead
+    // converter promptly. DOUT readiness, not this estimate, gates every read.
+    const unsigned long expectedMs = (1000UL + _config.sampleRateSps - 1) / _config.sampleRateSps;
+    return std::max(100UL, expectedMs * 3UL);
+}
+
+uint8_t HardwareScale::tareSampleCount() const { return _config.sampleRateSps == 80 ? MAX_TARE_SAMPLES : 5; }
+
+uint8_t HardwareScale::calibrationSampleCount() const {
+    return _config.sampleRateSps == 80 ? MAX_CALIBRATION_SAMPLES : 10;
+}
+
+void HardwareScale::recordConversionInterval() {
+    const unsigned long nowUs = micros();
+    if (_last_conversion_us != 0) {
+        const uint32_t intervalUs = nowUs - _last_conversion_us;
+        _interval_total_us += intervalUs;
+        _interval_count++;
+        _interval_min_us = std::min(_interval_min_us, intervalUs);
+        _interval_max_us = std::max(_interval_max_us, intervalUs);
+    }
+    _last_conversion_us = nowUs;
+
+    const unsigned long nowMs = millis();
+    if (_interval_log_started_ms == 0) {
+        _interval_log_started_ms = nowMs;
+    } else if (nowMs - _interval_log_started_ms >= INTERVAL_DIAGNOSTIC_PERIOD_MS && _interval_count > 0) {
+        ESP_LOGV(LOG_TAG, "HX711 conversion intervals: configured=%u SPS, n=%lu, avg=%.2f ms, min=%.2f ms, max=%.2f ms",
+                 _config.sampleRateSps, static_cast<unsigned long>(_interval_count),
+                 static_cast<double>(_interval_total_us) / _interval_count / 1000.0,
+                 static_cast<double>(_interval_min_us) / 1000.0, static_cast<double>(_interval_max_us) / 1000.0);
+        _interval_log_started_ms = nowMs;
+        _interval_count = 0;
+        _interval_total_us = 0;
+        _interval_min_us = UINT32_MAX;
+        _interval_max_us = 0;
+    }
 }
 
 bool HardwareScale::acceptReading(float reading, float &accepted) {
@@ -234,6 +289,8 @@ bool HardwareScale::acceptReading(float reading, float &accepted) {
     } else if (_has_pending_outlier && std::fabs(reading - _pending_outlier) <= threshold) {
         // A second reading near the first confirms a real step (for example a
         // cup being placed) rather than an isolated electrical/mechanical spike.
+        // This is intentionally consecutive-conversion logic: at 80 SPS a real
+        // step is confirmed sooner, while a one-conversion glitch is still held.
         _has_pending_outlier = false;
     } else {
         _pending_outlier = reading;
@@ -254,7 +311,7 @@ float HardwareScale::getWeight() const {
 void HardwareScale::loop() {
     // Send sentinel value if scale is not initialized
     if (!is_initialized) {
-        _reading_callback(HARDWARE_SCALE_UNAVAILABLE); // Sentinel value to signal scale unavailable
+        _reading_callback(HARDWARE_SCALE_UNAVAILABLE, 0.0f, 0.0f, false, false);
         return;
     }
 
@@ -275,34 +332,44 @@ void HardwareScale::loop() {
     }
 
     xSemaphoreTake(_operation_mutex, portMAX_DELAY);
-    if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+    if (!waitUntilReady(readyTimeoutMs())) {
         xSemaphoreGive(_operation_mutex);
-        _consecutive_read_failures++;
-        if (_consecutive_read_failures >= READ_FAILURES_BEFORE_FAULT && !_read_fault_reported) {
+        if (_read_failure_started_ms == 0) {
+            _read_failure_started_ms = millis();
+        }
+        if (millis() - _read_failure_started_ms >= READ_FAULT_DELAY_MS && !_read_fault_reported) {
             ESP_LOGE(LOG_TAG, "HX711 runtime timeout (%d, %d); marking scale unavailable until readings recover",
                      digitalRead(_data_pin1), digitalRead(_data_pin2));
             _read_fault_reported = true;
-            _reading_callback(HARDWARE_SCALE_UNAVAILABLE);
+            _reading_callback(HARDWARE_SCALE_UNAVAILABLE, 0.0f, 0.0f, false, false);
         }
         return;
     }
 
     _raw_weight = readRaw();
-    ESP_LOGV(LOG_TAG, "Raw Scale Reading: %ld, %ld", _raw_weight.value1, _raw_weight.value2);
+    recordConversionInterval();
     float reading = 0.0f;
     float accepted = 0.0f;
-    if (!convertRawToWeight(_raw_weight, reading)) {
+    float cell1Weight = 0.0f;
+    float cell2Weight = 0.0f;
+    if (!convertRawToWeight(_raw_weight, reading, cell1Weight, cell2Weight)) {
         xSemaphoreGive(_operation_mutex);
-        _consecutive_read_failures++;
-        if (_consecutive_read_failures == 1 || _consecutive_read_failures == READ_FAILURES_BEFORE_FAULT) {
+        if (_read_failure_started_ms == 0) {
+            _read_failure_started_ms = millis();
             ESP_LOGW(LOG_TAG, "Rejected invalid HX711 sample: %ld, %ld", _raw_weight.value1, _raw_weight.value2);
         }
-        if (_consecutive_read_failures >= READ_FAILURES_BEFORE_FAULT && !_read_fault_reported) {
+        if (millis() - _read_failure_started_ms >= READ_FAULT_DELAY_MS && !_read_fault_reported) {
             _read_fault_reported = true;
-            _reading_callback(HARDWARE_SCALE_UNAVAILABLE);
+            _reading_callback(HARDWARE_SCALE_UNAVAILABLE, 0.0f, 0.0f, false, false);
         }
         return;
     }
+
+    if (_read_fault_reported) {
+        ESP_LOGI(LOG_TAG, "HX711 readings recovered");
+    }
+    _read_failure_started_ms = 0;
+    _read_fault_reported = false;
 
     if (!acceptReading(reading, accepted)) {
         xSemaphoreGive(_operation_mutex);
@@ -319,7 +386,9 @@ void HardwareScale::loop() {
     // add latency to the reported scale measurement.
     if (responsive) {
         resetZeroTrackingHistory();
-    } else {
+    } else if (_last_zero_tracking_observation_ms == 0 ||
+               millis() - _last_zero_tracking_observation_ms >= ZERO_TRACKING_OBSERVATION_INTERVAL_MS) {
+        _last_zero_tracking_observation_ms = millis();
         _zero_median_samples[_zero_median_index] = accepted;
         _zero_median_index = (_zero_median_index + 1) % SCALE_ZERO_TRACK_MEDIAN_SAMPLES;
         if (_zero_median_count < SCALE_ZERO_TRACK_MEDIAN_SAMPLES) {
@@ -372,7 +441,7 @@ void HardwareScale::loop() {
         }
     }
 
-    const float alpha = responsive ? SCALE_FILTER_ALPHA_ACTIVE : SCALE_FILTER_ALPHA_IDLE;
+    const float alpha = responsive ? _config.activeAlpha : _config.idleAlpha;
     const float filtered_weight = alpha * corrected + (1.0f - alpha) * _weight.load();
     _weight.store(filtered_weight);
 
@@ -393,85 +462,137 @@ void HardwareScale::loop() {
     }
     xSemaphoreGive(_operation_mutex);
 
-    if (_read_fault_reported) {
-        ESP_LOGI(LOG_TAG, "HX711 readings recovered");
-    }
-    _consecutive_read_failures = 0;
-    _read_fault_reported = false;
     ESP_LOGV(LOG_TAG, "Scale Reading: %0.2f, Corrected: %0.2f, Filtered: %0.2f, Published: %0.2f, alpha: %.2f",
              reading, corrected, filtered_weight, output_weight, alpha);
-    _reading_callback(output_weight);
+    const unsigned long now = millis();
+    if (_last_publish_ms == 0 || now - _last_publish_ms >= SCALE_PUBLICATION_INTERVAL_MS) {
+        _last_publish_ms = now;
+        _reading_callback(output_weight, cell1Weight, cell2Weight, true, true);
+    }
 }
 
 void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
-    if (!validScaleFactor(scale_factor1) || !validScaleFactor(scale_factor2)) {
-        ESP_LOGE(LOG_TAG, "Rejected invalid scale factors: %.3f, %.3f", scale_factor1, scale_factor2);
-        return;
+    setConfiguration(scale_factor1, scale_factor2, _config.sampleRateSps, _config.idleAlpha, _config.activeAlpha);
+}
+
+void HardwareScale::setConfiguration(float scale_factor1, float scale_factor2, uint16_t sample_rate_sps,
+                                     float idle_alpha, float active_alpha) {
+    if (!validScaleFactor(scale_factor1)) {
+        ESP_LOGW(LOG_TAG, "Invalid scale factor 1 %.3f; using -2500 counts/g", scale_factor1);
+        scale_factor1 = -2500.0f;
+    }
+    if (!validScaleFactor(scale_factor2)) {
+        ESP_LOGW(LOG_TAG, "Invalid scale factor 2 %.3f; using 2500 counts/g", scale_factor2);
+        scale_factor2 = 2500.0f;
+    }
+    if (!validSampleRate(sample_rate_sps)) {
+        ESP_LOGW(LOG_TAG, "Invalid/missing HX711 sample rate %u; using 10 SPS", sample_rate_sps);
+        sample_rate_sps = HARDWARE_SCALE_DEFAULT_SAMPLE_RATE_SPS;
+    }
+    if (!validAlpha(idle_alpha)) {
+        ESP_LOGW(LOG_TAG, "Invalid/missing idle filter alpha %.3f; using %.2f", idle_alpha,
+                 HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_IDLE);
+        idle_alpha = HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_IDLE;
+    }
+    if (!validAlpha(active_alpha)) {
+        ESP_LOGW(LOG_TAG, "Invalid/missing brewing filter alpha %.3f; using %.2f", active_alpha,
+                 HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_ACTIVE);
+        active_alpha = HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_ACTIVE;
     }
     xSemaphoreTake(_operation_mutex, portMAX_DELAY);
     _scale_factor1 = scale_factor1;
     _scale_factor2 = scale_factor2;
+    _config = {sample_rate_sps, idle_alpha, active_alpha};
+    _last_conversion_us = 0;
+    _interval_log_started_ms = 0;
+    _interval_count = 0;
+    _interval_total_us = 0;
+    _interval_min_us = UINT32_MAX;
+    _interval_max_us = 0;
     // Zero correction is expressed in grams and is no longer valid after the
     // raw-counts-per-gram calibration changes.
     _zero_bias = 0.0f;
     resetZeroTrackingHistory();
     xSemaphoreGive(_operation_mutex);
     _scale_factors_ready = true;
-    ESP_LOGI(LOG_TAG, "✓ Scale factors received and applied: %.3f, %.3f - scale readings now calibrated", _scale_factor1, _scale_factor2);
+    ESP_LOGI(LOG_TAG, "Hardware scale configuration: sample rate=%u SPS, idle alpha=%.2f, active alpha=%.2f, scale factors=(%.3f, %.3f)",
+             _config.sampleRateSps, _config.idleAlpha, _config.activeAlpha, _scale_factor1, _scale_factor2);
 }
 
-bool HardwareScale::tare() {
+bool HardwareScale::tare() { return tareInternal(false); }
+
+bool HardwareScale::tareInternal(bool allowUnstableFallback) {
     xSemaphoreTake(_operation_mutex, portMAX_DELAY);
 
-    RawReading samples[SCALE_TARE_SAMPLES]{};
+    RawReading samples[MAX_TARE_SAMPLES]{};
+    const uint8_t sampleCount = tareSampleCount();
     bool stable = false;
+    bool haveCompleteSamples = false;
+    float lastSpread = NAN;
     for (uint8_t attempt = 0; attempt < TARE_MAX_ATTEMPTS && !stable; ++attempt) {
+        RawReading attemptSamples[MAX_TARE_SAMPLES]{};
         bool complete = true;
-        for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
-            if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+        for (uint8_t i = 0; i < sampleCount; ++i) {
+            if (!waitUntilReady(readyTimeoutMs())) {
                 complete = false;
                 break;
             }
-            samples[i] = readRaw();
+            attemptSamples[i] = readRaw();
         }
         if (!complete) {
             ESP_LOGW(LOG_TAG, "Tare attempt %u timed out waiting for HX711 data", attempt + 1);
             continue;
         }
+        haveCompleteSamples = true;
+        std::copy(attemptSamples, attemptSamples + sampleCount, samples);
 
         const auto [min1, max1] = std::minmax_element(
-            samples, samples + SCALE_TARE_SAMPLES, [](const RawReading &a, const RawReading &b) { return a.value1 < b.value1; });
+            samples, samples + sampleCount, [](const RawReading &a, const RawReading &b) { return a.value1 < b.value1; });
         const auto [min2, max2] = std::minmax_element(
-            samples, samples + SCALE_TARE_SAMPLES, [](const RawReading &a, const RawReading &b) { return a.value2 < b.value2; });
-        const float spread = std::fabs(static_cast<float>(max1->value1 - min1->value1) / _scale_factor1) +
-                             std::fabs(static_cast<float>(max2->value2 - min2->value2) / _scale_factor2);
-        stable = std::isfinite(spread) && spread <= TARE_MAX_SPREAD_GRAMS;
+            samples, samples + sampleCount, [](const RawReading &a, const RawReading &b) { return a.value2 < b.value2; });
+        lastSpread = std::fabs(static_cast<float>(max1->value1 - min1->value1) / _scale_factor1) +
+                     std::fabs(static_cast<float>(max2->value2 - min2->value2) / _scale_factor2);
+        stable = std::isfinite(lastSpread) && lastSpread <= TARE_MAX_SPREAD_GRAMS;
         if (!stable) {
-            ESP_LOGW(LOG_TAG, "Tare attempt %u unstable (%.3fg spread)", attempt + 1, spread);
+            ESP_LOGW(LOG_TAG, "Tare attempt %u unstable (%.3fg spread)", attempt + 1, lastSpread);
         }
     }
 
-    if (!stable) {
+    if (!stable && (!allowUnstableFallback || !haveCompleteSamples)) {
         xSemaphoreGive(_operation_mutex);
         ESP_LOGE(LOG_TAG, "Tare rejected after %u unstable/timeout attempts; preserving previous offsets", TARE_MAX_ATTEMPTS);
         return false;
     }
 
-    long values1[SCALE_TARE_SAMPLES];
-    long values2[SCALE_TARE_SAMPLES];
-    for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
+    if (!stable) {
+        ESP_LOGW(LOG_TAG,
+                 "Initial tare exceeded the %.2fg stability limit (%.3fg spread); using robust offsets so scale acquisition can start",
+                 TARE_MAX_SPREAD_GRAMS, lastSpread);
+    }
+
+    long values1[MAX_TARE_SAMPLES];
+    long values2[MAX_TARE_SAMPLES];
+    for (uint8_t i = 0; i < sampleCount; ++i) {
         values1[i] = samples[i].value1;
         values2[i] = samples[i].value2;
     }
-    std::sort(values1, values1 + SCALE_TARE_SAMPLES);
-    std::sort(values2, values2 + SCALE_TARE_SAMPLES);
-    // Trim the high and low sample from each cell, then average the middle three.
-    _offset1 = static_cast<float>(static_cast<int64_t>(values1[1]) + values1[2] + values1[3]) / 3.0f;
-    _offset2 = static_cast<float>(static_cast<int64_t>(values2[1]) + values2[2] + values2[3]) / 3.0f;
+    std::sort(values1, values1 + sampleCount);
+    std::sort(values2, values2 + sampleCount);
+    // Trim one high and low sample from each cell, then average the remainder.
+    int64_t sum1 = 0;
+    int64_t sum2 = 0;
+    for (uint8_t i = 1; i + 1 < sampleCount; ++i) {
+        sum1 += values1[i];
+        sum2 += values2[i];
+    }
+    _offset1 = static_cast<float>(sum1) / (sampleCount - 2);
+    _offset2 = static_cast<float>(sum2) / (sampleCount - 2);
     _weight.store(0.0f); // Reset weight to zero after tare
     resetFilterState();
+    _last_conversion_us = 0;
     xSemaphoreGive(_operation_mutex);
-    ESP_LOGI(LOG_TAG, "Tared scale offsets from %u stable samples: %.3f, %.3f", SCALE_TARE_SAMPLES, _offset1, _offset2);
+    ESP_LOGI(LOG_TAG, "Tared scale offsets from %u %s samples: %.3f, %.3f", sampleCount,
+             stable ? "stable" : "startup fallback", _offset1, _offset2);
     return true;
 }
 
@@ -483,18 +604,21 @@ void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
     xSemaphoreTake(_operation_mutex, portMAX_DELAY);
 
     int64_t value = 0;
-    for (int i = 0; i < 10; i++) {
-        if (!waitUntilReady(MAX_WAIT_READ_MS)) {
+    const uint8_t sampleCount = calibrationSampleCount();
+    for (uint8_t i = 0; i < sampleCount; i++) {
+        if (!waitUntilReady(readyTimeoutMs())) {
+            _last_conversion_us = 0;
             xSemaphoreGive(_operation_mutex);
             ESP_LOGE(LOG_TAG, "Calibration timed out waiting for HX711 data");
             return;
         }
         value += (scale == 0) ? readRaw().value1 : readRaw().value2; // Read from the first scale
     }
-    value /= 10;
+    value /= sampleCount;
 
     const float factor = (static_cast<float>(value) - (scale == 0 ? _offset1 : _offset2)) / calibrationWeight;
     if (!validScaleFactor(factor)) {
+        _last_conversion_us = 0;
         xSemaphoreGive(_operation_mutex);
         ESP_LOGE(LOG_TAG, "Rejected invalid calculated scale factor: %.3f", factor);
         return;
@@ -505,16 +629,19 @@ void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
         _scale_factor2 = factor;
     }
 
+    _last_conversion_us = 0;
     xSemaphoreGive(_operation_mutex);
     ESP_LOGI(LOG_TAG, "Calibrated scale %d with factor: %.3f", scale, (scale == 0 ? _scale_factor1 : _scale_factor2));
     _configuration_callback(_scale_factor1, _scale_factor2);
 }
 
 [[noreturn]] void HardwareScale::loopTask(void *arg) {
-    TickType_t lastWake = xTaskGetTickCount();
     auto *scale = static_cast<HardwareScale *>(arg);
     while (true) {
+        // loop() waits cooperatively for both DOUT pins to indicate a completed
+        // conversion. This consumes every 10- or 80-SPS conversion without a
+        // fixed polling cadence or a CPU-burning busy loop.
         scale->loop();
-        xTaskDelayUntil(&lastWake, pdMS_TO_TICKS(SCALE_READ_INTERVAL_MS));
+        taskYIELD();
     }
 }

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -1,0 +1,184 @@
+#include "HardwareScale.h"
+
+#include <algorithm>
+#include <cmath>
+
+#define HX711_GAIN 128
+#define MAX_SCALE_GRAMS 750.0f
+#define MAX_WAIT_READ_MS 250
+#define MAX_STARTUP_WAIT_MS 1200
+#define SCALE_FACTOR_TIMEOUT_MS 10000
+#define SCALE_FILTER_ALPHA 0.5f
+
+HardwareScale::HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin,
+                             const scale_reading_callback_t &reading_callback,
+                             const scale_configuration_callback_t &config_callback)
+    : _dataPin1(data_pin1), _dataPin2(data_pin2), _clockPin(clock_pin), _scaleFactor1(-2500.0f), _scaleFactor2(2500.0f),
+      _offset1(0.0f), _offset2(0.0f), _isTaringOrCalibrating(false), _readingCallback(reading_callback),
+      _configurationCallback(config_callback), taskHandle(nullptr) {
+    _rawWeight = {0, 0};
+}
+
+void HardwareScale::setup() {
+    pinMode(_dataPin1, INPUT);
+    pinMode(_dataPin2, INPUT);
+    pinMode(_clockPin, OUTPUT);
+    digitalWrite(_clockPin, LOW);
+
+    unsigned long start = millis();
+    while (!isReady() && (millis() - start) < MAX_STARTUP_WAIT_MS) {
+        delay(10);
+    }
+    if (!isReady()) {
+        ESP_LOGW(LOG_TAG, "HX711 not ready at boot, hardware scale disabled");
+        _initialized = false;
+        return;
+    }
+
+    for (int i = 0; i < 5; i++) {
+        unsigned long readStart = millis();
+        while (!isReady() && (millis() - readStart) < MAX_WAIT_READ_MS) {
+            delay(10);
+        }
+        if (!isReady()) {
+            ESP_LOGW(LOG_TAG, "HX711 warmup failed, hardware scale disabled");
+            _initialized = false;
+            return;
+        }
+        readRaw();
+    }
+
+    tare();
+    _initialized = true;
+    ESP_LOGI(LOG_TAG, "Hardware scale initialized");
+
+    _configurationCallback(_scaleFactor1, _scaleFactor2);
+    xTaskCreate(loopTask, "HardwareScale::loop", configMINIMAL_STACK_SIZE * 3, this, 0, &taskHandle);
+}
+
+bool HardwareScale::isReady() { return digitalRead(_dataPin1) == LOW && digitalRead(_dataPin2) == LOW; }
+
+HardwareScale::RawReading HardwareScale::readRaw() {
+    unsigned long value1 = 0;
+    unsigned long value2 = 0;
+
+    portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
+    portENTER_CRITICAL(&mux);
+
+    for (int8_t i = 23; i >= 0; i--) {
+        digitalWrite(_clockPin, HIGH);
+        delayMicroseconds(1);
+        value1 |= (digitalRead(_dataPin1) << i);
+        value2 |= (digitalRead(_dataPin2) << i);
+        digitalWrite(_clockPin, LOW);
+        delayMicroseconds(1);
+    }
+
+    for (uint8_t i = 0; i < (HX711_GAIN == 128 ? 1 : (HX711_GAIN == 64 ? 3 : 2)); ++i) {
+        digitalWrite(_clockPin, HIGH);
+        delayMicroseconds(1);
+        digitalWrite(_clockPin, LOW);
+        delayMicroseconds(1);
+    }
+
+    portEXIT_CRITICAL(&mux);
+
+    if (value1 & 0x800000) {
+        value1 |= 0xFF000000;
+    }
+    if (value2 & 0x800000) {
+        value2 |= 0xFF000000;
+    }
+
+    return {static_cast<long>(value1), static_cast<long>(value2)};
+}
+
+float HardwareScale::convertRawToWeight(const RawReading &raw) const {
+    const float weight1 = (static_cast<float>(raw.value1) - _offset1) / _scaleFactor1;
+    const float weight2 = (static_cast<float>(raw.value2) - _offset2) / _scaleFactor2;
+    return std::clamp(std::round((weight1 + weight2) * 100.0f) / 100.0f, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
+}
+
+float HardwareScale::getWeight() const { return _weight; }
+
+void HardwareScale::loop() {
+    if (!_initialized) {
+        _readingCallback(HARDWARE_SCALE_UNAVAILABLE);
+        return;
+    }
+
+    const unsigned long startWait = millis();
+    while (!_scaleFactorsReady) {
+        if (millis() - startWait > SCALE_FACTOR_TIMEOUT_MS) {
+            ESP_LOGW(LOG_TAG, "Scale factor timeout, continuing with defaults");
+            _scaleFactorsReady = true;
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+
+    while (!isReady() || _isTaringOrCalibrating) {
+        vTaskDelay(1);
+    }
+
+    _rawWeight = readRaw();
+    const float reading = convertRawToWeight(_rawWeight);
+    _weight = SCALE_FILTER_ALPHA * reading + (1.0f - SCALE_FILTER_ALPHA) * _weight;
+    _weight = std::clamp(_weight, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
+    _readingCallback(_weight);
+}
+
+void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
+    if (!std::isfinite(scale_factor1) || !std::isfinite(scale_factor2) || std::abs(scale_factor1) < 0.001f ||
+        std::abs(scale_factor2) < 0.001f) {
+        ESP_LOGW(LOG_TAG, "Ignoring invalid scale factors: %.3f, %.3f", scale_factor1, scale_factor2);
+        return;
+    }
+    _scaleFactor1 = scale_factor1;
+    _scaleFactor2 = scale_factor2;
+    _scaleFactorsReady = true;
+    ESP_LOGI(LOG_TAG, "Scale factors applied: %.3f, %.3f", _scaleFactor1, _scaleFactor2);
+}
+
+void HardwareScale::tare() {
+    _isTaringOrCalibrating = true;
+    while (!isReady()) {
+        delay(10);
+    }
+    const auto raw = readRaw();
+    _offset1 = raw.value1;
+    _offset2 = raw.value2;
+    _weight = 0.0f;
+    _isTaringOrCalibrating = false;
+}
+
+void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
+    _isTaringOrCalibrating = true;
+
+    long value = 0;
+    for (int i = 0; i < 10; i++) {
+        while (!isReady()) {
+            delay(10);
+        }
+        value += (scale == 0) ? readRaw().value1 : readRaw().value2;
+    }
+    value /= 10;
+
+    if (scale == 0) {
+        _scaleFactor1 = (static_cast<float>(value) - _offset1) / calibrationWeight;
+    } else if (scale == 1) {
+        _scaleFactor2 = (static_cast<float>(value) - _offset2) / calibrationWeight;
+    }
+
+    _isTaringOrCalibrating = false;
+    _configurationCallback(_scaleFactor1, _scaleFactor2);
+}
+
+void HardwareScale::loopTask(void *arg) {
+    TickType_t lastWake = xTaskGetTickCount();
+    auto *scale = static_cast<HardwareScale *>(arg);
+    while (true) {
+        scale->loop();
+        xTaskDelayUntil(&lastWake, pdMS_TO_TICKS(SCALE_READ_INTERVAL_MS));
+    }
+}

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.cpp
@@ -9,17 +9,25 @@
 #define MAX_STARTUP_WAIT_MS 1200
 #define SCALE_FACTOR_TIMEOUT_MS 10000
 #define SCALE_FILTER_ALPHA 0.5f
+#define SCALE_TARE_SAMPLES 3
 
 HardwareScale::HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin,
                              const scale_reading_callback_t &reading_callback,
                              const scale_configuration_callback_t &config_callback)
     : _dataPin1(data_pin1), _dataPin2(data_pin2), _clockPin(clock_pin), _scaleFactor1(-2500.0f), _scaleFactor2(2500.0f),
-      _offset1(0.0f), _offset2(0.0f), _isTaringOrCalibrating(false), _readingCallback(reading_callback),
-      _configurationCallback(config_callback), taskHandle(nullptr) {
+      _offset1(0.0f), _offset2(0.0f), _readingCallback(reading_callback), _configurationCallback(config_callback),
+      taskHandle(nullptr), _operationMutex(nullptr) {
     _rawWeight = {0, 0};
 }
 
 void HardwareScale::setup() {
+    _operationMutex = xSemaphoreCreateMutex();
+    if (_operationMutex == nullptr) {
+        ESP_LOGE(LOG_TAG, "Unable to create scale operation mutex");
+        _initialized = false;
+        return;
+    }
+
     pinMode(_dataPin1, INPUT);
     pinMode(_dataPin2, INPUT);
     pinMode(_clockPin, OUTPUT);
@@ -62,8 +70,7 @@ HardwareScale::RawReading HardwareScale::readRaw() {
     unsigned long value1 = 0;
     unsigned long value2 = 0;
 
-    portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
-    portENTER_CRITICAL(&mux);
+    portENTER_CRITICAL(&_readMux);
 
     for (int8_t i = 23; i >= 0; i--) {
         digitalWrite(_clockPin, HIGH);
@@ -81,7 +88,7 @@ HardwareScale::RawReading HardwareScale::readRaw() {
         delayMicroseconds(1);
     }
 
-    portEXIT_CRITICAL(&mux);
+    portEXIT_CRITICAL(&_readMux);
 
     if (value1 & 0x800000) {
         value1 |= 0xFF000000;
@@ -96,10 +103,10 @@ HardwareScale::RawReading HardwareScale::readRaw() {
 float HardwareScale::convertRawToWeight(const RawReading &raw) const {
     const float weight1 = (static_cast<float>(raw.value1) - _offset1) / _scaleFactor1;
     const float weight2 = (static_cast<float>(raw.value2) - _offset2) / _scaleFactor2;
-    return std::clamp(std::round((weight1 + weight2) * 100.0f) / 100.0f, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
+    return std::clamp(weight1 + weight2, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
 }
 
-float HardwareScale::getWeight() const { return _weight; }
+float HardwareScale::getWeight() const { return _weight.load(); }
 
 void HardwareScale::loop() {
     if (!_initialized) {
@@ -117,15 +124,21 @@ void HardwareScale::loop() {
         vTaskDelay(pdMS_TO_TICKS(250));
     }
 
-    while (!isReady() || _isTaringOrCalibrating) {
+    xSemaphoreTake(_operationMutex, portMAX_DELAY);
+    while (!isReady()) {
         vTaskDelay(1);
     }
 
     _rawWeight = readRaw();
     const float reading = convertRawToWeight(_rawWeight);
-    _weight = SCALE_FILTER_ALPHA * reading + (1.0f - SCALE_FILTER_ALPHA) * _weight;
-    _weight = std::clamp(_weight, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
-    _readingCallback(_weight);
+    // Always advance the filter state. A deadband here caused small changes to
+    // be discarded until a larger reading produced a visible jump.
+    float filteredWeight = SCALE_FILTER_ALPHA * reading + (1.0f - SCALE_FILTER_ALPHA) * _weight.load();
+    filteredWeight = std::clamp(filteredWeight, -1.0f * MAX_SCALE_GRAMS, MAX_SCALE_GRAMS);
+    _weight.store(filteredWeight);
+    xSemaphoreGive(_operationMutex);
+
+    _readingCallback(filteredWeight);
 }
 
 void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
@@ -134,28 +147,39 @@ void HardwareScale::setScaleFactors(float scale_factor1, float scale_factor2) {
         ESP_LOGW(LOG_TAG, "Ignoring invalid scale factors: %.3f, %.3f", scale_factor1, scale_factor2);
         return;
     }
+    xSemaphoreTake(_operationMutex, portMAX_DELAY);
     _scaleFactor1 = scale_factor1;
     _scaleFactor2 = scale_factor2;
+    xSemaphoreGive(_operationMutex);
     _scaleFactorsReady = true;
     ESP_LOGI(LOG_TAG, "Scale factors applied: %.3f, %.3f", _scaleFactor1, _scaleFactor2);
 }
 
 void HardwareScale::tare() {
-    _isTaringOrCalibrating = true;
-    while (!isReady()) {
-        delay(10);
+    xSemaphoreTake(_operationMutex, portMAX_DELAY);
+
+    int64_t sum1 = 0;
+    int64_t sum2 = 0;
+    for (uint8_t i = 0; i < SCALE_TARE_SAMPLES; ++i) {
+        while (!isReady()) {
+            delay(1);
+        }
+        const auto raw = readRaw();
+        sum1 += raw.value1;
+        sum2 += raw.value2;
     }
-    const auto raw = readRaw();
-    _offset1 = raw.value1;
-    _offset2 = raw.value2;
-    _weight = 0.0f;
-    _isTaringOrCalibrating = false;
+
+    _offset1 = static_cast<float>(sum1) / SCALE_TARE_SAMPLES;
+    _offset2 = static_cast<float>(sum2) / SCALE_TARE_SAMPLES;
+    _weight.store(0.0f);
+    xSemaphoreGive(_operationMutex);
+    ESP_LOGI(LOG_TAG, "Tared scale offsets from %u samples: %.3f, %.3f", SCALE_TARE_SAMPLES, _offset1, _offset2);
 }
 
 void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
-    _isTaringOrCalibrating = true;
+    xSemaphoreTake(_operationMutex, portMAX_DELAY);
 
-    long value = 0;
+    int64_t value = 0;
     for (int i = 0; i < 10; i++) {
         while (!isReady()) {
             delay(10);
@@ -170,7 +194,7 @@ void HardwareScale::calibrateScale(uint8_t scale, float calibrationWeight) {
         _scaleFactor2 = (static_cast<float>(value) - _offset2) / calibrationWeight;
     }
 
-    _isTaringOrCalibrating = false;
+    xSemaphoreGive(_operationMutex);
     _configurationCallback(_scaleFactor1, _scaleFactor2);
 }
 

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -10,8 +10,8 @@ constexpr float HARDWARE_SCALE_UNAVAILABLE = -9999.0f;  // Sentinel value to sig
 
 // Conditional outlier rejection handles isolated spikes, so both idle weighing
 // and brewing can remain responsive without a slow stationary EMA.
-constexpr float SCALE_FILTER_ALPHA_IDLE = 0.70f;
-constexpr float SCALE_FILTER_ALPHA_ACTIVE = 0.70f;
+constexpr float SCALE_FILTER_ALPHA_IDLE = 0.80f;
+constexpr float SCALE_FILTER_ALPHA_ACTIVE = 0.80f;
 constexpr uint8_t SCALE_TARE_SAMPLES = 5;
 
 // Idle publishing uses spatial hysteresis rather than more temporal filtering,

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -5,14 +5,17 @@
 #include <atomic>
 #include <functional>
 
-constexpr int SCALE_READ_INTERVAL_MS = 100;
 constexpr float HARDWARE_SCALE_UNAVAILABLE = -9999.0f;  // Sentinel value to signal scale not available
 
-// Conditional outlier rejection handles isolated spikes, so both idle weighing
-// and brewing can remain responsive without a slow stationary EMA.
-constexpr float SCALE_FILTER_ALPHA_IDLE = 0.80f;
-constexpr float SCALE_FILTER_ALPHA_ACTIVE = 0.80f;
-constexpr uint8_t SCALE_TARE_SAMPLES = 5;
+constexpr uint16_t HARDWARE_SCALE_DEFAULT_SAMPLE_RATE_SPS = 10;
+constexpr float HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_IDLE = 0.80f;
+constexpr float HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_ACTIVE = 0.80f;
+
+struct HardwareScaleConfig {
+    uint16_t sampleRateSps = HARDWARE_SCALE_DEFAULT_SAMPLE_RATE_SPS;
+    float idleAlpha = HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_IDLE;
+    float activeAlpha = HARDWARE_SCALE_DEFAULT_FILTER_ALPHA_ACTIVE;
+};
 
 // Idle publishing uses spatial hysteresis rather than more temporal filtering,
 // so a real weight change remains as responsive as the fast internal estimate.
@@ -28,7 +31,8 @@ constexpr float SCALE_ZERO_TRACK_MAX_RANGE_GRAMS = 0.15f;
 constexpr float SCALE_ZERO_TRACK_ALPHA = 0.015f;
 constexpr float SCALE_ZERO_TRACK_MAX_BIAS_GRAMS = 1.0f;
 
-using scale_reading_callback_t = std::function<void(float)>;
+using scale_reading_callback_t =
+    std::function<void(float weight, float cell1Weight, float cell2Weight, bool cell1Valid, bool cell2Valid)>;
 using scale_configuration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
 using void_callback_t = std::function<void()>;
 
@@ -49,6 +53,8 @@ class HardwareScale {
         float getWeight() const;
         inline RawReading getRawWeight() const { return _raw_weight; }
         void setScaleFactors(float scale_factor1, float scale_factor2);
+        void setConfiguration(float scale_factor1, float scale_factor2, uint16_t sample_rate_sps,
+                              float idle_alpha, float active_alpha);
         void calibrateScale(uint8_t scale, float calibrationWeight);
         void setBrewingActive(bool active);
         bool isReady();
@@ -72,7 +78,7 @@ class HardwareScale {
         float _previous_accepted_reading = 0.0f;
         float _last_accepted_reading = 0.0f;
         float _pending_outlier = 0.0f;
-        uint8_t _consecutive_read_failures = 0;
+        unsigned long _read_failure_started_ms = 0;
         bool _read_fault_reported = false;
         std::atomic<unsigned long> _responsive_until{0};
         float _published_weight = 0.0f;
@@ -83,6 +89,15 @@ class HardwareScale {
         float _zero_stability_samples[SCALE_ZERO_TRACK_STABILITY_SAMPLES]{};
         uint8_t _zero_stability_count = 0;
         uint8_t _zero_stability_index = 0;
+        unsigned long _last_zero_tracking_observation_ms = 0;
+        unsigned long _last_publish_ms = 0;
+        unsigned long _last_conversion_us = 0;
+        unsigned long _interval_log_started_ms = 0;
+        uint32_t _interval_count = 0;
+        uint64_t _interval_total_us = 0;
+        uint32_t _interval_min_us = UINT32_MAX;
+        uint32_t _interval_max_us = 0;
+        HardwareScaleConfig _config;
         scale_reading_callback_t _reading_callback;
         scale_configuration_callback_t _configuration_callback;
         xTaskHandle taskHandle;
@@ -94,9 +109,14 @@ class HardwareScale {
 
         RawReading readRaw();
         bool waitUntilReady(unsigned long timeoutMs) const;
-        bool convertRawToWeight(const RawReading &raw, float &weight) const;
+        bool convertRawToWeight(const RawReading &raw, float &weight, float &cell1Weight, float &cell2Weight) const;
         bool acceptReading(float reading, float &accepted);
         bool isResponsive() const;
+        unsigned long readyTimeoutMs() const;
+        uint8_t tareSampleCount() const;
+        uint8_t calibrationSampleCount() const;
+        void recordConversionInterval();
+        bool tareInternal(bool allowUnstableFallback);
         void resetFilterState();
         void resetZeroTrackingHistory();
 };

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -6,55 +6,99 @@
 #include <functional>
 
 constexpr int SCALE_READ_INTERVAL_MS = 100;
-constexpr float HARDWARE_SCALE_UNAVAILABLE = -9999.0f;
+constexpr float HARDWARE_SCALE_UNAVAILABLE = -9999.0f;  // Sentinel value to signal scale not available
+
+// Conditional outlier rejection handles isolated spikes, so both idle weighing
+// and brewing can remain responsive without a slow stationary EMA.
+constexpr float SCALE_FILTER_ALPHA_IDLE = 0.70f;
+constexpr float SCALE_FILTER_ALPHA_ACTIVE = 0.70f;
+constexpr uint8_t SCALE_TARE_SAMPLES = 5;
+
+// Idle publishing uses spatial hysteresis rather than more temporal filtering,
+// so a real weight change remains as responsive as the fast internal estimate.
+constexpr float SCALE_DISPLAY_STEP_GRAMS = 0.10f;
+constexpr float SCALE_DISPLAY_SWITCH_GRAMS = 0.07f;
+
+// Track only small, stable, idle zero drift. Brew/water activity disables this
+// path via setBrewingActive(), leaving shot measurements untouched.
+constexpr float SCALE_ZERO_TRACK_WINDOW_GRAMS = 0.35f;
+constexpr uint8_t SCALE_ZERO_TRACK_MEDIAN_SAMPLES = 3;
+constexpr uint8_t SCALE_ZERO_TRACK_STABILITY_SAMPLES = 10;
+constexpr float SCALE_ZERO_TRACK_MAX_RANGE_GRAMS = 0.15f;
+constexpr float SCALE_ZERO_TRACK_ALPHA = 0.015f;
+constexpr float SCALE_ZERO_TRACK_MAX_BIAS_GRAMS = 1.0f;
 
 using scale_reading_callback_t = std::function<void(float)>;
 using scale_configuration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
+using void_callback_t = std::function<void()>;
 
 class HardwareScale {
-  public:
-    HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, const scale_reading_callback_t &reading_callback,
-                  const scale_configuration_callback_t &config_callback);
-    ~HardwareScale() = default;
+    public:
+        HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin,
+            const scale_reading_callback_t &reading_callback,
+            const scale_configuration_callback_t &config_callback);
+        ~HardwareScale() = default;
 
-    struct RawReading {
-        long value1;
-        long value2;
-    };
+         struct RawReading {
+            long value1;
+            long value2;
+        };
 
-    void setup();
-    void loop();
-    float getWeight() const;
-    RawReading getRawWeight() const { return _rawWeight; }
-    void setScaleFactors(float scale_factor1, float scale_factor2);
-    void calibrateScale(uint8_t scale, float calibrationWeight);
-    bool isReady();
-    bool isAvailable() const { return _initialized; }
-    void tare();
+        void setup();
+        void loop();
+        float getWeight() const;
+        inline RawReading getRawWeight() const { return _raw_weight; }
+        void setScaleFactors(float scale_factor1, float scale_factor2);
+        void calibrateScale(uint8_t scale, float calibrationWeight);
+        void setBrewingActive(bool active);
+        bool isReady();
+        bool isAvailable() const { return is_initialized; }
+        bool tare();
 
-  private:
-    std::atomic<bool> _initialized{false};
-    std::atomic<bool> _scaleFactorsReady{false};
-    uint8_t _dataPin1;
-    uint8_t _dataPin2;
-    uint8_t _clockPin;
-    RawReading _rawWeight;
-    std::atomic<float> _weight{0.0f};
-    float _scaleFactor1;
-    float _scaleFactor2;
-    float _offset1;
-    float _offset2;
-    scale_reading_callback_t _readingCallback;
-    scale_configuration_callback_t _configurationCallback;
-    xTaskHandle taskHandle;
-    SemaphoreHandle_t _operationMutex;
-    portMUX_TYPE _readMux = portMUX_INITIALIZER_UNLOCKED;
+    private:
+        std::atomic<bool> is_initialized;
+        std::atomic<bool> _scale_factors_ready;
+        uint8_t _data_pin1;
+        uint8_t _data_pin2;
+        uint8_t _clock_pin;
+        RawReading _raw_weight;
+        std::atomic<float> _weight{0.0f};
+        float _scale_factor1;
+        float _scale_factor2;
+        float _offset1;
+        float _offset2;
+        bool _has_accepted_reading = false;
+        bool _has_pending_outlier = false;
+        float _previous_accepted_reading = 0.0f;
+        float _last_accepted_reading = 0.0f;
+        float _pending_outlier = 0.0f;
+        uint8_t _consecutive_read_failures = 0;
+        bool _read_fault_reported = false;
+        std::atomic<unsigned long> _responsive_until{0};
+        float _published_weight = 0.0f;
+        float _zero_bias = 0.0f;
+        float _zero_median_samples[SCALE_ZERO_TRACK_MEDIAN_SAMPLES]{};
+        uint8_t _zero_median_count = 0;
+        uint8_t _zero_median_index = 0;
+        float _zero_stability_samples[SCALE_ZERO_TRACK_STABILITY_SAMPLES]{};
+        uint8_t _zero_stability_count = 0;
+        uint8_t _zero_stability_index = 0;
+        scale_reading_callback_t _reading_callback;
+        scale_configuration_callback_t _configuration_callback;
+        xTaskHandle taskHandle;
+        SemaphoreHandle_t _operation_mutex;
+        portMUX_TYPE _read_mux = portMUX_INITIALIZER_UNLOCKED;
 
-    const char *LOG_TAG = "HardwareScale";
-    static void loopTask(void *arg);
+        const char *LOG_TAG = "HardwareScale";
+        static void loopTask(void *arg);
 
-    RawReading readRaw();
-    float convertRawToWeight(const RawReading &raw) const;
+        RawReading readRaw();
+        bool waitUntilReady(unsigned long timeoutMs) const;
+        bool convertRawToWeight(const RawReading &raw, float &weight) const;
+        bool acceptReading(float reading, float &accepted);
+        bool isResponsive() const;
+        void resetFilterState();
+        void resetZeroTrackingHistory();
 };
 
 #endif // HARDWARESCALE_H

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -2,6 +2,7 @@
 #define HARDWARESCALE_H
 
 #include <Arduino.h>
+#include <atomic>
 #include <functional>
 
 constexpr int SCALE_READ_INTERVAL_MS = 100;
@@ -32,21 +33,22 @@ class HardwareScale {
     void tare();
 
   private:
-    bool _initialized = false;
-    bool _scaleFactorsReady = false;
+    std::atomic<bool> _initialized{false};
+    std::atomic<bool> _scaleFactorsReady{false};
     uint8_t _dataPin1;
     uint8_t _dataPin2;
     uint8_t _clockPin;
     RawReading _rawWeight;
-    float _weight = 0.0f;
+    std::atomic<float> _weight{0.0f};
     float _scaleFactor1;
     float _scaleFactor2;
     float _offset1;
     float _offset2;
-    bool _isTaringOrCalibrating;
     scale_reading_callback_t _readingCallback;
     scale_configuration_callback_t _configurationCallback;
     xTaskHandle taskHandle;
+    SemaphoreHandle_t _operationMutex;
+    portMUX_TYPE _readMux = portMUX_INITIALIZER_UNLOCKED;
 
     const char *LOG_TAG = "HardwareScale";
     static void loopTask(void *arg);

--- a/lib/GaggiMateController/src/peripherals/HardwareScale.h
+++ b/lib/GaggiMateController/src/peripherals/HardwareScale.h
@@ -1,0 +1,58 @@
+#ifndef HARDWARESCALE_H
+#define HARDWARESCALE_H
+
+#include <Arduino.h>
+#include <functional>
+
+constexpr int SCALE_READ_INTERVAL_MS = 100;
+constexpr float HARDWARE_SCALE_UNAVAILABLE = -9999.0f;
+
+using scale_reading_callback_t = std::function<void(float)>;
+using scale_configuration_callback_t = std::function<void(float scaleFactor1, float scaleFactor2)>;
+
+class HardwareScale {
+  public:
+    HardwareScale(uint8_t data_pin1, uint8_t data_pin2, uint8_t clock_pin, const scale_reading_callback_t &reading_callback,
+                  const scale_configuration_callback_t &config_callback);
+    ~HardwareScale() = default;
+
+    struct RawReading {
+        long value1;
+        long value2;
+    };
+
+    void setup();
+    void loop();
+    float getWeight() const;
+    RawReading getRawWeight() const { return _rawWeight; }
+    void setScaleFactors(float scale_factor1, float scale_factor2);
+    void calibrateScale(uint8_t scale, float calibrationWeight);
+    bool isReady();
+    bool isAvailable() const { return _initialized; }
+    void tare();
+
+  private:
+    bool _initialized = false;
+    bool _scaleFactorsReady = false;
+    uint8_t _dataPin1;
+    uint8_t _dataPin2;
+    uint8_t _clockPin;
+    RawReading _rawWeight;
+    float _weight = 0.0f;
+    float _scaleFactor1;
+    float _scaleFactor2;
+    float _offset1;
+    float _offset2;
+    bool _isTaringOrCalibrating;
+    scale_reading_callback_t _readingCallback;
+    scale_configuration_callback_t _configurationCallback;
+    xTaskHandle taskHandle;
+
+    const char *LOG_TAG = "HardwareScale";
+    static void loopTask(void *arg);
+
+    RawReading readRaw();
+    float convertRawToWeight(const RawReading &raw) const;
+};
+
+#endif // HARDWARESCALE_H

--- a/lib/NanoPbComm/proto/gaggimate.proto
+++ b/lib/NanoPbComm/proto/gaggimate.proto
@@ -145,6 +145,9 @@ message Tare {}
 message ScaleFactors {
     float scale_factor1 = 1;
     float scale_factor2 = 2;
+    uint32 sample_rate_sps = 3;
+    float idle_filter_alpha = 4;
+    float active_filter_alpha = 5;
 }
 
 // One LED output's target brightness.
@@ -222,6 +225,10 @@ message VolumetricMeasurement {
 // selectable volumetric sources.
 message ScaleMeasurement {
     float weight = 1;
+    float cell1_weight = 2;
+    float cell2_weight = 3;
+    bool cell1_valid = 4;
+    bool cell2_valid = 5;
 }
 
 message TofMeasurement {

--- a/lib/NanoPbComm/proto/gaggimate.proto
+++ b/lib/NanoPbComm/proto/gaggimate.proto
@@ -44,6 +44,7 @@ message Payload {
         PressureScale pressure_scale = 9;
         Tare tare = 10;
         LedControl led = 11;
+        ScaleFactors scale_factors = 12;
 
         // Responses: controller -> display
         SystemInfo system_info = 20;
@@ -139,6 +140,11 @@ message PressureScale {
 }
 
 message Tare {}
+
+message ScaleFactors {
+    float scale_factor1 = 1;
+    float scale_factor2 = 2;
+}
 
 // One LED output's target brightness.
 message LedChannel {

--- a/lib/NanoPbComm/proto/gaggimate.proto
+++ b/lib/NanoPbComm/proto/gaggimate.proto
@@ -54,6 +54,7 @@ message Payload {
         VolumetricMeasurement volumetric = 24;
         TofMeasurement tof = 25;
         Error error = 26;
+        ScaleMeasurement scale = 27;
     }
 }
 
@@ -214,6 +215,13 @@ message AutotuneResult {
 
 message VolumetricMeasurement {
     float volume = 1;
+}
+
+// Hardware-scale weight, sent on its own channel (distinct from the pump-derived
+// VolumetricMeasurement estimate) so the display can offer both as independently
+// selectable volumetric sources.
+message ScaleMeasurement {
+    float weight = 1;
 }
 
 message TofMeasurement {

--- a/lib/NanoPbComm/src/GaggiMateClient.cpp
+++ b/lib/NanoPbComm/src/GaggiMateClient.cpp
@@ -197,6 +197,10 @@ void GaggiMateClient::registerHandlers() {
         if (_volumetricCb)
             _volumetricCb(p.content.volumetric.volume);
     });
+    _endpoint.on(gaggimate_Payload_scale_tag, [this](const gm::Payload &p) {
+        if (_scaleCb)
+            _scaleCb(p.content.scale.weight);
+    });
     _endpoint.on(gaggimate_Payload_tof_tag, [this](const gm::Payload &p) {
         if (_tofCb)
             _tofCb(p.content.tof.distance);

--- a/lib/NanoPbComm/src/GaggiMateClient.cpp
+++ b/lib/NanoPbComm/src/GaggiMateClient.cpp
@@ -152,7 +152,6 @@ void GaggiMateClient::sendAutotune(uint32_t testTime, uint32_t samples, uint32_t
 void GaggiMateClient::sendPressureScale(float scale) { _endpoint.send(buildPressureScale(scale)); }
 
 void GaggiMateClient::tare() { _endpoint.send(buildTare()); }
-
 void GaggiMateClient::sendLedControl(const LedChannelCommand *channels, size_t count) {
     _endpoint.send(buildLedControl(channels, count));
 }
@@ -199,7 +198,8 @@ void GaggiMateClient::registerHandlers() {
     });
     _endpoint.on(gaggimate_Payload_scale_tag, [this](const gm::Payload &p) {
         if (_scaleCb)
-            _scaleCb(p.content.scale.weight);
+            _scaleCb(p.content.scale.weight, p.content.scale.cell1_weight, p.content.scale.cell2_weight,
+                     p.content.scale.cell1_valid, p.content.scale.cell2_valid);
     });
     _endpoint.on(gaggimate_Payload_tof_tag, [this](const gm::Payload &p) {
         if (_tofCb)

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -29,7 +29,8 @@ class GaggiMateClient {
     using ButtonCallback = std::function<void(uint8_t index, bool pressed)>;
     using AutotuneResultCallback = std::function<void(float kp, float ki, float kd, float kf)>;
     using VolumetricCallback = std::function<void(float volume)>;
-    using ScaleCallback = std::function<void(float weight)>;
+    using ScaleCallback = std::function<void(float weight, float cell1Weight, float cell2Weight,
+                                             bool cell1Valid, bool cell2Valid)>;
     using TofCallback = std::function<void(uint32_t distance)>;
     using ErrorCallback = std::function<void(int code)>;
 
@@ -70,11 +71,15 @@ class GaggiMateClient {
     gm::Payload buildAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     gm::Payload buildPressureScale(float scale);
     gm::Payload buildTare();
-    gm::Payload buildScaleFactors(float scaleFactor1, float scaleFactor2) {
+    gm::Payload buildScaleFactors(float scaleFactor1, float scaleFactor2, uint16_t sampleRateSps = 10,
+                                  float idleFilterAlpha = 0.80f, float activeFilterAlpha = 0.80f) {
       gm::Payload p = gaggimate_Payload_init_zero;
       p.which_content = gaggimate_Payload_scale_factors_tag;
       p.content.scale_factors.scale_factor1 = scaleFactor1;
       p.content.scale_factors.scale_factor2 = scaleFactor2;
+      p.content.scale_factors.sample_rate_sps = sampleRateSps;
+      p.content.scale_factors.idle_filter_alpha = idleFilterAlpha;
+      p.content.scale_factors.active_filter_alpha = activeFilterAlpha;
       return p;
     }
     // Pack channel/brightness pairs into one LedControl payload; entries beyond
@@ -91,7 +96,10 @@ class GaggiMateClient {
                           float maxPower, float slipA, float slipB, float slipC, float slipD);
     void sendAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     void sendPressureScale(float scale);
-    void sendScaleFactors(float scaleFactor1, float scaleFactor2) { _endpoint.send(buildScaleFactors(scaleFactor1, scaleFactor2)); }
+    void sendScaleFactors(float scaleFactor1, float scaleFactor2, uint16_t sampleRateSps = 10,
+                          float idleFilterAlpha = 0.80f, float activeFilterAlpha = 0.80f) {
+        _endpoint.send(buildScaleFactors(scaleFactor1, scaleFactor2, sampleRateSps, idleFilterAlpha, activeFilterAlpha));
+    }
     void tare();
     // Drive several LED channels in one message (avoids per-channel sends that
     // the outbound queue would coalesce down to a single channel).

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -29,6 +29,7 @@ class GaggiMateClient {
     using ButtonCallback = std::function<void(uint8_t index, bool pressed)>;
     using AutotuneResultCallback = std::function<void(float kp, float ki, float kd, float kf)>;
     using VolumetricCallback = std::function<void(float volume)>;
+    using ScaleCallback = std::function<void(float weight)>;
     using TofCallback = std::function<void(uint32_t distance)>;
     using ErrorCallback = std::function<void(int code)>;
 
@@ -112,6 +113,7 @@ class GaggiMateClient {
     void onButtonState(ButtonCallback cb) { _buttonCb = std::move(cb); }
     void onAutotuneResult(AutotuneResultCallback cb) { _autotuneResultCb = std::move(cb); }
     void onVolumetricMeasurement(VolumetricCallback cb) { _volumetricCb = std::move(cb); }
+    void onScaleMeasurement(ScaleCallback cb) { _scaleCb = std::move(cb); }
     void onTofMeasurement(TofCallback cb) { _tofCb = std::move(cb); }
     void onError(ErrorCallback cb) { _errorCb = std::move(cb); }
 
@@ -126,6 +128,7 @@ class GaggiMateClient {
     ButtonCallback _buttonCb;
     AutotuneResultCallback _autotuneResultCb;
     VolumetricCallback _volumetricCb;
+    ScaleCallback _scaleCb;
     TofCallback _tofCb;
     ErrorCallback _errorCb;
 

--- a/lib/NanoPbComm/src/GaggiMateClient.h
+++ b/lib/NanoPbComm/src/GaggiMateClient.h
@@ -69,6 +69,13 @@ class GaggiMateClient {
     gm::Payload buildAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     gm::Payload buildPressureScale(float scale);
     gm::Payload buildTare();
+    gm::Payload buildScaleFactors(float scaleFactor1, float scaleFactor2) {
+      gm::Payload p = gaggimate_Payload_init_zero;
+      p.which_content = gaggimate_Payload_scale_factors_tag;
+      p.content.scale_factors.scale_factor1 = scaleFactor1;
+      p.content.scale_factors.scale_factor2 = scaleFactor2;
+      return p;
+    }
     // Pack channel/brightness pairs into one LedControl payload; entries beyond
     // the schema's per-message cap (LedControl.channels max_count) are dropped.
     gm::Payload buildLedControl(const LedChannelCommand *channels, size_t count);
@@ -83,6 +90,7 @@ class GaggiMateClient {
                           float maxPower, float slipA, float slipB, float slipC, float slipD);
     void sendAutotune(uint32_t testTime, uint32_t samples, uint32_t heaterWattage);
     void sendPressureScale(float scale);
+    void sendScaleFactors(float scaleFactor1, float scaleFactor2) { _endpoint.send(buildScaleFactors(scaleFactor1, scaleFactor2)); }
     void tare();
     // Drive several LED channels in one message (avoids per-channel sends that
     // the outbound queue would coalesce down to a single channel).

--- a/lib/NanoPbComm/src/GaggiMateServer.cpp
+++ b/lib/NanoPbComm/src/GaggiMateServer.cpp
@@ -97,10 +97,15 @@ gm::Payload GaggiMateServer::buildVolumetricMeasurement(float volume) {
     return p;
 }
 
-gm::Payload GaggiMateServer::buildScaleMeasurement(float weight) {
+gm::Payload GaggiMateServer::buildScaleMeasurement(float weight, float cell1Weight, float cell2Weight,
+                                                   bool cell1Valid, bool cell2Valid) {
     gm::Payload p = gaggimate_Payload_init_zero;
     p.which_content = gaggimate_Payload_scale_tag;
     p.content.scale.weight = weight;
+    p.content.scale.cell1_weight = cell1Weight;
+    p.content.scale.cell2_weight = cell2Weight;
+    p.content.scale.cell1_valid = cell1Valid;
+    p.content.scale.cell2_valid = cell2Valid;
     return p;
 }
 
@@ -135,7 +140,10 @@ void GaggiMateServer::sendAutotuneResult(float kp, float ki, float kd, float kf)
 
 void GaggiMateServer::sendVolumetricMeasurement(float volume) { _endpoint.sendUnreliable(buildVolumetricMeasurement(volume)); }
 
-void GaggiMateServer::sendScaleMeasurement(float weight) { _endpoint.sendUnreliable(buildScaleMeasurement(weight)); }
+void GaggiMateServer::sendScaleMeasurement(float weight, float cell1Weight, float cell2Weight, bool cell1Valid,
+                                           bool cell2Valid) {
+    _endpoint.sendUnreliable(buildScaleMeasurement(weight, cell1Weight, cell2Weight, cell1Valid, cell2Valid));
+}
 
 void GaggiMateServer::sendTofMeasurement(uint32_t distance) { _endpoint.sendUnreliable(buildTofMeasurement(distance)); }
 
@@ -182,7 +190,10 @@ void GaggiMateServer::registerHandlers() {
     });
     _endpoint.on(gaggimate_Payload_scale_factors_tag, [this](const gm::Payload &p) {
         if (_scaleFactorsCb)
-            _scaleFactorsCb(p.content.scale_factors.scale_factor1, p.content.scale_factors.scale_factor2);
+            _scaleFactorsCb(p.content.scale_factors.scale_factor1, p.content.scale_factors.scale_factor2,
+                            static_cast<uint16_t>(p.content.scale_factors.sample_rate_sps),
+                            p.content.scale_factors.idle_filter_alpha,
+                            p.content.scale_factors.active_filter_alpha);
     });
     _endpoint.on(gaggimate_Payload_led_tag, [this](const gm::Payload &p) {
         if (!_ledCb)

--- a/lib/NanoPbComm/src/GaggiMateServer.cpp
+++ b/lib/NanoPbComm/src/GaggiMateServer.cpp
@@ -97,6 +97,13 @@ gm::Payload GaggiMateServer::buildVolumetricMeasurement(float volume) {
     return p;
 }
 
+gm::Payload GaggiMateServer::buildScaleMeasurement(float weight) {
+    gm::Payload p = gaggimate_Payload_init_zero;
+    p.which_content = gaggimate_Payload_scale_tag;
+    p.content.scale.weight = weight;
+    return p;
+}
+
 gm::Payload GaggiMateServer::buildTofMeasurement(uint32_t distance) {
     gm::Payload p = gaggimate_Payload_init_zero;
     p.which_content = gaggimate_Payload_tof_tag;
@@ -127,6 +134,8 @@ void GaggiMateServer::sendAutotuneResult(float kp, float ki, float kd, float kf)
 }
 
 void GaggiMateServer::sendVolumetricMeasurement(float volume) { _endpoint.sendUnreliable(buildVolumetricMeasurement(volume)); }
+
+void GaggiMateServer::sendScaleMeasurement(float weight) { _endpoint.sendUnreliable(buildScaleMeasurement(weight)); }
 
 void GaggiMateServer::sendTofMeasurement(uint32_t distance) { _endpoint.sendUnreliable(buildTofMeasurement(distance)); }
 

--- a/lib/NanoPbComm/src/GaggiMateServer.cpp
+++ b/lib/NanoPbComm/src/GaggiMateServer.cpp
@@ -171,6 +171,10 @@ void GaggiMateServer::registerHandlers() {
         if (_tareCb)
             _tareCb();
     });
+    _endpoint.on(gaggimate_Payload_scale_factors_tag, [this](const gm::Payload &p) {
+        if (_scaleFactorsCb)
+            _scaleFactorsCb(p.content.scale_factors.scale_factor1, p.content.scale_factors.scale_factor2);
+    });
     _endpoint.on(gaggimate_Payload_led_tag, [this](const gm::Payload &p) {
         if (!_ledCb)
             return;

--- a/lib/NanoPbComm/src/GaggiMateServer.h
+++ b/lib/NanoPbComm/src/GaggiMateServer.h
@@ -25,7 +25,8 @@ class GaggiMateServer {
     using AutotuneCallback = std::function<void(uint32_t testTime, uint32_t samples, uint32_t heaterWattage)>;
     using PressureScaleCallback = std::function<void(float scale)>;
     using TareCallback = std::function<void()>;
-    using ScaleFactorsCallback = std::function<void(float scaleFactor1, float scaleFactor2)>;
+    using ScaleFactorsCallback = std::function<void(float scaleFactor1, float scaleFactor2, uint16_t sampleRateSps,
+                                                    float idleFilterAlpha, float activeFilterAlpha)>;
     using LedCallback = std::function<void(uint8_t channel, uint8_t brightness)>;
 
     GaggiMateServer();
@@ -44,7 +45,8 @@ class GaggiMateServer {
     gm::Payload buildButtonState(uint8_t index, bool pressed);
     gm::Payload buildAutotuneResult(float kp, float ki, float kd, float kf);
     gm::Payload buildVolumetricMeasurement(float volume);
-    gm::Payload buildScaleMeasurement(float weight);
+    gm::Payload buildScaleMeasurement(float weight, float cell1Weight = 0.0f, float cell2Weight = 0.0f,
+                                      bool cell1Valid = false, bool cell2Valid = false);
     gm::Payload buildTofMeasurement(uint32_t distance);
     gm::Payload buildError(int code);
 
@@ -54,7 +56,8 @@ class GaggiMateServer {
     void sendButtonState(uint8_t index, bool pressed);
     void sendAutotuneResult(float kp, float ki, float kd, float kf);
     void sendVolumetricMeasurement(float volume);
-    void sendScaleMeasurement(float weight);
+    void sendScaleMeasurement(float weight, float cell1Weight = 0.0f, float cell2Weight = 0.0f,
+                              bool cell1Valid = false, bool cell2Valid = false);
     void sendTofMeasurement(uint32_t distance);
     void sendError(int code);
 

--- a/lib/NanoPbComm/src/GaggiMateServer.h
+++ b/lib/NanoPbComm/src/GaggiMateServer.h
@@ -44,6 +44,7 @@ class GaggiMateServer {
     gm::Payload buildButtonState(uint8_t index, bool pressed);
     gm::Payload buildAutotuneResult(float kp, float ki, float kd, float kf);
     gm::Payload buildVolumetricMeasurement(float volume);
+    gm::Payload buildScaleMeasurement(float weight);
     gm::Payload buildTofMeasurement(uint32_t distance);
     gm::Payload buildError(int code);
 
@@ -53,6 +54,7 @@ class GaggiMateServer {
     void sendButtonState(uint8_t index, bool pressed);
     void sendAutotuneResult(float kp, float ki, float kd, float kf);
     void sendVolumetricMeasurement(float volume);
+    void sendScaleMeasurement(float weight);
     void sendTofMeasurement(uint32_t distance);
     void sendError(int code);
 

--- a/lib/NanoPbComm/src/GaggiMateServer.h
+++ b/lib/NanoPbComm/src/GaggiMateServer.h
@@ -25,6 +25,7 @@ class GaggiMateServer {
     using AutotuneCallback = std::function<void(uint32_t testTime, uint32_t samples, uint32_t heaterWattage)>;
     using PressureScaleCallback = std::function<void(float scale)>;
     using TareCallback = std::function<void()>;
+    using ScaleFactorsCallback = std::function<void(float scaleFactor1, float scaleFactor2)>;
     using LedCallback = std::function<void(uint8_t channel, uint8_t brightness)>;
 
     GaggiMateServer();
@@ -77,6 +78,7 @@ class GaggiMateServer {
     void onAutotune(AutotuneCallback cb) { _autotuneCb = std::move(cb); }
     void onPressureScale(PressureScaleCallback cb) { _pressureScaleCb = std::move(cb); }
     void onTare(TareCallback cb) { _tareCb = std::move(cb); }
+    void onScaleFactors(ScaleFactorsCallback cb) { _scaleFactorsCb = std::move(cb); }
     void onLedControl(LedCallback cb) { _ledCb = std::move(cb); }
 
   private:
@@ -93,6 +95,7 @@ class GaggiMateServer {
     AutotuneCallback _autotuneCb;
     PressureScaleCallback _pressureScaleCb;
     TareCallback _tareCb;
+    ScaleFactorsCallback _scaleFactorsCb;
     LedCallback _ledCb;
 
     void registerHandlers();

--- a/lib/NanoPbComm/src/Messages.h
+++ b/lib/NanoPbComm/src/Messages.h
@@ -38,6 +38,7 @@ using BoilerReading = gaggimate_BoilerReading;
 using ButtonState = gaggimate_ButtonState;
 using AutotuneResult = gaggimate_AutotuneResult;
 using VolumetricMeasurement = gaggimate_VolumetricMeasurement;
+using ScaleMeasurement = gaggimate_ScaleMeasurement;
 using TofMeasurement = gaggimate_TofMeasurement;
 using Error = gaggimate_Error;
 

--- a/lib/NanoPbComm/src/Messages.h
+++ b/lib/NanoPbComm/src/Messages.h
@@ -26,6 +26,7 @@ using PumpSettings = gaggimate_PumpSettings;
 using AutotuneRequest = gaggimate_AutotuneRequest;
 using PressureScale = gaggimate_PressureScale;
 using Tare = gaggimate_Tare;
+using ScaleFactors = gaggimate_ScaleFactors;
 using LedChannel = gaggimate_LedChannel;
 using LedControl = gaggimate_LedControl;
 

--- a/lib/NanoPbComm/src/Protocol.h
+++ b/lib/NanoPbComm/src/Protocol.h
@@ -21,7 +21,7 @@ static constexpr const char *INFO_CHAR_UUID = "f8d7203b-e00c-48e2-83ba-37ff49cdb
 // Protocol/schema version. Bump on any breaking change to gaggimate.proto so a
 // display talking to an out-of-date controller (or vice versa) can detect the
 // mismatch. Carried in SystemInfo.protocol_version.
-static constexpr uint32_t PROTOCOL_VERSION = 3;
+static constexpr uint32_t PROTOCOL_VERSION = 4;
 
 // Outbound priorities (higher wins in the queue).
 enum Priority : uint8_t {
@@ -73,6 +73,7 @@ inline uint8_t defaultPriority(pb_size_t which) {
         return PRIO_CONTROL;
     case gaggimate_Payload_sensor_tag:
     case gaggimate_Payload_volumetric_tag:
+    case gaggimate_Payload_scale_tag:
     case gaggimate_Payload_tof_tag:
         return PRIO_LOW;
     default:

--- a/sim/comms/GaggiMateClient.h
+++ b/sim/comms/GaggiMateClient.h
@@ -45,7 +45,8 @@ class GaggiMateClient {
     using ButtonCallback = std::function<void(uint8_t index, bool pressed)>;
     using AutotuneResultCallback = std::function<void(float kp, float ki, float kd, float kf)>;
     using VolumetricCallback = std::function<void(float volume)>;
-    using ScaleCallback = std::function<void(float weight)>;
+    using ScaleCallback = std::function<void(float weight, float cell1Weight, float cell2Weight,
+                                             bool cell1Valid, bool cell2Valid)>;
     using TofCallback = std::function<void(uint32_t distance)>;
     using ErrorCallback = std::function<void(int code)>;
 

--- a/sim/comms/GaggiMateClient.h
+++ b/sim/comms/GaggiMateClient.h
@@ -19,7 +19,7 @@ using std::vector;
 // Protocol version the firmware checks against; report the same so there's no
 // "protocol mismatch" path in the simulator.
 namespace gm_proto {
-static constexpr uint32_t PROTOCOL_VERSION = 3;
+static constexpr uint32_t PROTOCOL_VERSION = 4;
 }
 
 // Stand-in for the nanopb gm::Payload: a tagged command the build*() helpers
@@ -45,6 +45,7 @@ class GaggiMateClient {
     using ButtonCallback = std::function<void(uint8_t index, bool pressed)>;
     using AutotuneResultCallback = std::function<void(float kp, float ki, float kd, float kf)>;
     using VolumetricCallback = std::function<void(float volume)>;
+    using ScaleCallback = std::function<void(float weight)>;
     using TofCallback = std::function<void(uint32_t distance)>;
     using ErrorCallback = std::function<void(int code)>;
 
@@ -99,6 +100,7 @@ class GaggiMateClient {
     void onButtonState(ButtonCallback cb) { _buttonCb = std::move(cb); }
     void onAutotuneResult(AutotuneResultCallback cb) { _autotuneResultCb = std::move(cb); }
     void onVolumetricMeasurement(VolumetricCallback cb) { _volumetricCb = std::move(cb); }
+    void onScaleMeasurement(ScaleCallback cb) { _scaleCb = std::move(cb); }
     void onTofMeasurement(TofCallback cb) { _tofCb = std::move(cb); }
     void onError(ErrorCallback cb) { _errorCb = std::move(cb); }
 
@@ -119,6 +121,7 @@ class GaggiMateClient {
     ButtonCallback _buttonCb;
     AutotuneResultCallback _autotuneResultCb;
     VolumetricCallback _volumetricCb;
+    ScaleCallback _scaleCb;
     TofCallback _tofCb;
     ErrorCallback _errorCb;
 };

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -370,7 +370,12 @@ void Controller::setupBluetooth() {
         hardwareScaleCell2Weight.store(normalizeWeightForDisplay(cell2Weight));
         hardwareScaleCell1Valid.store(cell1Valid);
         hardwareScaleCell2Valid.store(cell2Valid);
-        onVolumetricMeasurement(value, VolumetricMeasurementSource::HARDWARE);
+        // An unavailable/faulted controller-side scale sends invalid cell flags.
+        // Do not treat that sentinel message as fresh weight data; otherwise the
+        // display-side health timeout can never expire.
+        if (cell1Valid && cell2Valid) {
+            onVolumetricMeasurement(value, VolumetricMeasurementSource::HARDWARE);
+        }
     });
     comms.onTofMeasurement([this](uint32_t value) {
         tofDistance = static_cast<int>(value);
@@ -1101,6 +1106,15 @@ void Controller::clearLocked(std::vector<const char *> &events) {
     delete lastProcess;
     lastProcess = nullptr;
     currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
+#ifdef NIGHTLY_BUILD
+    latestFlowEstimation = 0.0;
+    estimatorAtLastPhysicalMeasurement = 0.0;
+    lastPhysicalMeasurement = 0.0;
+    flowEstimationOffset = 0.0;
+    flowEstimationValid = false;
+    physicalMeasurementValid = false;
+    physicalEstimatorBaselineValid = false;
+#endif
 }
 
 void Controller::activateGrind() {
@@ -1190,10 +1204,55 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
 #endif
 
     if (source == VolumetricMeasurementSource::BLUETOOTH) {
-        lastBluetoothMeasurement = millis();
+        lastBluetoothMeasurement.store(millis());
     } else if (source == VolumetricMeasurementSource::HARDWARE) {
-        lastHardwareMeasurement = millis();
+        lastHardwareMeasurement.store(millis());
     }
+
+    double effectiveMeasurement = measurement;
+#ifdef NIGHTLY_BUILD
+    bool switchedToFlowEstimation = false;
+    {
+        std::lock_guard<std::recursive_mutex> guard(processMutex);
+        const bool physicalSourceSelected =
+            currentVolumetricSource == VolumetricMeasurementSource::HARDWARE ||
+            currentVolumetricSource == VolumetricMeasurementSource::BLUETOOTH;
+        const bool activeBrew = currentProcess != nullptr && currentProcess->getType() == MODE_BREW && currentProcess->isActive();
+
+        if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
+            latestFlowEstimation = measurement;
+            flowEstimationValid = true;
+
+            if (activeBrew && physicalSourceSelected && !isScaleSourceHealthy(currentVolumetricSource)) {
+                // Continue from the last physical weight, including the virtual
+                // weight accumulated during the physical source's timeout.
+                flowEstimationOffset =
+                    physicalMeasurementValid
+                        ? lastPhysicalMeasurement -
+                              (physicalEstimatorBaselineValid ? estimatorAtLastPhysicalMeasurement : measurement)
+                        : 0.0;
+                currentVolumetricSource = VolumetricMeasurementSource::FLOW_ESTIMATION;
+                switchedToFlowEstimation = true;
+            }
+
+            if (currentVolumetricSource == VolumetricMeasurementSource::FLOW_ESTIMATION) {
+                effectiveMeasurement = measurement + flowEstimationOffset;
+            }
+        } else if (physicalSourceSelected && source == currentVolumetricSource) {
+            lastPhysicalMeasurement = measurement;
+            physicalMeasurementValid = true;
+            if (flowEstimationValid) {
+                estimatorAtLastPhysicalMeasurement = latestFlowEstimation;
+                physicalEstimatorBaselineValid = true;
+            }
+        }
+    }
+
+    if (switchedToFlowEstimation) {
+        ESP_LOGW(LOG_TAG, "Selected physical scale stopped reporting; continuing shot with flow estimation (offset %.3f g)",
+                 flowEstimationOffset);
+    }
+#endif
 
     if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
         pluginManager->trigger(F("controller:volumetric-measurement:estimation:change"), "value", static_cast<float>(measurement));
@@ -1209,7 +1268,7 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     // if another scale remains healthy after the selected scale stops reporting.
     if (source == getEffectiveScaleSource()) {
         pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value",
-                               normalizeWeightForDisplay(measurement));
+                               normalizeWeightForDisplay(effectiveMeasurement));
     }
 
     // This callback fires from the NimBLE task on core 0; deactivate()/clear() on
@@ -1220,10 +1279,10 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
         return;
     }
     if (currentProcess != nullptr) {
-        currentProcess->updateVolume(measurement);
+        currentProcess->updateVolume(effectiveMeasurement);
     }
     if (lastProcess != nullptr && !lastProcess->isComplete()) {
-        lastProcess->updateVolume(measurement);
+        lastProcess->updateVolume(effectiveMeasurement);
     }
 }
 
@@ -1305,19 +1364,16 @@ String Controller::getActiveScaleSourceName() const {
 }
 
 bool Controller::isBluetoothScaleHealthy() const {
-    unsigned long timeSinceLastBluetooth = millis() - lastBluetoothMeasurement;
-    return (timeSinceLastBluetooth < BLUETOOTH_GRACE_PERIOD_MS) || volumetricOverride;
+    const unsigned long lastMeasurement = lastBluetoothMeasurement.load();
+    return lastMeasurement != 0 && millis() - lastMeasurement < BLUETOOTH_GRACE_PERIOD_MS;
 }
 
 bool Controller::isHardwareScaleHealthy() const {
     if (!systemInfo.capabilities.hwScale) {
         return false;
     }
-    if (volumetricOverride) {
-        return true;
-    }
-    unsigned long timeSinceLastHardware = millis() - lastHardwareMeasurement;
-    return timeSinceLastHardware < HARDWARE_GRACE_PERIOD_MS;
+    const unsigned long lastMeasurement = lastHardwareMeasurement.load();
+    return lastMeasurement != 0 && millis() - lastMeasurement < HARDWARE_GRACE_PERIOD_MS;
 }
 
 void Controller::onFlush() {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -1022,7 +1022,11 @@ void Controller::activate() {
     clear();
     comms.tare();
     if (isVolumetricAvailable()) {
-        currentVolumetricSource = getActiveScaleSource();
+        const auto source = getActiveScaleSource();
+        {
+            std::lock_guard<std::recursive_mutex> guard(processMutex);
+            currentVolumetricSource = source;
+        }
         if (mode == MODE_BREW) {
             pluginManager->trigger("controller:brew:prestart");
         }
@@ -1106,7 +1110,10 @@ void Controller::activateGrind() {
     clear();
     const auto grindScaleSource = getGrindScaleSource();
     if (settings.isVolumetricTarget() && grindScaleSource != VolumetricMeasurementSource::INACTIVE) {
-        currentVolumetricSource = grindScaleSource;
+        {
+            std::lock_guard<std::recursive_mutex> guard(processMutex);
+            currentVolumetricSource = grindScaleSource;
+        }
         startProcess(new GrindProcess(ProcessTarget::VOLUMETRIC, 0, settings.getTargetGrindVolume(), settings.getGrindDelay()));
     } else {
         startProcess(
@@ -1196,22 +1203,22 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
         pluginManager->trigger(F("controller:volumetric-measurement:bluetooth:change"), "value", static_cast<float>(measurement));
     }
 
-    // Only the source selected by the controller may update the unified
-    // measurement stream consumed by shot history, the UI, and WebUI. Without
-    // this gate, simultaneous hardware and Bluetooth reports race and the last
-    // callback wins regardless of the configured source.
-    if (source == getActiveScaleSource()) {
+    // Keep the unified stream on the source selected when the process started.
+    // Live health-based selection is only used while no process source is
+    // locked. This keeps shot history, the UI, and process volume in agreement
+    // if another scale remains healthy after the selected scale stops reporting.
+    if (source == getEffectiveScaleSource()) {
         pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value",
                                normalizeWeightForDisplay(measurement));
     }
 
+    // This callback fires from the NimBLE task on core 0; deactivate()/clear() on
+    // other tasks can delete the processes, so hold the lock across the deref (GM-147).
+    std::lock_guard<std::recursive_mutex> guard(processMutex);
     if (currentVolumetricSource != source) {
         ESP_LOGD(LOG_TAG, "Ignoring volumetric measurement, source does not match");
         return;
     }
-    // This callback fires from the NimBLE task on core 0; deactivate()/clear() on
-    // other tasks can delete the processes, so hold the lock across the deref (GM-147).
-    std::lock_guard<std::recursive_mutex> guard(processMutex);
     if (currentProcess != nullptr) {
         currentProcess->updateVolume(measurement);
     }
@@ -1259,6 +1266,15 @@ VolumetricMeasurementSource Controller::getActiveScaleSource() const {
 #endif
 }
 
+VolumetricMeasurementSource Controller::getEffectiveScaleSource() const {
+    VolumetricMeasurementSource processSource;
+    {
+        std::lock_guard<std::recursive_mutex> guard(processMutex);
+        processSource = currentVolumetricSource;
+    }
+    return processSource != VolumetricMeasurementSource::INACTIVE ? processSource : getActiveScaleSource();
+}
+
 VolumetricMeasurementSource Controller::getGrindScaleSource() const {
     return isBluetoothScaleHealthy() ? VolumetricMeasurementSource::BLUETOOTH
                                      : VolumetricMeasurementSource::INACTIVE;
@@ -1275,7 +1291,7 @@ bool Controller::isScaleSourceHealthy(VolumetricMeasurementSource source) const 
 }
 
 String Controller::getActiveScaleSourceName() const {
-    const auto source = getActiveScaleSource();
+    const auto source = getEffectiveScaleSource();
     if (source == VolumetricMeasurementSource::HARDWARE) {
         return "hardware";
     }

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -1182,6 +1182,12 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     }
 #endif
 
+    if (source == VolumetricMeasurementSource::BLUETOOTH) {
+        lastBluetoothMeasurement = millis();
+    } else if (source == VolumetricMeasurementSource::HARDWARE) {
+        lastHardwareMeasurement = millis();
+    }
+
     if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
         pluginManager->trigger(F("controller:volumetric-measurement:estimation:change"), "value", static_cast<float>(measurement));
     } else if (source == VolumetricMeasurementSource::HARDWARE) {
@@ -1189,13 +1195,14 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     } else {
         pluginManager->trigger(F("controller:volumetric-measurement:bluetooth:change"), "value", static_cast<float>(measurement));
     }
-    pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value",
-                           normalizeWeightForDisplay(measurement));
 
-    if (source == VolumetricMeasurementSource::BLUETOOTH) {
-        lastBluetoothMeasurement = millis();
-    } else if (source == VolumetricMeasurementSource::HARDWARE) {
-        lastHardwareMeasurement = millis();
+    // Only the source selected by the controller may update the unified
+    // measurement stream consumed by shot history, the UI, and WebUI. Without
+    // this gate, simultaneous hardware and Bluetooth reports race and the last
+    // callback wins regardless of the configured source.
+    if (source == getActiveScaleSource()) {
+        pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value",
+                               normalizeWeightForDisplay(measurement));
     }
 
     if (currentVolumetricSource != source) {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -43,6 +43,13 @@
 
 const String LOG_TAG = F("Controller");
 constexpr uint32_t ADDON_HW_SCALE = 8;
+constexpr double DISPLAY_NEGATIVE_WEIGHT_THRESHOLD = -0.1;
+
+float normalizeWeightForDisplay(double measurement) {
+    return measurement <= 0.0 && measurement > DISPLAY_NEGATIVE_WEIGHT_THRESHOLD
+               ? 0.0f
+               : static_cast<float>(measurement);
+}
 
 void Controller::setup() {
     mode = MODE_STANDBY;
@@ -358,7 +365,13 @@ void Controller::setupBluetooth() {
         // flow estimate; the hardware scale reports via onScaleMeasurement below.
         onVolumetricMeasurement(value, VolumetricMeasurementSource::FLOW_ESTIMATION);
     });
-    comms.onScaleMeasurement([this](float value) { onVolumetricMeasurement(value, VolumetricMeasurementSource::HARDWARE); });
+    comms.onScaleMeasurement([this](float value, float cell1Weight, float cell2Weight, bool cell1Valid, bool cell2Valid) {
+        hardwareScaleCell1Weight.store(normalizeWeightForDisplay(cell1Weight));
+        hardwareScaleCell2Weight.store(normalizeWeightForDisplay(cell2Weight));
+        hardwareScaleCell1Valid.store(cell1Valid);
+        hardwareScaleCell2Valid.store(cell2Valid);
+        onVolumetricMeasurement(value, VolumetricMeasurementSource::HARDWARE);
+    });
     comms.onTofMeasurement([this](uint32_t value) {
         tofDistance = static_cast<int>(value);
         ESP_LOGV(LOG_TAG, "Received new TOF distance: %d", tofDistance);
@@ -801,7 +814,8 @@ void Controller::setScaleFactors() {
         return;
     }
 
-    comms.sendScaleFactors(scaleFactor1, scaleFactor2);
+    comms.sendScaleFactors(scaleFactor1, scaleFactor2, settings.getHardwareScaleSampleRateSps(),
+                           settings.getHardwareScaleIdleAlpha(), settings.getHardwareScaleActiveAlpha());
 }
 
 void Controller::setPumpModelCoeffs(void) {
@@ -1175,7 +1189,8 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     } else {
         pluginManager->trigger(F("controller:volumetric-measurement:bluetooth:change"), "value", static_cast<float>(measurement));
     }
-    pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value", static_cast<float>(measurement));
+    pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value",
+                           normalizeWeightForDisplay(measurement));
 
     if (source == VolumetricMeasurementSource::BLUETOOTH) {
         lastBluetoothMeasurement = millis();

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -42,6 +42,7 @@
 #endif
 
 const String LOG_TAG = F("Controller");
+constexpr uint32_t ADDON_HW_SCALE = 8;
 
 void Controller::setup() {
     mode = MODE_STANDBY;
@@ -352,8 +353,11 @@ void Controller::setupBluetooth() {
         pluginManager->trigger("controller:autotune:result");
         autotuning = false;
     });
-    comms.onVolumetricMeasurement(
-        [this](float value) { onVolumetricMeasurement(value, VolumetricMeasurementSource::FLOW_ESTIMATION); });
+    comms.onVolumetricMeasurement([this](float value) {
+        const auto source = systemInfo.capabilities.hwScale ? VolumetricMeasurementSource::HARDWARE
+                                                            : VolumetricMeasurementSource::FLOW_ESTIMATION;
+        onVolumetricMeasurement(value, source);
+    });
     comms.onTofMeasurement([this](uint32_t value) {
         tofDistance = static_cast<int>(value);
         ESP_LOGV(LOG_TAG, "Received new TOF distance: %d", tofDistance);
@@ -377,6 +381,7 @@ void Controller::onSystemInfo(const char *hardware, const char *version, uint32_
                                 },
                             .protocolVersion = protocolVersion,
                             .protocolMismatch = mismatch};
+    systemInfo.capabilities.hwScale = systemInfo.capabilities.hasAddon(ADDON_HW_SCALE);
     ESP_LOGI(LOG_TAG, "System info: %s %s (proto=%u local=%u dm=%d ps=%d led=%d tof=%d)", hardware, version, protocolVersion,
              gm_proto::PROTOCOL_VERSION, dimming, pressure, ledControl, tof);
     if (mismatch) {
@@ -385,6 +390,7 @@ void Controller::onSystemInfo(const char *hardware, const char *version, uint32_
         pluginManager->trigger("controller:protocol:mismatch", "value", static_cast<int>(protocolVersion));
     } else {
         setPressureScale();
+        setScaleFactors();
         setPidSettings();
         setPumpModelCoeffs();
         configResendUntil = millis() + CONFIG_RESEND_WINDOW_MS;
@@ -419,6 +425,7 @@ void Controller::onIncompatibleController(const String &infoJson) {
         version = "0.0.0";
     onSystemInfo(hardware.c_str(), version.c_str(), 0, doc["cp"]["dm"].as<bool>(), doc["cp"]["ps"].as<bool>(),
                  doc["cp"]["led"].as<bool>(), doc["cp"]["tof"].as<bool>(), {});
+    systemInfo.capabilities.hwScale = doc["cp"]["hs"].as<bool>();
 }
 
 void Controller::setupWifi() {
@@ -670,9 +677,9 @@ bool Controller::isReady() const { return !isUpdating() && !isErrorState() && !i
 
 bool Controller::isVolumetricAvailable() const {
 #ifdef NIGHTLY_BUILD
-    return isBluetoothScaleHealthy() || systemInfo.capabilities.dimming;
+    return isBluetoothScaleHealthy() || isHardwareScaleHealthy() || systemInfo.capabilities.dimming;
 #else
-    return isBluetoothScaleHealthy();
+    return isBluetoothScaleHealthy() || isHardwareScaleHealthy();
 #endif
 }
 
@@ -777,6 +784,23 @@ void Controller::setPressureScale(void) {
     if (systemInfo.capabilities.pressure) {
         comms.sendPressureScale(settings.getPressureScaling());
     }
+}
+
+void Controller::setScaleFactors() {
+    if (!systemInfo.capabilities.hwScale) {
+        return;
+    }
+
+    const float scaleFactor1 = settings.getScaleFactor1();
+    const float scaleFactor2 = settings.getScaleFactor2();
+
+    if (!std::isfinite(scaleFactor1) || !std::isfinite(scaleFactor2) || std::abs(scaleFactor1) < 0.001f ||
+        std::abs(scaleFactor2) < 0.001f) {
+        ESP_LOGW(LOG_TAG, "Skipping invalid scale factors: %.3f, %.3f", scaleFactor1, scaleFactor2);
+        return;
+    }
+
+    comms.sendScaleFactors(scaleFactor1, scaleFactor2);
 }
 
 void Controller::setPumpModelCoeffs(void) {
@@ -983,12 +1007,7 @@ void Controller::activate() {
     clear();
     comms.tare();
     if (isVolumetricAvailable()) {
-#ifdef NIGHTLY_BUILD
-        currentVolumetricSource =
-            isBluetoothScaleHealthy() ? VolumetricMeasurementSource::BLUETOOTH : VolumetricMeasurementSource::FLOW_ESTIMATION;
-#else
-        currentVolumetricSource = VolumetricMeasurementSource::BLUETOOTH;
-#endif
+        currentVolumetricSource = getActiveScaleSource();
         if (mode == MODE_BREW) {
             pluginManager->trigger("controller:brew:prestart");
         }
@@ -1071,7 +1090,7 @@ void Controller::activateGrind() {
         return;
     clear();
     if (settings.isVolumetricTarget() && isVolumetricAvailable()) {
-        currentVolumetricSource = VolumetricMeasurementSource::BLUETOOTH;
+        currentVolumetricSource = getActiveScaleSource();
         startProcess(new GrindProcess(ProcessTarget::VOLUMETRIC, 0, settings.getTargetGrindVolume(), settings.getGrindDelay()));
     } else {
         startProcess(
@@ -1141,15 +1160,25 @@ void Controller::onProfileSaveAsNew() {
 }
 
 void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source) {
+#ifndef NIGHTLY_BUILD
     if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
-        currentCoffeeVolume = static_cast<float>(measurement);
+        return;
     }
-    pluginManager->trigger(source == VolumetricMeasurementSource::FLOW_ESTIMATION
-                               ? F("controller:volumetric-measurement:estimation:change")
-                               : F("controller:volumetric-measurement:bluetooth:change"),
-                           "value", static_cast<float>(measurement));
+#endif
+
+    if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
+        pluginManager->trigger(F("controller:volumetric-measurement:estimation:change"), "value", static_cast<float>(measurement));
+    } else if (source == VolumetricMeasurementSource::HARDWARE) {
+        pluginManager->trigger(F("controller:volumetric-measurement:hardware:change"), "value", static_cast<float>(measurement));
+    } else {
+        pluginManager->trigger(F("controller:volumetric-measurement:bluetooth:change"), "value", static_cast<float>(measurement));
+    }
+    pluginManager->trigger(F("controller:volumetric-measurement:active:change"), "value", static_cast<float>(measurement));
+
     if (source == VolumetricMeasurementSource::BLUETOOTH) {
         lastBluetoothMeasurement = millis();
+    } else if (source == VolumetricMeasurementSource::HARDWARE) {
+        lastHardwareMeasurement = millis();
     }
 
     if (currentVolumetricSource != source) {
@@ -1167,9 +1196,78 @@ void Controller::onVolumetricMeasurement(double measurement, VolumetricMeasureme
     }
 }
 
+VolumetricMeasurementSource Controller::getPreferredScaleSource() const {
+    const String preferred = settings.getPreferredScaleSource();
+    if (preferred == "hardware") {
+        return VolumetricMeasurementSource::HARDWARE;
+    }
+    if (preferred == "bluetooth") {
+        return VolumetricMeasurementSource::BLUETOOTH;
+    }
+    return VolumetricMeasurementSource::FLOW_ESTIMATION;
+}
+
+VolumetricMeasurementSource Controller::getActiveScaleSource() const {
+    const auto preferred = getPreferredScaleSource();
+
+    if (preferred == VolumetricMeasurementSource::HARDWARE && isHardwareScaleHealthy()) {
+        return VolumetricMeasurementSource::HARDWARE;
+    }
+    if (preferred == VolumetricMeasurementSource::BLUETOOTH && isBluetoothScaleHealthy()) {
+        return VolumetricMeasurementSource::BLUETOOTH;
+    }
+    if (isHardwareScaleHealthy()) {
+        return VolumetricMeasurementSource::HARDWARE;
+    }
+    if (isBluetoothScaleHealthy()) {
+        return VolumetricMeasurementSource::BLUETOOTH;
+    }
+
+#ifdef NIGHTLY_BUILD
+    return VolumetricMeasurementSource::FLOW_ESTIMATION;
+#else
+    return VolumetricMeasurementSource::INACTIVE;
+#endif
+}
+
+bool Controller::isScaleSourceHealthy(VolumetricMeasurementSource source) const {
+    if (source == VolumetricMeasurementSource::HARDWARE) {
+        return isHardwareScaleHealthy();
+    }
+    if (source == VolumetricMeasurementSource::BLUETOOTH) {
+        return isBluetoothScaleHealthy();
+    }
+    return true;
+}
+
+String Controller::getActiveScaleSourceName() const {
+    const auto source = getActiveScaleSource();
+    if (source == VolumetricMeasurementSource::HARDWARE) {
+        return "hardware";
+    }
+    if (source == VolumetricMeasurementSource::BLUETOOTH) {
+        return "bluetooth";
+    }
+    if (source == VolumetricMeasurementSource::FLOW_ESTIMATION) {
+        return "estimation";
+    }
+    return "inactive";
+}
+
 bool Controller::isBluetoothScaleHealthy() const {
     unsigned long timeSinceLastBluetooth = millis() - lastBluetoothMeasurement;
     return (timeSinceLastBluetooth < BLUETOOTH_GRACE_PERIOD_MS) || volumetricOverride;
+}
+
+bool Controller::isHardwareScaleHealthy() const {
+    if (!systemInfo.capabilities.hwScale) {
+        return false;
+    }
+    if (volumetricOverride) {
+        return true;
+    }
+    unsigned long timeSinceLastHardware = millis() - lastHardwareMeasurement;
+    return timeSinceLastHardware < HARDWARE_GRACE_PERIOD_MS;
 }
 
 void Controller::onFlush() {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -1090,8 +1090,9 @@ void Controller::activateGrind() {
     if (isGrindActive())
         return;
     clear();
-    if (settings.isVolumetricTarget() && isVolumetricAvailable()) {
-        currentVolumetricSource = getActiveScaleSource();
+    const auto grindScaleSource = getGrindScaleSource();
+    if (settings.isVolumetricTarget() && grindScaleSource != VolumetricMeasurementSource::INACTIVE) {
+        currentVolumetricSource = grindScaleSource;
         startProcess(new GrindProcess(ProcessTarget::VOLUMETRIC, 0, settings.getTargetGrindVolume(), settings.getGrindDelay()));
     } else {
         startProcess(
@@ -1209,6 +1210,11 @@ VolumetricMeasurementSource Controller::getPreferredScaleSource() const {
 }
 
 VolumetricMeasurementSource Controller::getActiveScaleSource() const {
+    // Always use BT scale for grinding
+    if (mode == MODE_GRIND) {
+        return getGrindScaleSource();
+    }
+
     const auto preferred = getPreferredScaleSource();
 
     if (preferred == VolumetricMeasurementSource::HARDWARE && isHardwareScaleHealthy()) {
@@ -1229,6 +1235,11 @@ VolumetricMeasurementSource Controller::getActiveScaleSource() const {
 #else
     return VolumetricMeasurementSource::INACTIVE;
 #endif
+}
+
+VolumetricMeasurementSource Controller::getGrindScaleSource() const {
+    return isBluetoothScaleHealthy() ? VolumetricMeasurementSource::BLUETOOTH
+                                     : VolumetricMeasurementSource::INACTIVE;
 }
 
 bool Controller::isScaleSourceHealthy(VolumetricMeasurementSource source) const {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -354,10 +354,11 @@ void Controller::setupBluetooth() {
         autotuning = false;
     });
     comms.onVolumetricMeasurement([this](float value) {
-        const auto source = systemInfo.capabilities.hwScale ? VolumetricMeasurementSource::HARDWARE
-                                                            : VolumetricMeasurementSource::FLOW_ESTIMATION;
-        onVolumetricMeasurement(value, source);
+        // The controller's volumetric channel now carries only the pump-derived
+        // flow estimate; the hardware scale reports via onScaleMeasurement below.
+        onVolumetricMeasurement(value, VolumetricMeasurementSource::FLOW_ESTIMATION);
     });
+    comms.onScaleMeasurement([this](float value) { onVolumetricMeasurement(value, VolumetricMeasurementSource::HARDWARE); });
     comms.onTofMeasurement([this](uint32_t value) {
         tofDistance = static_cast<int>(value);
         ESP_LOGV(LOG_TAG, "Received new TOF distance: %d", tofDistance);

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -8,6 +8,7 @@
 #include <WiFi.h>
 #include <display/core/ProfileManager.h>
 #include <display/core/process/Process.h>
+#include <atomic>
 #include <mutex>
 #include <vector>
 #ifndef GAGGIMATE_HEADLESS
@@ -108,6 +109,10 @@ class Controller {
     String getActiveScaleSourceName() const;
     bool isBluetoothScaleHealthy() const;
     bool isHardwareScaleHealthy() const;
+    float getHardwareScaleCell1Weight() const { return hardwareScaleCell1Weight.load(); }
+    float getHardwareScaleCell2Weight() const { return hardwareScaleCell2Weight.load(); }
+    bool isHardwareScaleCell1Valid() const { return hardwareScaleCell1Valid.load(); }
+    bool isHardwareScaleCell2Valid() const { return hardwareScaleCell2Valid.load(); }
     void onFlush();
     int getWaterLevel() const {
         float reversedLevel = static_cast<float>(settings.getEmptyTankDistance()) -
@@ -239,6 +244,10 @@ class Controller {
     VolumetricMeasurementSource currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
     unsigned long lastBluetoothMeasurement = 0;
     unsigned long lastHardwareMeasurement = 0;
+    std::atomic<float> hardwareScaleCell1Weight{0.0f};
+    std::atomic<float> hardwareScaleCell2Weight{0.0f};
+    std::atomic<bool> hardwareScaleCell1Valid{false};
+    std::atomic<bool> hardwareScaleCell2Valid{false};
     static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 1500; // 1.5 second grace period
     static const unsigned long HARDWARE_GRACE_PERIOD_MS = 1500;
     static const unsigned long CONTROLLER_WAITING_TIMEOUT_MS = 10000;

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -101,7 +101,6 @@ class Controller {
     void onProfileSave() const;
     void onProfileSaveAsNew();
     void onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source);
-    void setVolumetricOverride(bool override) { volumetricOverride = override; }
     VolumetricMeasurementSource getActiveScaleSource() const;
     VolumetricMeasurementSource getEffectiveScaleSource() const;
     VolumetricMeasurementSource getGrindScaleSource() const;
@@ -235,7 +234,6 @@ class Controller {
     unsigned long lastConfigResend = 0;
     static const unsigned long CONFIG_RESEND_WINDOW_MS = 8000;
     static const unsigned long CONFIG_RESEND_INTERVAL_MS = 1000;
-    bool volumetricOverride = false;
     bool processCompleted = false;
     bool steamReady = false;
     bool sdcard = false;
@@ -243,8 +241,20 @@ class Controller {
 
     // Bluetooth scale connection monitoring
     VolumetricMeasurementSource currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
-    unsigned long lastBluetoothMeasurement = 0;
-    unsigned long lastHardwareMeasurement = 0;
+    std::atomic<unsigned long> lastBluetoothMeasurement{0};
+    std::atomic<unsigned long> lastHardwareMeasurement{0};
+#ifdef NIGHTLY_BUILD
+    // The virtual scale runs in parallel with a physical scale. If the selected
+    // physical source stops reporting, preserve continuity by applying the
+    // estimator's change since the last good physical measurement.
+    double latestFlowEstimation = 0.0;
+    double estimatorAtLastPhysicalMeasurement = 0.0;
+    double lastPhysicalMeasurement = 0.0;
+    double flowEstimationOffset = 0.0;
+    bool flowEstimationValid = false;
+    bool physicalMeasurementValid = false;
+    bool physicalEstimatorBaselineValid = false;
+#endif
     std::atomic<float> hardwareScaleCell1Weight{0.0f};
     std::atomic<float> hardwareScaleCell2Weight{0.0f};
     std::atomic<bool> hardwareScaleCell1Valid{false};

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -103,6 +103,7 @@ class Controller {
     void onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source);
     void setVolumetricOverride(bool override) { volumetricOverride = override; }
     VolumetricMeasurementSource getActiveScaleSource() const;
+    VolumetricMeasurementSource getEffectiveScaleSource() const;
     VolumetricMeasurementSource getGrindScaleSource() const;
     VolumetricMeasurementSource getPreferredScaleSource() const;
     bool isScaleSourceHealthy(VolumetricMeasurementSource source) const;

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -18,7 +18,7 @@
 const IPAddress WIFI_AP_IP(4, 4, 4, 1); // the IP address the web server, Samsung requires the IP to be in public space
 const IPAddress WIFI_SUBNET_MASK(255, 255, 255, 0); // no need to change: https://avinetworks.com/glossary/subnet-mask/
 
-enum class VolumetricMeasurementSource { INACTIVE, FLOW_ESTIMATION, BLUETOOTH };
+enum class VolumetricMeasurementSource { INACTIVE, FLOW_ESTIMATION, BLUETOOTH, HARDWARE };
 
 class Controller {
   public:
@@ -33,6 +33,7 @@ class Controller {
     void setMode(int newMode);
     void setTargetTemp(float temperature);
     void setPressureScale();
+    void setScaleFactors();
     void setPumpModelCoeffs();
     void setPidSettings();
     void setTargetGrindDuration(int duration);
@@ -100,7 +101,12 @@ class Controller {
     void onProfileSaveAsNew();
     void onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source);
     void setVolumetricOverride(bool override) { volumetricOverride = override; }
+    VolumetricMeasurementSource getActiveScaleSource() const;
+    VolumetricMeasurementSource getPreferredScaleSource() const;
+    bool isScaleSourceHealthy(VolumetricMeasurementSource source) const;
+    String getActiveScaleSourceName() const;
     bool isBluetoothScaleHealthy() const;
+    bool isHardwareScaleHealthy() const;
     void onFlush();
     int getWaterLevel() const {
         float reversedLevel = static_cast<float>(settings.getEmptyTankDistance()) -
@@ -231,7 +237,9 @@ class Controller {
     // Bluetooth scale connection monitoring
     VolumetricMeasurementSource currentVolumetricSource = VolumetricMeasurementSource::INACTIVE;
     unsigned long lastBluetoothMeasurement = 0;
+    unsigned long lastHardwareMeasurement = 0;
     static const unsigned long BLUETOOTH_GRACE_PERIOD_MS = 1500; // 1.5 second grace period
+    static const unsigned long HARDWARE_GRACE_PERIOD_MS = 1500;
     static const unsigned long CONTROLLER_WAITING_TIMEOUT_MS = 10000;
 
     xTaskHandle logicTaskHandle;

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -102,6 +102,7 @@ class Controller {
     void onVolumetricMeasurement(double measurement, VolumetricMeasurementSource source);
     void setVolumetricOverride(bool override) { volumetricOverride = override; }
     VolumetricMeasurementSource getActiveScaleSource() const;
+    VolumetricMeasurementSource getGrindScaleSource() const;
     VolumetricMeasurementSource getPreferredScaleSource() const;
     bool isScaleSourceHealthy(VolumetricMeasurementSource source) const;
     String getActiveScaleSourceName() const;

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -99,6 +99,17 @@ void Settings::setTemperatureOffset(const int temperature_offset) { temperatureO
 
 void Settings::setPressureScaling(const float pressure_scaling) { pressureScaling.set(pressure_scaling); }
 
+void Settings::setScaleFactors(float scale_factor_1, float scale_factor_2) {
+    scaleFactor1.set(scale_factor_1);
+    scaleFactor2.set(scale_factor_2);
+}
+
+void Settings::setPreferredScaleSource(const String &scaleSource) {
+    if (scaleSource == "hardware" || scaleSource == "bluetooth" || scaleSource == "auto") {
+        preferredScaleSource.set(scaleSource);
+    }
+}
+
 void Settings::setTargetGrindVolume(double target_grind_volume) { targetGrindVolume.set(target_grind_volume); }
 
 void Settings::setTargetGrindDuration(const int target_duration) { targetGrindDuration.set(target_duration); }

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -1,6 +1,7 @@
 #include "Settings.h"
 
 #include <algorithm>
+#include <cmath>
 #include <display/util/ColorConversion.h>
 #include <utility>
 
@@ -102,6 +103,18 @@ void Settings::setPressureScaling(const float pressure_scaling) { pressureScalin
 void Settings::setScaleFactors(float scale_factor_1, float scale_factor_2) {
     scaleFactor1.set(scale_factor_1);
     scaleFactor2.set(scale_factor_2);
+}
+
+void Settings::setHardwareScaleConfiguration(uint16_t sample_rate_sps, float idle_alpha, float active_alpha) {
+    hardwareScaleSampleRateSps.set((sample_rate_sps == 10 || sample_rate_sps == 80)
+                                       ? sample_rate_sps
+                                       : DEFAULT_HARDWARE_SCALE_SAMPLE_RATE_SPS);
+    hardwareScaleIdleAlpha.set(std::isfinite(idle_alpha) && idle_alpha > 0.0f && idle_alpha <= 1.0f
+                                   ? idle_alpha
+                                   : DEFAULT_HARDWARE_SCALE_IDLE_ALPHA);
+    hardwareScaleActiveAlpha.set(std::isfinite(active_alpha) && active_alpha > 0.0f && active_alpha <= 1.0f
+                                     ? active_alpha
+                                     : DEFAULT_HARDWARE_SCALE_ACTIVE_ALPHA);
 }
 
 void Settings::setPreferredScaleSource(const String &scaleSource) {

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -75,6 +75,9 @@ class Settings {
     int getTargetWaterTemp() const { return targetWaterTemp.get(); }
     int getTemperatureOffset() const { return temperatureOffset.get(); }
     float getPressureScaling() const { return pressureScaling.get(); }
+    float getScaleFactor1() const { return scaleFactor1.get(); }
+    float getScaleFactor2() const { return scaleFactor2.get(); }
+    String getPreferredScaleSource() const { return preferredScaleSource.get(); }
     double getTargetGrindVolume() const { return targetGrindVolume.get(); }
     int getTargetGrindDuration() const { return targetGrindDuration.get(); }
     int getStartupMode() const { return startupMode.get(); }
@@ -162,6 +165,8 @@ class Settings {
     void setTargetWaterTemp(int target_water_temp);
     void setTemperatureOffset(int temperature_offset);
     void setPressureScaling(float pressure_scaling);
+    void setScaleFactors(float scale_factor_1, float scale_factor_2);
+    void setPreferredScaleSource(const String &scaleSource);
     void setTargetGrindVolume(double target_grind_volume);
     void setTargetGrindDuration(int target_duration);
     void setStartupMode(int startup_mode);
@@ -245,6 +250,9 @@ class Settings {
     Property<int> targetWaterTemp{registry, "tw", 80};
     Property<int> temperatureOffset{registry, "to", DEFAULT_TEMPERATURE_OFFSET};
     Property<float> pressureScaling{registry, "ps", DEFAULT_PRESSURE_SCALING};
+    Property<float> scaleFactor1{registry, "sf1", 0.0f};
+    Property<float> scaleFactor2{registry, "sf2", 0.0f};
+    Property<String> preferredScaleSource{registry, "pss", "hardware"};
     Property<double> targetGrindVolume{registry, "tgv", 18.0};
     Property<int> targetGrindDuration{registry, "tgd", 25000};
     Property<double> brewDelay{registry, "del_br", 800.0};

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -9,6 +9,10 @@
 #include <display/core/utils.h>
 #include <vector>
 
+constexpr uint16_t DEFAULT_HARDWARE_SCALE_SAMPLE_RATE_SPS = 10;
+constexpr float DEFAULT_HARDWARE_SCALE_IDLE_ALPHA = 0.80f;
+constexpr float DEFAULT_HARDWARE_SCALE_ACTIVE_ALPHA = 0.80f;
+
 #define PREFERENCES_KEY "controller"
 
 struct AutoWakeupSchedule {
@@ -77,6 +81,11 @@ class Settings {
     float getPressureScaling() const { return pressureScaling.get(); }
     float getScaleFactor1() const { return scaleFactor1.get(); }
     float getScaleFactor2() const { return scaleFactor2.get(); }
+    uint16_t getHardwareScaleSampleRateSps() const {
+        return static_cast<uint16_t>(hardwareScaleSampleRateSps.get());
+    }
+    float getHardwareScaleIdleAlpha() const { return hardwareScaleIdleAlpha.get(); }
+    float getHardwareScaleActiveAlpha() const { return hardwareScaleActiveAlpha.get(); }
     String getPreferredScaleSource() const { return preferredScaleSource.get(); }
     double getTargetGrindVolume() const { return targetGrindVolume.get(); }
     int getTargetGrindDuration() const { return targetGrindDuration.get(); }
@@ -166,6 +175,7 @@ class Settings {
     void setTemperatureOffset(int temperature_offset);
     void setPressureScaling(float pressure_scaling);
     void setScaleFactors(float scale_factor_1, float scale_factor_2);
+    void setHardwareScaleConfiguration(uint16_t sample_rate_sps, float idle_alpha, float active_alpha);
     void setPreferredScaleSource(const String &scaleSource);
     void setTargetGrindVolume(double target_grind_volume);
     void setTargetGrindDuration(int target_duration);
@@ -252,6 +262,9 @@ class Settings {
     Property<float> pressureScaling{registry, "ps", DEFAULT_PRESSURE_SCALING};
     Property<float> scaleFactor1{registry, "sf1", 0.0f};
     Property<float> scaleFactor2{registry, "sf2", 0.0f};
+    Property<int> hardwareScaleSampleRateSps{registry, "hs_rate", DEFAULT_HARDWARE_SCALE_SAMPLE_RATE_SPS};
+    Property<float> hardwareScaleIdleAlpha{registry, "hs_ia", DEFAULT_HARDWARE_SCALE_IDLE_ALPHA};
+    Property<float> hardwareScaleActiveAlpha{registry, "hs_aa", DEFAULT_HARDWARE_SCALE_ACTIVE_ALPHA};
     Property<String> preferredScaleSource{registry, "pss", "hardware"};
     Property<double> targetGrindVolume{registry, "tgv", 18.0};
     Property<int> targetGrindDuration{registry, "tgd", 25000};

--- a/src/display/core/SystemInfo.h
+++ b/src/display/core/SystemInfo.h
@@ -11,6 +11,7 @@ struct SystemCapabilities {
     bool pressure;
     bool ledControl;
     bool tof;
+    bool hwScale = false;
     std::vector<uint32_t> addons;
 
     bool hasAddon(uint32_t addon) const { return std::find(addons.begin(), addons.end(), addon) != addons.end(); }

--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -111,8 +111,8 @@ struct ShotLogSample {
     int16_t fl;  // current pump flow * 100 (allows small negatives)
     int16_t tf;  // target flow * 100
     int16_t pf;  // puck flow * 100
-    int16_t vf;  // bluetooth flow * 100
-    uint16_t v;  // bluetooth weight * 10
+    int16_t vf;  // active scale weight flow * 100
+    uint16_t v;  // active scale weight * 10
     uint16_t ev; // estimated weight * 10
     uint16_t pr; // puck resistance * 100
     uint16_t si; // system info bit-packed

--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -17,7 +17,7 @@
 // Older files may have fewer fields - use fieldsMask to determine layout.
 
 static constexpr uint32_t SHOT_LOG_MAGIC = 0x544F4853; // 'S''H''O''T' little-endian 0x54 0x4F 0x48 0x53
-static constexpr uint8_t SHOT_LOG_VERSION = 5;
+static constexpr uint8_t SHOT_LOG_VERSION = 6;
 static constexpr uint16_t SHOT_LOG_HEADER_SIZE = 512;
 static constexpr uint16_t SHOT_LOG_SAMPLE_INTERVAL_MS = 250; // nominal recording interval
 static constexpr uint32_t SHOT_LOG_FIELDS_MASK_ALL = 0x1FFF; // 13 fields present (removed phase number)
@@ -127,6 +127,10 @@ static constexpr uint16_t SYSTEM_INFO_CURRENTLY_VOLUMETRIC = 0x0002;      // Cur
 static constexpr uint16_t SYSTEM_INFO_BLUETOOTH_SCALE_CONNECTED = 0x0004; // Bluetooth scale connected
 static constexpr uint16_t SYSTEM_INFO_VOLUMETRIC_AVAILABLE = 0x0008;      // Volumetric available
 static constexpr uint16_t SYSTEM_INFO_EXTENDED_RECORDING = 0x0010;        // Extended recording active
+static constexpr uint16_t SYSTEM_INFO_PROCESS_IS_BREW = 0x0020;           // Process is MODE_BREW
+static constexpr uint16_t SYSTEM_INFO_TARGET_IS_VOLUMETRIC = 0x0040;      // Target is volumetric
+static constexpr uint16_t SYSTEM_INFO_PHASE_HAS_VOLUMETRIC = 0x0080;      // Phase has volumetric target
+static constexpr uint16_t SYSTEM_INFO_ACTIVE_SCALE_CONNECTED = 0x0100;    // Active hardware/Bluetooth scale is healthy
 
 // Binary shot index format
 // File: /h/index.bin

--- a/src/display/plugins/BLEScalePlugin.cpp
+++ b/src/display/plugins/BLEScalePlugin.cpp
@@ -138,15 +138,11 @@ void BLEScalePlugin::update() {
         return;
     }
 
-    // Don't update volumetric override if scale access might fail
     bool hasConnectedScale = false;
     if (scale != nullptr) {
         // Check if scale pointer is valid before accessing
         hasConnectedScale = scale->isConnected();
     }
-
-    if (controller->isVolumetricAvailable())
-        controller->setVolumetricOverride(hasConnectedScale);
 
     if (!active)
         return;

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -89,8 +89,8 @@ void ShotHistoryPlugin::setup(Controller *c, PluginManager *pm) {
     pm->on("controller:brew:clear", [this](Event const &) { endExtendedRecording(); });
     pm->on("controller:volumetric-measurement:estimation:change",
            [this](Event const &event) { currentEstimatedWeight = event.getFloat("value"); });
-    pm->on("controller:volumetric-measurement:bluetooth:change",
-           [this](Event const &event) { currentBluetoothWeight = event.getFloat("value"); });
+        pm->on("controller:volumetric-measurement:active:change",
+            [this](Event const &event) { currentBluetoothWeight = event.getFloat("value"); });
     pm->on("boiler:currentTemperature:change", [this](Event const &event) { currentTemperature = event.getFloat("value"); });
     pm->on("pump:puck-resistance:change", [this](Event const &event) { currentPuckResistance = event.getFloat("value"); });
     // Initialize rebuild state

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -141,7 +141,8 @@ void ShotHistoryPlugin::record() {
         // saturate vf for seconds. See GM-110.
         const float activeWeight = currentActiveWeight > 0.0f ? currentActiveWeight : 0.0f;
         const float activeDiff = activeWeight - lastActiveWeight;
-        if (fabsf(activeDiff) <= MAX_PLAUSIBLE_WEIGHT_DELTA) {
+        const bool plausibleActiveDelta = fabsf(activeDiff) <= MAX_PLAUSIBLE_WEIGHT_DELTA;
+        if (plausibleActiveDelta) {
             const float activeFlow = activeDiff / (SHOT_LOG_SAMPLE_INTERVAL_MS / 1000.0f);
             currentActiveFlow = currentActiveFlow * 0.75f + activeFlow * 0.25f;
         }
@@ -162,7 +163,10 @@ void ShotHistoryPlugin::record() {
         sample.ev = encodeUnsigned(currentEstimatedWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
         sample.pr = encodeUnsigned(currentPuckResistance, RESISTANCE_SCALE, RESISTANCE_MAX_VALUE);
         sample.si = getSystemInfo(); // Pack system state information
-        if (activeWeight > maxRecordedWeight) {
+        // Apply the same spike rejection to the final-weight maximum. A real
+        // sustained step is accepted on the following stable sample, whereas a
+        // one-sample excursion cannot permanently inflate the shot total.
+        if (plausibleActiveDelta && activeWeight > maxRecordedWeight) {
             maxRecordedWeight = activeWeight;
         }
 

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -489,9 +489,9 @@ uint16_t ShotHistoryPlugin::getSystemInfo() {
         }
     }
 
-    // Bit 8: Active scale source connected/healthy (hardware or Bluetooth).
+    // Bit 8: Effective scale source connected/healthy (hardware or Bluetooth).
     if (controller != nullptr) {
-        const VolumetricMeasurementSource activeSource = controller->getActiveScaleSource();
+        const VolumetricMeasurementSource activeSource = controller->getEffectiveScaleSource();
         if ((activeSource == VolumetricMeasurementSource::HARDWARE ||
              activeSource == VolumetricMeasurementSource::BLUETOOTH) &&
             controller->isScaleSourceHealthy(activeSource)) {

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -89,8 +89,8 @@ void ShotHistoryPlugin::setup(Controller *c, PluginManager *pm) {
     pm->on("controller:brew:clear", [this](Event const &) { endExtendedRecording(); });
     pm->on("controller:volumetric-measurement:estimation:change",
            [this](Event const &event) { currentEstimatedWeight = event.getFloat("value"); });
-        pm->on("controller:volumetric-measurement:active:change",
-            [this](Event const &event) { currentBluetoothWeight = event.getFloat("value"); });
+    pm->on("controller:volumetric-measurement:active:change",
+           [this](Event const &event) { currentActiveWeight = event.getFloat("value"); });
     pm->on("boiler:currentTemperature:change", [this](Event const &event) { currentTemperature = event.getFloat("value"); });
     pm->on("pump:puck-resistance:change", [this](Event const &event) { currentPuckResistance = event.getFloat("value"); });
     // Initialize rebuild state
@@ -135,17 +135,17 @@ void ShotHistoryPlugin::record() {
                 currentFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
             }
         }
-        // Bluetooth weight flow (vf): derive from the same non-negative weight we
+        // Active-scale weight flow (vf): derive from the same non-negative weight we
         // store in sample.v so the two can never disagree, and skip the EMA update
-        // on an implausible single-sample jump so one bad scale/BLE reading cannot
+        // on an implausible single-sample jump so one bad scale reading cannot
         // saturate vf for seconds. See GM-110.
-        const float btWeight = currentBluetoothWeight > 0.0f ? currentBluetoothWeight : 0.0f;
-        const float btDiff = btWeight - lastBluetoothWeight;
-        if (fabsf(btDiff) <= MAX_PLAUSIBLE_WEIGHT_DELTA) {
-            const float btFlow = btDiff / (SHOT_LOG_SAMPLE_INTERVAL_MS / 1000.0f);
-            currentBluetoothFlow = currentBluetoothFlow * 0.75f + btFlow * 0.25f;
+        const float activeWeight = currentActiveWeight > 0.0f ? currentActiveWeight : 0.0f;
+        const float activeDiff = activeWeight - lastActiveWeight;
+        if (fabsf(activeDiff) <= MAX_PLAUSIBLE_WEIGHT_DELTA) {
+            const float activeFlow = activeDiff / (SHOT_LOG_SAMPLE_INTERVAL_MS / 1000.0f);
+            currentActiveFlow = currentActiveFlow * 0.75f + activeFlow * 0.25f;
         }
-        lastBluetoothWeight = btWeight;
+        lastActiveWeight = activeWeight;
 
         ShotLogSample sample{};
         uint32_t tick = sampleCount <= 0xFFFF ? sampleCount : 0xFFFF;
@@ -157,11 +157,14 @@ void ShotHistoryPlugin::record() {
         sample.fl = encodeSigned(controller->getCurrentPumpFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
         sample.tf = encodeSigned(controller->getTargetFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
         sample.pf = encodeSigned(controller->getCurrentPuckFlow(), FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-        sample.vf = encodeSigned(currentBluetoothFlow, FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
-        sample.v = encodeUnsigned(btWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
+        sample.vf = encodeSigned(currentActiveFlow, FLOW_SCALE, FLOW_MIN_VALUE, FLOW_MAX_VALUE);
+        sample.v = encodeUnsigned(activeWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
         sample.ev = encodeUnsigned(currentEstimatedWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE);
         sample.pr = encodeUnsigned(currentPuckResistance, RESISTANCE_SCALE, RESISTANCE_MAX_VALUE);
         sample.si = getSystemInfo(); // Pack system state information
+        if (activeWeight > maxRecordedWeight) {
+            maxRecordedWeight = activeWeight;
+        }
 
         // Track phase transitions
         if (controller->getMode() == MODE_BREW) {
@@ -220,7 +223,7 @@ void ShotHistoryPlugin::record() {
                 return;
             }
 
-            const float weightDiff = abs(currentBluetoothWeight - lastStableWeight);
+            const float weightDiff = abs(currentActiveWeight - lastStableWeight);
 
             if (weightDiff < WEIGHT_STABILIZATION_THRESHOLD) {
                 if (lastWeightChangeTime == 0) {
@@ -233,7 +236,7 @@ void ShotHistoryPlugin::record() {
             } else {
                 // Weight changed, reset stabilization timer
                 lastWeightChangeTime = 0;
-                lastStableWeight = currentBluetoothWeight;
+                lastStableWeight = currentActiveWeight;
             }
 
             // Also stop extended recording after maximum duration
@@ -248,7 +251,7 @@ void ShotHistoryPlugin::record() {
         header.sampleCount = sampleCount;
         header.durationMs = millis() - shotStart;
         header.finalExitReason = finalExitReason; // why the shot ended (last phase exit or manual abort)
-        float finalWeight = currentBluetoothWeight;
+        float finalWeight = maxRecordedWeight;
         header.finalWeight = finalWeight > 0.0f ? encodeUnsigned(finalWeight, WEIGHT_SCALE, WEIGHT_MAX_VALUE) : 0;
         currentFile.seek(0, SeekSet);
         currentFile.write(reinterpret_cast<const uint8_t *>(&header), sizeof(header));
@@ -323,11 +326,12 @@ void ShotHistoryPlugin::startRecording() {
     shotStart = millis();
     lastWeightChangeTime = 0;
     extendedRecordingStart = 0;
-    currentBluetoothWeight = 0.0f;
+    currentActiveWeight = 0.0f;
     lastStableWeight = 0.0f;
     currentEstimatedWeight = 0.0f;
-    currentBluetoothFlow = 0.0f;
-    lastBluetoothWeight = 0.0f;
+    currentActiveFlow = 0.0f;
+    lastActiveWeight = 0.0f;
+    maxRecordedWeight = 0.0f;
     currentProfileName = controller->getProfileManager()->getSelectedProfile().label;
     recording = true;
     extendedRecording = false;
@@ -367,11 +371,11 @@ void ShotHistoryPlugin::endRecording() {
         }
     }
 
-    if (recording && controller && controller->isVolumetricAvailable() && currentBluetoothWeight > 0) {
+    if (recording && controller && controller->isVolumetricAvailable() && currentActiveWeight > 0) {
         // Start extended recording for any shot with active weight data
         extendedRecording = true;
         extendedRecordingStart = millis();
-        lastStableWeight = currentBluetoothWeight;
+        lastStableWeight = currentActiveWeight;
         lastWeightChangeTime = 0;
     }
 

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -465,6 +465,32 @@ uint16_t ShotHistoryPlugin::getSystemInfo() {
         systemInfo |= SYSTEM_INFO_EXTENDED_RECORDING;
     }
 
+    // Bits 5-7: Brew process/target state used by v6 analysis.
+    if (controller != nullptr) {
+        std::lock_guard<std::recursive_mutex> guard(controller->getProcessLock());
+        Process *process = controller->getProcess();
+        if (process != nullptr && process->getType() == MODE_BREW) {
+            systemInfo |= SYSTEM_INFO_PROCESS_IS_BREW;
+            auto *brewProcess = static_cast<BrewProcess *>(process);
+            if (brewProcess->target == ProcessTarget::VOLUMETRIC) {
+                systemInfo |= SYSTEM_INFO_TARGET_IS_VOLUMETRIC;
+            }
+            if (brewProcess->currentPhase.hasVolumetricTarget()) {
+                systemInfo |= SYSTEM_INFO_PHASE_HAS_VOLUMETRIC;
+            }
+        }
+    }
+
+    // Bit 8: Active scale source connected/healthy (hardware or Bluetooth).
+    if (controller != nullptr) {
+        const VolumetricMeasurementSource activeSource = controller->getActiveScaleSource();
+        if ((activeSource == VolumetricMeasurementSource::HARDWARE ||
+             activeSource == VolumetricMeasurementSource::BLUETOOTH) &&
+            controller->isScaleSourceHealthy(activeSource)) {
+            systemInfo |= SYSTEM_INFO_ACTIVE_SCALE_CONNECTED;
+        }
+    }
+
     return systemInfo;
 }
 

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -80,12 +80,13 @@ class ShotHistoryPlugin : public Plugin {
     unsigned long extendedRecordingStart = 0;
     unsigned long lastWeightChangeTime = 0;
     float currentTemperature = 0.0f;
-    float currentBluetoothWeight = 0.0f;
+    float currentActiveWeight = 0.0f;
     float lastStableWeight = 0.0f;
-    float lastBluetoothWeight = 0.0f;
-    float currentBluetoothFlow = 0.0f;
+    float lastActiveWeight = 0.0f;
+    float currentActiveFlow = 0.0f;
     float currentEstimatedWeight = 0.0f;
     float currentPuckResistance = 0.0f;
+    float maxRecordedWeight = 0.0f;
     String currentProfileName;
 
     // Phase transition tracking (v5+)

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -151,6 +151,17 @@ void WebUIPlugin::loop() {
         lastUpdateCheck = now;
         updateOTAStatus(ota->getCurrentVersion());
     }
+    if (now > lastHardwareScaleDiagnostic + HARDWARE_SCALE_DIAGNOSTIC_PERIOD && !ws.getClients().empty() &&
+        controller->getSystemInfo().capabilities.hwScale) {
+        lastHardwareScaleDiagnostic = now;
+        hardwareScaleDiagnosticDoc.clear();
+        hardwareScaleDiagnosticDoc["tp"] = "evt:hardware-scale";
+        hardwareScaleDiagnosticDoc["c1"] = controller->getHardwareScaleCell1Weight();
+        hardwareScaleDiagnosticDoc["c2"] = controller->getHardwareScaleCell2Weight();
+        hardwareScaleDiagnosticDoc["c1v"] = controller->isHardwareScaleCell1Valid();
+        hardwareScaleDiagnosticDoc["c2v"] = controller->isHardwareScaleCell2Valid();
+        broadcastJson(hardwareScaleDiagnosticDoc);
+    }
     if (now > lastStatus + STATUS_PERIOD && !ws.getClients().empty()) {
         lastStatus = now;
         statusDoc.clear();
@@ -688,6 +699,19 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 }
                 settings->setScaleFactors(sf1, sf2);
             }
+            if (request->hasArg("hardwareScaleSampleRateSps") || request->hasArg("hardwareScaleIdleAlpha") ||
+                request->hasArg("hardwareScaleActiveAlpha")) {
+                const uint16_t sampleRate = request->hasArg("hardwareScaleSampleRateSps")
+                                                ? static_cast<uint16_t>(request->arg("hardwareScaleSampleRateSps").toInt())
+                                                : settings->getHardwareScaleSampleRateSps();
+                const float idleAlpha = request->hasArg("hardwareScaleIdleAlpha")
+                                            ? request->arg("hardwareScaleIdleAlpha").toFloat()
+                                            : settings->getHardwareScaleIdleAlpha();
+                const float activeAlpha = request->hasArg("hardwareScaleActiveAlpha")
+                                              ? request->arg("hardwareScaleActiveAlpha").toFloat()
+                                              : settings->getHardwareScaleActiveAlpha();
+                settings->setHardwareScaleConfiguration(sampleRate, idleAlpha, activeAlpha);
+            }
             if (request->hasArg("preferredScaleSource"))
                 settings->setPreferredScaleSource(request->arg("preferredScaleSource"));
             if (request->hasArg("pid"))
@@ -853,6 +877,9 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["pressureScaling"] = String(settings.getPressureScaling());
     doc["scaleFactor1"] = settings.getScaleFactor1();
     doc["scaleFactor2"] = settings.getScaleFactor2();
+    doc["hardwareScaleSampleRateSps"] = settings.getHardwareScaleSampleRateSps();
+    doc["hardwareScaleIdleAlpha"] = settings.getHardwareScaleIdleAlpha();
+    doc["hardwareScaleActiveAlpha"] = settings.getHardwareScaleActiveAlpha();
     doc["preferredScaleSource"] = settings.getPreferredScaleSource();
     doc["boilerFillActive"] = settings.isBoilerFillActive();
     doc["startupFillTime"] = settings.getStartupFillTime() / 1000;

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -120,9 +120,9 @@ void WebUIPlugin::setup(Controller *_controller, PluginManager *_pluginManager) 
         broadcastJson(doc);
     });
 
-    // Subscribe to Bluetooth scale weight updates
-    pluginManager->on("controller:volumetric-measurement:bluetooth:change",
-                      [this](Event const &event) { this->currentBluetoothWeight = event.getFloat("value"); });
+    // Subscribe to volumetric measurement updates (hardware, bluetooth, or estimation)
+    pluginManager->on("controller:volumetric-measurement:active:change",
+                      [this](Event const &event) { this->currentWeight = event.getFloat("value"); });
 
     setupServer();
 }
@@ -166,6 +166,8 @@ void WebUIPlugin::loop() {
         statusDoc["cp"] = controller->getSystemInfo().capabilities.pressure;
         statusDoc["cd"] = controller->getSystemInfo().capabilities.dimming;
         statusDoc["gp"] = controller->getSystemInfo().capabilities.hasAddon(7);
+        statusDoc["hs"] = controller->getSystemInfo().capabilities.hwScale;
+        statusDoc["scaleSource"] = controller->getActiveScaleSourceName();
         statusDoc["tw"] = profileManager->getSelectedProfile().getTotalVolume(); // total target weight for the process
         statusDoc["bta"] = controller->isVolumetricAvailable() ? 1 : 0;
         statusDoc["bt"] =
@@ -192,8 +194,8 @@ void WebUIPlugin::loop() {
 
         bool bleConnected = BLEScales.isConnected();
         // Add Bluetooth scale weight information
-        statusDoc["bw"] = bleConnected ? this->currentBluetoothWeight : 0; // current bluetooth weight
-        statusDoc["cw"] = bleConnected ? this->currentBluetoothWeight : 0; // Use 'currentWeight' for forward compatbility
+        statusDoc["bw"] = this->currentWeight;
+        statusDoc["cw"] = this->currentWeight;
         statusDoc["bc"] = bleConnected;                                    // bluetooth scale connected status
         // Scale battery — only surfaced when the driver reports one and the
         // value isn't the UNKNOWN sentinel (255). UI omits the battery pill
@@ -539,6 +541,8 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
                     client->text(toWsBuffer(resp));
                 } else if (msgType == "req:flush:start") {
                     handleFlushStart(client->id(), doc);
+                } else if (msgType == "req:scale:tare") {
+                    controller->getClientController()->tare();
                 }
             }
         }
@@ -673,6 +677,19 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setTemperatureOffset(request->arg("temperatureOffset").toInt());
             if (request->hasArg("pressureScaling"))
                 settings->setPressureScaling(request->arg("pressureScaling").toFloat());
+            if (request->hasArg("scaleFactor1") || request->hasArg("scaleFactor2")) {
+                float sf1 = settings->getScaleFactor1();
+                float sf2 = settings->getScaleFactor2();
+                if (request->hasArg("scaleFactor1")) {
+                    sf1 = request->arg("scaleFactor1").toFloat();
+                }
+                if (request->hasArg("scaleFactor2")) {
+                    sf2 = request->arg("scaleFactor2").toFloat();
+                }
+                settings->setScaleFactors(sf1, sf2);
+            }
+            if (request->hasArg("preferredScaleSource"))
+                settings->setPreferredScaleSource(request->arg("preferredScaleSource"));
             if (request->hasArg("pid"))
                 settings->setPid(request->arg("pid"));
             if (request->hasArg("pumpModelCoeffs"))
@@ -807,6 +824,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
         });
         pluginManager->trigger("settings:changed");
         controller->setTargetTemp(controller->getTargetTemp());
+        controller->setScaleFactors();
         controller->setPumpModelCoeffs();
     }
 
@@ -833,6 +851,9 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["mdnsName"] = settings.getMdnsName();
     doc["temperatureOffset"] = String(settings.getTemperatureOffset());
     doc["pressureScaling"] = String(settings.getPressureScaling());
+    doc["scaleFactor1"] = settings.getScaleFactor1();
+    doc["scaleFactor2"] = settings.getScaleFactor2();
+    doc["preferredScaleSource"] = settings.getPreferredScaleSource();
     doc["boilerFillActive"] = settings.isBoilerFillActive();
     doc["startupFillTime"] = settings.getStartupFillTime() / 1000;
     doc["steamFillTime"] = settings.getSteamFillTime() / 1000;

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -76,7 +76,7 @@ class WebUIPlugin : public Plugin {
     bool apMode = false;
     bool serverRunning = false;
     String updateComponent = "";
-    float currentBluetoothWeight = 0.0f;
+    float currentWeight = 0.0f;
     // Reused for every 500ms status broadcast. Allocating a fresh JsonDocument
     // each tick was a major contributor to internal-heap fragmentation
     // (device reports 33%+ fragmentation, causing AsyncTCP buffer allocs to

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -14,6 +14,7 @@
 constexpr size_t UPDATE_CHECK_INTERVAL = 30 * 60 * 1000;
 constexpr size_t CLEANUP_PERIOD = 1000;
 constexpr size_t STATUS_PERIOD = 500;
+constexpr size_t HARDWARE_SCALE_DIAGNOSTIC_PERIOD = 200;
 constexpr size_t DNS_PERIOD = 50;
 
 const String LOCAL_URL = "http://4.4.4.1/";
@@ -70,6 +71,7 @@ class WebUIPlugin : public Plugin {
 
     long lastUpdateCheck = 0;
     long lastStatus = 0;
+    long lastHardwareScaleDiagnostic = 0;
     long lastCleanup = 0;
     long lastDns = 0;
     bool updating = false;
@@ -83,6 +85,9 @@ class WebUIPlugin : public Plugin {
     // stall mid-asset-serve). Keeping one doc lets its underlying pool grow
     // once and stay put.
     JsonDocument statusDoc{&psramAllocator};
+    // Small, independent 5-Hz stream used only by the calibration indicators;
+    // it avoids raising the rate of the much larger general status document.
+    JsonDocument hardwareScaleDiagnosticDoc{&psramAllocator};
 };
 
 #endif // WEBUIPLUGIN_H

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -218,10 +218,10 @@ void DefaultUI::init() {
     pluginManager->on("profiles:profile:favorite", [this](Event const &event) { reloadProfiles(); });
     pluginManager->on("profiles:profile:unfavorite", [this](Event const &event) { reloadProfiles(); });
     pluginManager->on("profiles:profile:save", [this](Event const &event) { reloadProfiles(); });
-    pluginManager->on("controller:volumetric-measurement:bluetooth:change", [=](Event const &event) {
+    pluginManager->on("controller:volumetric-measurement:active:change", [=](Event const &event) {
         double newWeight = event.getFloat("value");
-        if (round(newWeight * 10.0) != round(bluetoothWeight * 10.0)) {
-            bluetoothWeight = newWeight;
+        if (round(newWeight * 10.0) != round(activeWeight * 10.0)) {
+            activeWeight = newWeight;
             rerender = true;
         }
     });
@@ -257,7 +257,7 @@ void DefaultUI::loop() {
         updateProfileInfo();
         updateBoiler();
         updateBrewProcess();
-        currentWeight = FloatValue(bluetoothWeight);
+        currentWeight = FloatValue(activeWeight);
         eez::flow::setGlobalVariable(FLOW_GLOBAL_VARIABLE_SCALE_WEIGHT_CURRENT, currentWeight);
 
         char timeBuf[12];
@@ -557,12 +557,9 @@ void DefaultUI::updateSystemStatus() {
     if (stringChanged(systemStatus.error_label(), errorLabel.c_str()))
         systemStatus.error_label(errorLabel.c_str());
     systemStatus.volumetric_available(controller->isVolumetricAvailable());
-    systemStatus.bluetooth_scales(controller->isBluetoothScaleHealthy());
-    const String controllerVersion = controller->getSystemInfo().version;
-    if (stringChanged(systemStatus.controller_version(), controllerVersion.c_str()))
-        systemStatus.controller_version(controllerVersion.c_str());
-    if (stringChanged(systemStatus.display_version(), BUILD_GIT_VERSION))
-        systemStatus.display_version(BUILD_GIT_VERSION);
+    systemStatus.bluetooth_scales(controller->isScaleSourceHealthy(controller->getActiveScaleSource()));
+    systemStatus.controller_version(controller->getSystemInfo().version.c_str());
+    systemStatus.display_version(BUILD_GIT_VERSION);
     systemStatus.update_available(updateAvailable);
     systemStatus.in_menu(currentScreen == SCREEN_ID_MENU_SCREEN_NEW);
     systemStatus.pressure_available(pressureAvailable);

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -557,7 +557,7 @@ void DefaultUI::updateSystemStatus() {
     if (stringChanged(systemStatus.error_label(), errorLabel.c_str()))
         systemStatus.error_label(errorLabel.c_str());
     systemStatus.volumetric_available(controller->isVolumetricAvailable());
-    systemStatus.bluetooth_scales(controller->isScaleSourceHealthy(controller->getActiveScaleSource()));
+    systemStatus.bluetooth_scales(controller->isScaleSourceHealthy(controller->getEffectiveScaleSource()));
     systemStatus.controller_version(controller->getSystemInfo().version.c_str());
     systemStatus.display_version(BUILD_GIT_VERSION);
     systemStatus.update_available(updateAvailable);

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -120,7 +120,7 @@ class DefaultUI {
     float pressure = 0.0f;
     float currentTemp = 0.0f;
     float targetTemp = 0.0f;
-    double bluetoothWeight = 0.0;
+    double activeWeight = 0.0;
     BrewScreenState brewScreenState = BrewScreenState::Brew;
 
     // EEZ Structs

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -59,6 +59,8 @@ import { faRotate } from '@fortawesome/free-solid-svg-icons/faRotate';
 
 const DEFAULT_SCALE_FACTOR_1 = -2500.0;
 const DEFAULT_SCALE_FACTOR_2 = 2500.0;
+const DEFAULT_HARDWARE_SCALE_SAMPLE_RATE_SPS = 10;
+const DEFAULT_HARDWARE_SCALE_FILTER_ALPHA = 0.8;
 
 function splitPidString(pidString) {
   if (!pidString) return { pid: pidString, kf: '0.000' };
@@ -115,6 +117,19 @@ function transformFetchedSettings(fetchedSettings) {
     Number.isFinite(sf1) && Math.abs(sf1) > 0.001 ? sf1 : DEFAULT_SCALE_FACTOR_1;
   settingsWithToggle.scaleFactor2 =
     Number.isFinite(sf2) && Math.abs(sf2) > 0.001 ? sf2 : DEFAULT_SCALE_FACTOR_2;
+  const sampleRate = Number(fetchedSettings.hardwareScaleSampleRateSps);
+  settingsWithToggle.hardwareScaleSampleRateSps =
+    sampleRate === 80 ? 80 : DEFAULT_HARDWARE_SCALE_SAMPLE_RATE_SPS;
+  const idleAlpha = Number(fetchedSettings.hardwareScaleIdleAlpha);
+  settingsWithToggle.hardwareScaleIdleAlpha =
+    Number.isFinite(idleAlpha) && idleAlpha > 0 && idleAlpha <= 1
+      ? idleAlpha
+      : DEFAULT_HARDWARE_SCALE_FILTER_ALPHA;
+  const activeAlpha = Number(fetchedSettings.hardwareScaleActiveAlpha);
+  settingsWithToggle.hardwareScaleActiveAlpha =
+    Number.isFinite(activeAlpha) && activeAlpha > 0 && activeAlpha <= 1
+      ? activeAlpha
+      : DEFAULT_HARDWARE_SCALE_FILTER_ALPHA;
 
   if (fetchedSettings.pid) {
     const split = splitPidString(fetchedSettings.pid);

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -57,6 +57,9 @@ import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faBluetoothB } from '@fortawesome/free-brands-svg-icons/faBluetoothB';
 import { faRotate } from '@fortawesome/free-solid-svg-icons/faRotate';
 
+const DEFAULT_SCALE_FACTOR_1 = -2500.0;
+const DEFAULT_SCALE_FACTOR_2 = 2500.0;
+
 function splitPidString(pidString) {
   if (!pidString) return { pid: pidString, kf: '0.000' };
   const parts = pidString.split(',');
@@ -105,6 +108,13 @@ function transformFetchedSettings(fetchedSettings) {
         : fetchedSettings.standbyBrightness > 0,
     dashboardLayout: fetchedSettings.dashboardLayout || DASHBOARD_LAYOUTS.ORDER_FIRST,
   };
+
+  const sf1 = Number(fetchedSettings.scaleFactor1);
+  const sf2 = Number(fetchedSettings.scaleFactor2);
+  settingsWithToggle.scaleFactor1 =
+    Number.isFinite(sf1) && Math.abs(sf1) > 0.001 ? sf1 : DEFAULT_SCALE_FACTOR_1;
+  settingsWithToggle.scaleFactor2 =
+    Number.isFinite(sf2) && Math.abs(sf2) > 0.001 ? sf2 : DEFAULT_SCALE_FACTOR_2;
 
   if (fetchedSettings.pid) {
     const split = splitPidString(fetchedSettings.pid);
@@ -503,4 +513,3 @@ export function Settings() {
     </PageLayout>
   );
 }
-

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -503,3 +503,4 @@ export function Settings() {
     </PageLayout>
   );
 }
+

--- a/web/src/pages/Settings/tabs/MachineTab.jsx
+++ b/web/src/pages/Settings/tabs/MachineTab.jsx
@@ -1,15 +1,18 @@
-import { useState } from 'preact/hooks';
+import { useCallback, useContext, useState } from 'preact/hooks';
 import { computed } from '@preact/signals';
-import { machine } from '../../../services/ApiService.js';
+import { ApiServiceContext, machine } from '../../../services/ApiService.js';
 import Section from '../../../components/Card.jsx';
 import { Tooltip } from '../../../components/Tooltip.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrosshairs } from '@fortawesome/free-solid-svg-icons/faCrosshairs';
+import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { InputGroupField, SettingsFormField } from '../../../components/SettingsFormField.jsx';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
 const pressureAvailable = computed(() => machine.value.capabilities.pressure);
 const tofDistance = computed(() => machine.value.status.tofDistance);
+const hardwareScaleAvailable = computed(() => !!machine.value.capabilities.hardwareScale);
+const status = computed(() => machine.value.status);
 
 function SunriseColorField({ id, label, value, fallback, onChange }) {
   return (
@@ -59,7 +62,35 @@ function TankDistanceField({ id, label, value, onChange, onUseCurrent }) {
 }
 
 export function MachineTab({ formData, onChange, setField }) {
+  const apiService = useContext(ApiServiceContext);
   const [steamPumpDraft, setSteamPumpDraft] = useState(null);
+  const [calibrationWeight, setCalibrationWeight] = useState('');
+
+  const tareScale = useCallback(() => {
+    apiService.send({ tp: 'req:scale:tare' });
+  }, [apiService]);
+
+  const calibrateLoadCell = useCallback(
+    cellNumber => {
+      const measuredWeight = status.value?.currentWeight;
+      const actualWeight = Number.parseFloat(calibrationWeight);
+      if (!measuredWeight || !actualWeight || actualWeight <= 0) {
+        window.alert(
+          'Please ensure the scale is showing a weight and enter a valid calibration weight.',
+        );
+        return;
+      }
+
+      const currentFactor =
+        cellNumber === 1
+          ? Number.parseFloat(formData.scaleFactor1) || 1
+          : Number.parseFloat(formData.scaleFactor2) || 1;
+      const newFactor = (measuredWeight * currentFactor) / actualWeight;
+      setField(`scaleFactor${cellNumber}`, newFactor.toFixed(2));
+      setCalibrationWeight('');
+    },
+    [calibrationWeight, formData.scaleFactor1, formData.scaleFactor2, setField],
+  );
 
   return (
     <div className='space-y-4 sm:space-y-6 lg:grid lg:grid-cols-2 lg:gap-4'>
@@ -269,6 +300,121 @@ export function MachineTab({ formData, onChange, setField }) {
           </InputGroupField>
         </div>
       </Section>
+
+      <Section title='Scales'>
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+          <SettingsFormField
+            label='Preferred Scale Source'
+            htmlFor='preferredScaleSource'
+            helpText='Choose which source to prefer when both hardware and Bluetooth scales are available.'
+            noMargin
+          >
+            <select
+              id='preferredScaleSource'
+              name='preferredScaleSource'
+              className='select select-bordered w-full'
+              value={formData.preferredScaleSource || 'hardware'}
+              onChange={onChange('preferredScaleSource')}
+            >
+              <option value='hardware'>Prefer Hardware Scale (Built-in)</option>
+              <option value='bluetooth'>Prefer Bluetooth Scale</option>
+              <option value='auto'>Auto (best available)</option>
+            </select>
+          </SettingsFormField>
+        </div>
+
+        {hardwareScaleAvailable.value && (
+          <div className='border-base-content/5 mt-6 space-y-4 border-t pt-6'>
+            <div>
+              <h3 className='font-medium'>Hardware Scale Calibration</h3>
+              <p className='text-base-content/60 mt-1 text-sm'>
+                Tare the scale, then place a known weight and calibrate each load cell.
+              </p>
+            </div>
+
+            <div className='bg-base-200 flex items-center justify-between rounded-lg p-3'>
+              <div className='flex items-center gap-2'>
+                <FontAwesomeIcon icon={faWeightScale} className='text-primary' />
+                <span className='text-2xl font-bold'>
+                  {status.value?.currentWeight?.toFixed(1) || '0.0'}g
+                </span>
+              </div>
+              <button type='button' className='btn btn-outline btn-sm' onClick={tareScale}>
+                Tare
+              </button>
+            </div>
+
+            <SettingsFormField
+              label='Actual Weight of Calibration Object'
+              htmlFor='calibrationWeight'
+              noMargin
+            >
+              <label className='input input-bordered w-full'>
+                <input
+                  id='calibrationWeight'
+                  type='number'
+                  className='grow'
+                  placeholder='100.0'
+                  min='0.1'
+                  step='0.1'
+                  value={calibrationWeight}
+                  onChange={event => setCalibrationWeight(event.currentTarget.value)}
+                />
+                <span>g</span>
+              </label>
+            </SettingsFormField>
+
+            <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+              <button
+                type='button'
+                className='btn btn-primary btn-sm'
+                onClick={() => calibrateLoadCell(1)}
+                disabled={!status.value?.currentWeight || !calibrationWeight}
+              >
+                Calibrate Load Cell 1
+              </button>
+              <button
+                type='button'
+                className='btn btn-primary btn-sm'
+                onClick={() => calibrateLoadCell(2)}
+                disabled={!status.value?.currentWeight || !calibrationWeight}
+              >
+                Calibrate Load Cell 2
+              </button>
+            </div>
+
+            <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+              <SettingsFormField label='Load Cell 1 Scale Factor' htmlFor='scaleFactor1' noMargin>
+                <input
+                  id='scaleFactor1'
+                  name='scaleFactor1'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='-50000'
+                  max='50000'
+                  step='0.01'
+                  value={formData.scaleFactor1}
+                  onChange={onChange('scaleFactor1')}
+                />
+              </SettingsFormField>
+              <SettingsFormField label='Load Cell 2 Scale Factor' htmlFor='scaleFactor2' noMargin>
+                <input
+                  id='scaleFactor2'
+                  name='scaleFactor2'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='-50000'
+                  max='50000'
+                  step='0.01'
+                  value={formData.scaleFactor2}
+                  onChange={onChange('scaleFactor2')}
+                />
+              </SettingsFormField>
+            </div>
+          </div>
+        )}
+      </Section>
+
       {/* Alba Settings */}
       {ledControl.value && (
         <Section title='Alba Settings' className='h-full'>

--- a/web/src/pages/Settings/tabs/MachineTab.jsx
+++ b/web/src/pages/Settings/tabs/MachineTab.jsx
@@ -70,11 +70,35 @@ export function MachineTab({ formData, onChange, setField }) {
     apiService.send({ tp: 'req:scale:tare' });
   }, [apiService]);
 
+  const changeHardwareScaleSampleRate = useCallback(
+    event => {
+      const sampleRate = Number.parseInt(event.currentTarget.value, 10) === 80 ? 80 : 10;
+      const defaultAlpha = sampleRate === 80 ? '0.40' : '0.80';
+      setField('hardwareScaleSampleRateSps', sampleRate);
+      setField('hardwareScaleIdleAlpha', defaultAlpha);
+      setField('hardwareScaleActiveAlpha', defaultAlpha);
+    },
+    [setField],
+  );
+
   const calibrateLoadCell = useCallback(
     cellNumber => {
-      const measuredWeight = status.value?.currentWeight;
+      const measuredWeight =
+        cellNumber === 1
+          ? status.value?.hardwareScaleCell1Weight
+          : status.value?.hardwareScaleCell2Weight;
+      const measurementValid =
+        cellNumber === 1
+          ? status.value?.hardwareScaleCell1Valid
+          : status.value?.hardwareScaleCell2Valid;
       const actualWeight = Number.parseFloat(calibrationWeight);
-      if (!measuredWeight || !actualWeight || actualWeight <= 0) {
+      if (
+        !measurementValid ||
+        !Number.isFinite(measuredWeight) ||
+        Math.abs(measuredWeight) < 0.01 ||
+        !Number.isFinite(actualWeight) ||
+        actualWeight <= 0
+      ) {
         window.alert(
           'Please ensure the scale is showing a weight and enter a valid calibration weight.',
         );
@@ -326,7 +350,77 @@ export function MachineTab({ formData, onChange, setField }) {
         {hardwareScaleAvailable.value && (
           <div className='border-base-content/5 mt-6 space-y-4 border-t pt-6'>
             <div>
-              <h3 className='font-medium'>Hardware Scale Calibration</h3>
+              <h3 className='font-medium'>Hardware Scale</h3>
+              <p className='text-base-content/60 mt-1 text-sm'>
+                Configure acquisition and filtering, then tare and calibrate each load cell.
+              </p>
+            </div>
+
+            <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+              <SettingsFormField
+                label='HX711 Sample Rate'
+                htmlFor='hardwareScaleSampleRateSps'
+                helpText='Must match the physical RATE-jumper configuration on the HX711 board. This setting does not switch the RATE pin.'
+                noMargin
+              >
+                <select
+                  id='hardwareScaleSampleRateSps'
+                  name='hardwareScaleSampleRateSps'
+                  className='select select-bordered w-full'
+                  value={formData.hardwareScaleSampleRateSps || 10}
+                  onChange={changeHardwareScaleSampleRate}
+                >
+                  <option value='10'>10 SPS</option>
+                  <option value='80'>80 SPS</option>
+                </select>
+              </SettingsFormField>
+              <SettingsFormField
+                label='Idle Filter Alpha'
+                htmlFor='hardwareScaleIdleAlpha'
+                helpText='Larger alpha responds faster with less smoothing; smaller alpha is smoother but slower.'
+                noMargin
+              >
+                <input
+                  id='hardwareScaleIdleAlpha'
+                  name='hardwareScaleIdleAlpha'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='0.05'
+                  max='1'
+                  step='0.01'
+                  value={formData.hardwareScaleIdleAlpha}
+                  onChange={onChange('hardwareScaleIdleAlpha')}
+                />
+              </SettingsFormField>
+              <SettingsFormField
+                label='Brewing Filter Alpha'
+                htmlFor='hardwareScaleActiveAlpha'
+                helpText='Larger alpha responds faster with less smoothing; smaller alpha is smoother but slower.'
+                noMargin
+              >
+                <input
+                  id='hardwareScaleActiveAlpha'
+                  name='hardwareScaleActiveAlpha'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='0.05'
+                  max='1'
+                  step='0.01'
+                  value={formData.hardwareScaleActiveAlpha}
+                  onChange={onChange('hardwareScaleActiveAlpha')}
+                />
+              </SettingsFormField>
+            </div>
+
+            <p className='text-base-content/60 text-xs'>
+              A given alpha behaves faster in time at 80 SPS because it is applied more often. Tune
+              the two alpha values independently for your installed sample rate. Changing sample
+              rate resets both values to 0.80 at 10 SPS or 0.40 at 80 SPS as sensible starting
+              points.
+            </p>
+
+            <div>
+              <h4 className='font-medium'>Calibration</h4>
               <p className='text-base-content/60 mt-1 text-sm'>
                 Tare the scale, then place a known weight and calibrate each load cell.
               </p>
@@ -369,7 +463,7 @@ export function MachineTab({ formData, onChange, setField }) {
                 type='button'
                 className='btn btn-primary btn-sm'
                 onClick={() => calibrateLoadCell(1)}
-                disabled={!status.value?.currentWeight || !calibrationWeight}
+                disabled={!status.value?.hardwareScaleCell1Valid || !calibrationWeight}
               >
                 Calibrate Load Cell 1
               </button>
@@ -377,39 +471,55 @@ export function MachineTab({ formData, onChange, setField }) {
                 type='button'
                 className='btn btn-primary btn-sm'
                 onClick={() => calibrateLoadCell(2)}
-                disabled={!status.value?.currentWeight || !calibrationWeight}
+                disabled={!status.value?.hardwareScaleCell2Valid || !calibrationWeight}
               >
                 Calibrate Load Cell 2
               </button>
             </div>
 
             <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
-              <SettingsFormField label='Load Cell 1 Scale Factor' htmlFor='scaleFactor1' noMargin>
-                <input
-                  id='scaleFactor1'
-                  name='scaleFactor1'
-                  type='number'
-                  className='input input-bordered w-full'
-                  min='-50000'
-                  max='50000'
-                  step='0.01'
-                  value={formData.scaleFactor1}
-                  onChange={onChange('scaleFactor1')}
-                />
-              </SettingsFormField>
-              <SettingsFormField label='Load Cell 2 Scale Factor' htmlFor='scaleFactor2' noMargin>
-                <input
-                  id='scaleFactor2'
-                  name='scaleFactor2'
-                  type='number'
-                  className='input input-bordered w-full'
-                  min='-50000'
-                  max='50000'
-                  step='0.01'
-                  value={formData.scaleFactor2}
-                  onChange={onChange('scaleFactor2')}
-                />
-              </SettingsFormField>
+              <div>
+                <p className='text-base-content/60 mb-1 text-xs'>
+                  Current:{' '}
+                  {status.value?.hardwareScaleCell1Valid
+                    ? `${status.value.hardwareScaleCell1Weight.toFixed(1)} g`
+                    : 'Unavailable / uncalibrated'}
+                </p>
+                <SettingsFormField label='Load Cell 1 Scale Factor' htmlFor='scaleFactor1' noMargin>
+                  <input
+                    id='scaleFactor1'
+                    name='scaleFactor1'
+                    type='number'
+                    className='input input-bordered w-full'
+                    min='-50000'
+                    max='50000'
+                    step='0.01'
+                    value={formData.scaleFactor1}
+                    onChange={onChange('scaleFactor1')}
+                  />
+                </SettingsFormField>
+              </div>
+              <div>
+                <p className='text-base-content/60 mb-1 text-xs'>
+                  Current:{' '}
+                  {status.value?.hardwareScaleCell2Valid
+                    ? `${status.value.hardwareScaleCell2Weight.toFixed(1)} g`
+                    : 'Unavailable / uncalibrated'}
+                </p>
+                <SettingsFormField label='Load Cell 2 Scale Factor' htmlFor='scaleFactor2' noMargin>
+                  <input
+                    id='scaleFactor2'
+                    name='scaleFactor2'
+                    type='number'
+                    className='input input-bordered w-full'
+                    min='-50000'
+                    max='50000'
+                    step='0.01'
+                    value={formData.scaleFactor2}
+                    onChange={onChange('scaleFactor2')}
+                  />
+                </SettingsFormField>
+              </div>
             </div>
           </div>
         )}

--- a/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
@@ -36,7 +36,7 @@ function getPhaseSysAnomalies(samples, sysInfo) {
   const sysFieldMap = [
     ['sys_shot_vol', 'shotStartedVolumetric'],
     ['sys_curr_vol', 'currentlyVolumetric'],
-    ['sys_scale', 'bluetoothScaleConnected'],
+    ['sys_scale', 'activeScaleConnected'],
     ['sys_vol_avail', 'volumetricAvailable'],
     ['sys_ext', 'extendedRecording'],
   ];
@@ -548,7 +548,7 @@ function getPhaseStats(samples, sysInfo, sysAnomalies, analyzerSystemInfo) {
     sys_raw: sysInfo.raw,
     sys_shot_vol: sysInfo.shotStartedVolumetric,
     sys_curr_vol: sysInfo.currentlyVolumetric,
-    sys_scale: sysInfo.bluetoothScaleConnected,
+    sys_scale: sysInfo.activeScaleConnected,
     sys_vol_avail: sysInfo.volumetricAvailable,
     sys_ext: sysInfo.extendedRecording,
     sys_brew_mode: analyzerSystemInfo.brewModeLabel,
@@ -586,7 +586,7 @@ export function analyzeExecutedPhase({
   const sysInfo = getPhaseEndSample(samples).systemInfo || {};
   const sysAnomalies = getPhaseSysAnomalies(samples, sysInfo);
   const scaleLostInThisPhase =
-    isBrewByWeight && samples.some(s => s.systemInfo?.bluetoothScaleConnected === false);
+    isBrewByWeight && samples.some(s => s.systemInfo?.activeScaleConnected === false);
   const nextScaleConnectionBroken = scaleConnectionBrokenPermanently || scaleLostInThisPhase;
   const delayTracker = createPhaseDelayTracker(isLastPhase);
   const exitState = createExitState();

--- a/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
@@ -151,7 +151,7 @@ export function calculateShotMetrics(shotData, profileData, settings) {
 
   let globalScaleLost = false;
   if (isBrewByWeight) {
-    globalScaleLost = gSamples.some(s => s.systemInfo?.bluetoothScaleConnected === false);
+    globalScaleLost = gSamples.some(s => s.systemInfo?.activeScaleConnected === false);
   }
 
   // --- 3. GLOBAL TOTALS ---
@@ -231,7 +231,7 @@ export function calculateShotMetrics(shotData, profileData, settings) {
     sys_raw: finalSysInfo.raw,
     sys_shot_vol: finalSysInfo.shotStartedVolumetric,
     sys_curr_vol: finalSysInfo.currentlyVolumetric,
-    sys_scale: finalSysInfo.bluetoothScaleConnected,
+    sys_scale: finalSysInfo.activeScaleConnected,
     sys_vol_avail: finalSysInfo.volumetricAvailable,
     sys_ext: finalSysInfo.extendedRecording,
     sys_brew_mode: brewModeLabel,

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -61,6 +61,10 @@ const FIELD_DEFS = {
       bluetoothScaleConnected: !!(val & 0x0004),
       volumetricAvailable: !!(val & 0x0008),
       extendedRecording: !!(val & 0x0010),
+      processIsBrew: !!(val & 0x0020),
+      targetIsVolumetric: !!(val & 0x0040),
+      phaseHasVolumetric: !!(val & 0x0080),
+      activeScaleConnected: !!(val & 0x0100),
     }),
   },
   // Phase number field removed in v5+, moved to header transitions
@@ -280,6 +284,12 @@ export function parseBinaryShot(arrayBuffer, id) {
       sample.phaseNumber = currentPhase;
       sample.phaseDisplayNumber = currentPhase + 1; // 1-based for display
       sample.phaseName = phaseName;
+    }
+
+    // v1-v5 only recorded the Bluetooth-specific scale bit. Preserve their
+    // original meaning while presenting one source-neutral field to analysis.
+    if (sample.systemInfo && version < 6) {
+      sample.systemInfo.activeScaleConnected = sample.systemInfo.bluetoothScaleConnected;
     }
 
     samples.push(sample);

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -183,6 +183,7 @@ export default class ApiService {
       grindActive: message.gact || false,
       currentWeight: message.cw || 0,
       bluetoothConnected: message.bc || false,
+      activeScaleSource: message.scaleSource || 'inactive',
       process: message.process || null,
       timestamp: new Date(),
       rssi: message.rssi || 0,
@@ -209,6 +210,7 @@ export default class ApiService {
         pressure: message.cp,
         ledControl: message.led,
         gearpumpAddon: !!message.gp,
+        hardwareScale: !!message.hs,
       },
       history: [...machine.value.history, historyEntry],
     };
@@ -240,6 +242,7 @@ export const machine = signal({
   capabilities: {
     pressure: false,
     dimming: false,
+    hardwareScale: false,
   },
   history: [],
 });

--- a/web/src/services/ApiService.js
+++ b/web/src/services/ApiService.js
@@ -102,6 +102,8 @@ export default class ApiService {
     const listeners = Object.values(this.listeners[message.tp] || {});
     if (message.tp === 'evt:status') {
       this._onStatus(message);
+    } else if (message.tp === 'evt:hardware-scale') {
+      this._onHardwareScale(message);
     }
     for (const listener of listeners) {
       listener(message);
@@ -216,6 +218,19 @@ export default class ApiService {
     };
     newValue.history = newValue.history.slice(-600);
     machine.value = newValue;
+  }
+
+  _onHardwareScale(message) {
+    machine.value = {
+      ...machine.value,
+      status: {
+        ...machine.value.status,
+        hardwareScaleCell1Weight: message.c1 ?? 0,
+        hardwareScaleCell2Weight: message.c2 ?? 0,
+        hardwareScaleCell1Valid: !!message.c1v,
+        hardwareScaleCell2Valid: !!message.c2v,
+      },
+    };
   }
 }
 


### PR DESCRIPTION
- Add support for 2xHX711 Hardware scales
- Modify protocol to add scale value, scale calibration parameters
- Add related settings in Webui - user can select preferred scale source 
- Grind function always uses Bluetooth (with fallback to none/time)
- Add taring to Webui
- Modify controller volumetric source naming to be generic currentWeight / activeWeight / currentSource etc. - source selection in controller based on settings/nightly
- EEZ project is unmodified (kept systemStatus.bluetooth_scales which should be renamed in the EEZ project to something generic)

<img width="1638" height="837" alt="image" src="https://github.com/user-attachments/assets/83a5a6ca-f0b7-43d1-b8b9-a32f6a919926" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hardware-scale support with per-cell measurements, tare, calibration, and configurable sampling and filtering.
  * Added automatic selection between hardware and Bluetooth scales, with configurable preferred source.
  * Added web controls for scale selection, calibration, tare, and scale-factor editing.
  * Added scale diagnostics, active-source status, and capability information.

* **Bug Fixes**
  * Weight displays, shot history, and volumetric measurements now consistently use the active scale.
  * Improved handling of invalid, unstable, or temporarily unavailable readings.
  * Preserved active-scale information when viewing older shot records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->