### PR TITLE
Cleaning Schedule (Backflush / Descale)

### DIFF
--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -16,6 +16,7 @@
 #include <display/core/zones.h>
 #include <display/plugins/AutoWakeupPlugin.h>
 #include <display/plugins/BoilerFillPlugin.h>
+#include <display/plugins/CleaningSchedulePlugin.h>
 #include <display/plugins/LedControlPlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
 #include <display/plugins/SmartGrindPlugin.h>
@@ -104,6 +105,7 @@ void Controller::setup() {
 #endif
     pluginManager->registerPlugin(new LedControlPlugin());
     pluginManager->registerPlugin(new AutoWakeupPlugin());
+    pluginManager->registerPlugin(new CleaningSchedulePlugin());
     pluginManager->setup(this);
 
     pluginManager->on("profiles:profile:save", [this](Event const &event) {

--- a/src/display/core/Property.h
+++ b/src/display/core/Property.h
@@ -15,6 +15,11 @@ template <> struct PreferencesCodec<int> {
     static void write(Preferences &prefs, const char *key, const int &value) { prefs.putInt(key, value); }
 };
 
+template <> struct PreferencesCodec<unsigned long> {
+    static unsigned long read(Preferences &prefs, const char *key, const unsigned long &def) { return prefs.getULong(key, def); }
+    static void write(Preferences &prefs, const char *key, const unsigned long &value) { prefs.putULong(key, value); }
+};
+
 template <> struct PreferencesCodec<bool> {
     static bool read(Preferences &prefs, const char *key, const bool &def) { return prefs.getBool(key, def); }
     static void write(Preferences &prefs, const char *key, const bool &value) { prefs.putBool(key, value); }

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -267,6 +267,14 @@ void Settings::setIntegralGain(float integral_gain) { integralGain.set(integral_
 
 void Settings::setMaxPumpPower(float max_pump_power) { maxPumpPower.set(max_pump_power); }
 
+void Settings::setBackflushIntervalDays(int backflush_interval_days) { backflushIntervalDays.set(backflush_interval_days); }
+
+void Settings::setDescalingIntervalWeeks(int descaling_interval_weeks) { descalingIntervalWeeks.set(descaling_interval_weeks); }
+
+void Settings::setLastBackflushTime(unsigned long last_backflush_time) { lastBackflushTime.set(last_backflush_time); }
+
+void Settings::setLastDescalingTime(unsigned long last_descaling_time) { lastDescalingTime.set(last_descaling_time); }
+
 void Settings::doSave() {
     bool dirty = false;
     for (auto *property : registry) {

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -157,6 +157,10 @@ class Settings {
     float getConvergenceGain() const { return convergenceGain.get(); }
     float getIntegralGain() const { return integralGain.get(); }
     float getMaxPumpPower() const { return maxPumpPower.get(); }
+    int getBackflushIntervalDays() const { return backflushIntervalDays.get(); }
+    int getDescalingIntervalWeeks() const { return descalingIntervalWeeks.get(); }
+    unsigned long getLastBackflushTime() const { return lastBackflushTime.get(); }
+    unsigned long getLastDescalingTime() const { return lastDescalingTime.get(); }
 
     void setTargetSteamTemp(int target_steam_temp);
     void setTargetWaterTemp(int target_water_temp);
@@ -234,6 +238,10 @@ class Settings {
     void setConvergenceGain(float convergenceGain);
     void setIntegralGain(float integralGain);
     void setMaxPumpPower(float maxPumpPower);
+    void setBackflushIntervalDays(int backflushIntervalDays);
+    void setDescalingIntervalWeeks(int descalingIntervalWeeks);
+    void setLastBackflushTime(unsigned long lastBackflushTime);
+    void setLastDescalingTime(unsigned long lastDescalingTime);
 
   private:
     Preferences preferences;
@@ -315,6 +323,12 @@ class Settings {
     Property<float> convergenceGain{registry, "p_cv", DEFAULT_CONVERGENCE_GAIN};
     Property<float> integralGain{registry, "p_ig", DEFAULT_INTEGRAL_GAIN};
     Property<float> maxPumpPower{registry, "p_mp", 1.0f};
+
+    // Cleaning schedule
+    Property<int> backflushIntervalDays{registry, "cl_bid", 14};
+    Property<int> descalingIntervalWeeks{registry, "cl_diw", 6};
+    Property<unsigned long> lastBackflushTime{registry, "cl_lbt", 0};
+    Property<unsigned long> lastDescalingTime{registry, "cl_ldt", 0};
 
     void doSave();
     xTaskHandle taskHandle;

--- a/src/display/plugins/CleaningSchedulePlugin.cpp
+++ b/src/display/plugins/CleaningSchedulePlugin.cpp
@@ -1,0 +1,399 @@
+#include "CleaningSchedulePlugin.h"
+#include <display/core/Controller.h>
+#include <display/core/Event.h>
+#include <display/core/ProfileManager.h>
+#include <display/core/constants.h>
+#include <display/core/utils.h>
+#include <time.h>
+
+// Static profile ID constants
+const String CleaningSchedulePlugin::BACKFLUSH_PROFILE_ID = "flush";
+const String CleaningSchedulePlugin::DESCALING_PROFILE_ID = "descaling_cleaning";
+
+void CleaningSchedulePlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+    this->pluginManager = pluginManager;
+
+    ESP_LOGI("CleaningSchedulePlugin", "Setting up cleaning schedule plugin");
+
+    // Ensure cleaning profiles exist
+    ensureCleaningProfilesExist();
+
+    // Set up event listeners for when cleaning is triggered
+    pluginManager->on("cleaning:backflush:start", [this](Event const &) { startBackflush(); });
+
+    pluginManager->on("cleaning:descaling:start", [this](Event const &) { startDescaling(); });
+
+    pluginManager->on("cleaning:backflush:reset", [this](Event const &) { resetBackflushTimer(); });
+
+    pluginManager->on("cleaning:descaling:reset", [this](Event const &) { resetDescalingTimer(); });
+
+    // Listen for process completion to auto-reset cleaning timers
+    pluginManager->on("controller:process:end", [this](Event const &) { checkAndResetCleaningTimers(); });
+
+    // Initialize check time
+    lastCheckTime = millis();
+}
+
+void CleaningSchedulePlugin::loop() {
+    unsigned long currentTime = millis();
+
+    // Check cleaning status periodically
+    if (currentTime - lastCheckTime >= CHECK_INTERVAL) {
+        lastCheckTime = currentTime;
+        triggerNotificationEvents();
+    }
+}
+
+void CleaningSchedulePlugin::startBackflush() {
+    ESP_LOGI("CleaningSchedulePlugin", "Starting backflush procedure");
+
+    // Load the backflush profile and switch to brew mode
+    loadCleaningProfile(BACKFLUSH_PROFILE_ID);
+}
+
+void CleaningSchedulePlugin::startDescaling() {
+    ESP_LOGI("CleaningSchedulePlugin", "Starting descaling procedure");
+
+    // Load the descaling profile and switch to brew mode
+    loadCleaningProfile(DESCALING_PROFILE_ID);
+}
+
+void CleaningSchedulePlugin::resetBackflushTimer() {
+    Settings &settings = controller->getSettings();
+    settings.setLastBackflushTime(getCurrentTimeSeconds());
+    ESP_LOGI("CleaningSchedulePlugin", "Backflush timer reset");
+
+    // Trigger event to update UI
+    pluginManager->trigger("cleaning:backflush:timer:reset");
+}
+
+void CleaningSchedulePlugin::resetDescalingTimer() {
+    Settings &settings = controller->getSettings();
+    settings.setLastDescalingTime(getCurrentTimeSeconds());
+    ESP_LOGI("CleaningSchedulePlugin", "Descaling timer reset");
+
+    // Trigger event to update UI
+    pluginManager->trigger("cleaning:descaling:timer:reset");
+}
+
+bool CleaningSchedulePlugin::isBackflushDue() const {
+    const Settings &settings = controller->getSettings();
+    int intervalDays = settings.getBackflushIntervalDays();
+    unsigned long lastBackflushTime = settings.getLastBackflushTime();
+
+    if (lastBackflushTime == 0) {
+        return false; // Never performed, not due yet
+    }
+
+    unsigned long currentTime = getCurrentTimeSeconds();
+    unsigned long daysSince = (currentTime - lastBackflushTime) / (24 * 60 * 60);
+
+    return daysSince >= intervalDays;
+}
+
+bool CleaningSchedulePlugin::isDescalingDue() const {
+    const Settings &settings = controller->getSettings();
+    int intervalWeeks = settings.getDescalingIntervalWeeks();
+    unsigned long lastDescalingTime = settings.getLastDescalingTime();
+
+    if (lastDescalingTime == 0) {
+        return false; // Never performed, not due yet
+    }
+
+    unsigned long currentTime = getCurrentTimeSeconds();
+    unsigned long weeksSince = (currentTime - lastDescalingTime) / (7 * 24 * 60 * 60);
+
+    return weeksSince >= intervalWeeks;
+}
+
+int CleaningSchedulePlugin::getDaysSinceLastBackflush() const {
+    const Settings &settings = controller->getSettings();
+    unsigned long lastBackflushTime = settings.getLastBackflushTime();
+
+    if (lastBackflushTime == 0) {
+        return -1; // Never performed
+    }
+
+    unsigned long currentTime = getCurrentTimeSeconds();
+    return (currentTime - lastBackflushTime) / (24 * 60 * 60);
+}
+
+int CleaningSchedulePlugin::getWeeksSinceLastDescaling() const {
+    const Settings &settings = controller->getSettings();
+    unsigned long lastDescalingTime = settings.getLastDescalingTime();
+
+    if (lastDescalingTime == 0) {
+        return -1; // Never performed
+    }
+
+    unsigned long currentTime = getCurrentTimeSeconds();
+    return (currentTime - lastDescalingTime) / (7 * 24 * 60 * 60);
+}
+
+Profile CleaningSchedulePlugin::createBackflushProfile() const {
+    Profile profile{};
+    profile.id = BACKFLUSH_PROFILE_ID;
+    profile.label = "[Utility] Backflush";
+    profile.utility = true;
+    profile.description = "";
+    profile.temperature = 93;
+    profile.type = "standard";
+
+    // Phase 1: Pressurize (10 seconds)
+    Phase phase1{};
+    phase1.name = "Pressurize";
+    phase1.phase = PhaseType::PHASE_TYPE_BREW;
+    phase1.valve = 1;
+    phase1.duration = 10.0f;
+    phase1.pumpIsSimple = true;
+    phase1.pumpSimple = 100;
+    profile.phases.push_back(phase1);
+
+    // Phase 2: Depressurize (10 seconds)
+    Phase phase2{};
+    phase2.name = "Depressurize";
+    phase2.phase = PhaseType::PHASE_TYPE_BREW;
+    phase2.valve = 0;
+    phase2.duration = 10.0f;
+    phase2.pumpIsSimple = true;
+    phase2.pumpSimple = 0;
+    profile.phases.push_back(phase2);
+
+    // Phase 3: Pressurize (10 seconds)
+    Phase phase3{};
+    phase3.name = "Pressurize";
+    phase3.phase = PhaseType::PHASE_TYPE_BREW;
+    phase3.valve = 1;
+    phase3.duration = 10.0f;
+    phase3.pumpIsSimple = true;
+    phase3.pumpSimple = 100;
+    profile.phases.push_back(phase3);
+
+    // Phase 4: Depressurize (10 seconds)
+    Phase phase4{};
+    phase4.name = "Depressurize";
+    phase4.phase = PhaseType::PHASE_TYPE_BREW;
+    phase4.valve = 0;
+    phase4.duration = 10.0f;
+    phase4.pumpIsSimple = true;
+    phase4.pumpSimple = 0;
+    profile.phases.push_back(phase4);
+
+    // Phase 5: Pressurize (10 seconds)
+    Phase phase5{};
+    phase5.name = "Pressurize";
+    phase5.phase = PhaseType::PHASE_TYPE_BREW;
+    phase5.valve = 1;
+    phase5.duration = 10.0f;
+    phase5.pumpIsSimple = true;
+    phase5.pumpSimple = 100;
+    profile.phases.push_back(phase5);
+
+    // Phase 6: Depressurize (10 seconds)
+    Phase phase6{};
+    phase6.name = "Depressurize";
+    phase6.phase = PhaseType::PHASE_TYPE_BREW;
+    phase6.valve = 0;
+    phase6.duration = 10.0f;
+    phase6.pumpIsSimple = true;
+    phase6.pumpSimple = 0;
+    profile.phases.push_back(phase6);
+
+    // Phase 7: Pressurize (10 seconds)
+    Phase phase7{};
+    phase7.name = "Pressurize";
+    phase7.phase = PhaseType::PHASE_TYPE_BREW;
+    phase7.valve = 1;
+    phase7.duration = 10.0f;
+    phase7.pumpIsSimple = true;
+    phase7.pumpSimple = 100;
+    profile.phases.push_back(phase7);
+
+    // Phase 8: Depressurize (10 seconds)
+    Phase phase8{};
+    phase8.name = "Depressurize";
+    phase8.phase = PhaseType::PHASE_TYPE_BREW;
+    phase8.valve = 0;
+    phase8.duration = 10.0f;
+    phase8.pumpIsSimple = true;
+    phase8.pumpSimple = 0;
+    profile.phases.push_back(phase8);
+
+    // Phase 9: Pressurize (10 seconds)
+    Phase phase9{};
+    phase9.name = "Pressurize";
+    phase9.phase = PhaseType::PHASE_TYPE_BREW;
+    phase9.valve = 1;
+    phase9.duration = 10.0f;
+    phase9.pumpIsSimple = true;
+    phase9.pumpSimple = 100;
+    profile.phases.push_back(phase9);
+
+    return profile;
+}
+
+Profile CleaningSchedulePlugin::createDescalingProfile() const {
+    Profile profile{};
+    profile.id = DESCALING_PROFILE_ID;
+    profile.label = "[Utility] Descale";
+    profile.utility = true;
+    profile.description = "";
+    profile.temperature = 0;
+    profile.type = "pro";
+
+    // Phase 1: 300ml Steam Flush
+    Phase phase1{};
+    phase1.name = "300ml Steam Flush";
+    phase1.phase = PhaseType::PHASE_TYPE_BREW;
+    phase1.valve = 0;
+    phase1.duration = 40.0f;
+    phase1.temperature = 0.0f;
+    phase1.transition.type = TransitionType::INSTANT;
+    phase1.transition.duration = 0.0f;
+    phase1.transition.adaptive = false;
+    phase1.pumpIsSimple = true;
+    phase1.pumpSimple = 100;
+
+    Target target1{};
+    target1.type = TargetType::TARGET_TYPE_PUMPED;
+    target1.operator_ = TargetOperator::GTE;
+    target1.value = 300.0f;
+    phase1.targets.push_back(target1);
+    profile.phases.push_back(phase1);
+
+    // Phase 2: Wait
+    Phase phase2{};
+    phase2.name = "Wait";
+    phase2.phase = PhaseType::PHASE_TYPE_PREINFUSION;
+    phase2.valve = 0;
+    phase2.duration = 600.0f;
+    phase2.temperature = 0.0f;
+    phase2.transition.type = TransitionType::INSTANT;
+    phase2.transition.duration = 0.0f;
+    phase2.transition.adaptive = false;
+    phase2.pumpIsSimple = true;
+    phase2.pumpSimple = 0;
+    profile.phases.push_back(phase2);
+
+    // Phase 3: 300ml Steam Flush
+    Phase phase3{};
+    phase3.name = "300ml Steam Flush";
+    phase3.phase = PhaseType::PHASE_TYPE_BREW;
+    phase3.valve = 0;
+    phase3.duration = 40.0f;
+    phase3.temperature = 0.0f;
+    phase3.transition.type = TransitionType::INSTANT;
+    phase3.transition.duration = 0.0f;
+    phase3.transition.adaptive = false;
+    phase3.pumpIsSimple = true;
+    phase3.pumpSimple = 100;
+
+    Target target3{};
+    target3.type = TargetType::TARGET_TYPE_PUMPED;
+    target3.operator_ = TargetOperator::GTE;
+    target3.value = 300.0f;
+    phase3.targets.push_back(target3);
+    profile.phases.push_back(phase3);
+
+    // Phase 4: Rinse and Refill
+    Phase phase4{};
+    phase4.name = "Rinse and Refill";
+    phase4.phase = PhaseType::PHASE_TYPE_PREINFUSION;
+    phase4.valve = 0;
+    phase4.duration = 120.0f;
+    phase4.temperature = 0.0f;
+    phase4.transition.type = TransitionType::INSTANT;
+    phase4.transition.duration = 0.0f;
+    phase4.transition.adaptive = false;
+    phase4.pumpIsSimple = true;
+    phase4.pumpSimple = 0;
+    profile.phases.push_back(phase4);
+
+    // Phase 5: 1lt Flush
+    Phase phase5{};
+    phase5.name = "1lt Flush";
+    phase5.phase = PhaseType::PHASE_TYPE_BREW;
+    phase5.valve = 0;
+    phase5.duration = 120.0f;
+    phase5.temperature = 0.0f;
+    phase5.transition.type = TransitionType::INSTANT;
+    phase5.transition.duration = 0.0f;
+    phase5.transition.adaptive = false;
+    phase5.pumpIsSimple = true;
+    phase5.pumpSimple = 100;
+
+    Target target5{};
+    target5.type = TargetType::TARGET_TYPE_PUMPED;
+    target5.operator_ = TargetOperator::GTE;
+    target5.value = 1000.0f;
+    phase5.targets.push_back(target5);
+    profile.phases.push_back(phase5);
+
+    return profile;
+}
+
+void CleaningSchedulePlugin::ensureCleaningProfilesExist() {
+    ProfileManager *profileManager = controller->getProfileManager();
+
+    // Create backflush profile if it doesn't exist
+    if (!profileManager->profileExists(BACKFLUSH_PROFILE_ID)) {
+        Profile backflushProfile = createBackflushProfile();
+        profileManager->saveProfile(backflushProfile);
+        ESP_LOGI("CleaningSchedulePlugin", "Created backflush profile");
+    }
+
+    // Create descaling profile if it doesn't exist
+    if (!profileManager->profileExists(DESCALING_PROFILE_ID)) {
+        Profile descalingProfile = createDescalingProfile();
+        profileManager->saveProfile(descalingProfile);
+        ESP_LOGI("CleaningSchedulePlugin", "Created descaling profile");
+    }
+}
+
+void CleaningSchedulePlugin::loadCleaningProfile(const String &profileId) {
+    ProfileManager *profileManager = controller->getProfileManager();
+
+    // Select the cleaning profile
+    profileManager->selectProfile(profileId);
+
+    // Switch to brew mode
+    controller->setMode(MODE_BREW);
+
+    ESP_LOGI("CleaningSchedulePlugin", "Loaded cleaning profile: %s", profileId.c_str());
+}
+
+void CleaningSchedulePlugin::checkAndResetCleaningTimers() {
+    // Get the currently selected profile to check if it's a cleaning profile
+    ProfileManager *profileManager = controller->getProfileManager();
+    Profile selectedProfile = profileManager->getSelectedProfile();
+
+    if (selectedProfile.id == BACKFLUSH_PROFILE_ID) {
+        ESP_LOGI("CleaningSchedulePlugin", "Backflush profile completed, resetting timer");
+        resetBackflushTimer();
+    } else if (selectedProfile.id == DESCALING_PROFILE_ID) {
+        ESP_LOGI("CleaningSchedulePlugin", "Descaling profile completed, resetting timer");
+        resetDescalingTimer();
+    }
+}
+
+unsigned long CleaningSchedulePlugin::getCurrentTimeSeconds() const {
+    time_t now;
+    time(&now);
+    return (unsigned long)now;
+}
+
+void CleaningSchedulePlugin::triggerNotificationEvents() {
+    // Trigger events for UI notification systems
+    if (isBackflushDue()) {
+        pluginManager->trigger("cleaning:backflush:due");
+    }
+
+    if (isDescalingDue()) {
+        pluginManager->trigger("cleaning:descaling:due");
+    }
+
+    // Always trigger status events for UI updates
+    pluginManager->trigger("cleaning:status:update", "backflush_days", getDaysSinceLastBackflush());
+    pluginManager->trigger("cleaning:status:update", "descaling_weeks", getWeeksSinceLastDescaling());
+}

--- a/src/display/plugins/CleaningSchedulePlugin.cpp
+++ b/src/display/plugins/CleaningSchedulePlugin.cpp
@@ -262,19 +262,22 @@ Profile CleaningSchedulePlugin::createDescalingProfile() const {
     phase1.targets.push_back(target1);
     profile.phases.push_back(phase1);
 
-    // Phase 2: Wait
-    Phase phase2{};
-    phase2.name = "Wait";
-    phase2.phase = PhaseType::PHASE_TYPE_PREINFUSION;
-    phase2.valve = 0;
-    phase2.duration = 600.0f;
-    phase2.temperature = 0.0f;
-    phase2.transition.type = TransitionType::INSTANT;
-    phase2.transition.duration = 0.0f;
-    phase2.transition.adaptive = false;
-    phase2.pumpIsSimple = true;
-    phase2.pumpSimple = 0;
-    profile.phases.push_back(phase2);
+    // Keep each wait phase below the firmware's 300-second brew safety limit.
+    // Together these phases preserve the original 10-minute soak.
+    for (int waitIndex = 1; waitIndex <= 3; waitIndex++) {
+        Phase waitPhase{};
+        waitPhase.name = "Wait " + String(waitIndex) + " of 3";
+        waitPhase.phase = PhaseType::PHASE_TYPE_PREINFUSION;
+        waitPhase.valve = 0;
+        waitPhase.duration = 200.0f;
+        waitPhase.temperature = 0.0f;
+        waitPhase.transition.type = TransitionType::INSTANT;
+        waitPhase.transition.duration = 0.0f;
+        waitPhase.transition.adaptive = false;
+        waitPhase.pumpIsSimple = true;
+        waitPhase.pumpSimple = 0;
+        profile.phases.push_back(waitPhase);
+    }
 
     // Phase 3: 300ml Steam Flush
     Phase phase3{};
@@ -336,19 +339,42 @@ Profile CleaningSchedulePlugin::createDescalingProfile() const {
 void CleaningSchedulePlugin::ensureCleaningProfilesExist() {
     ProfileManager *profileManager = controller->getProfileManager();
 
-    // Create backflush profile if it doesn't exist
-    if (!profileManager->profileExists(BACKFLUSH_PROFILE_ID)) {
-        Profile backflushProfile = createBackflushProfile();
-        profileManager->saveProfile(backflushProfile);
-        ESP_LOGI("CleaningSchedulePlugin", "Created backflush profile");
-    }
+    auto ensureProfile = [profileManager](Profile expectedProfile, const char *profileName, bool replaceOversizedPhases) {
+        Profile existingProfile{};
+        const bool exists = profileManager->profileExists(expectedProfile.id);
+        const bool loaded = exists && profileManager->loadProfile(expectedProfile.id, existingProfile);
 
-    // Create descaling profile if it doesn't exist
-    if (!profileManager->profileExists(DESCALING_PROFILE_ID)) {
-        Profile descalingProfile = createDescalingProfile();
-        profileManager->saveProfile(descalingProfile);
-        ESP_LOGI("CleaningSchedulePlugin", "Created descaling profile");
-    }
+        bool hasOversizedPhase = false;
+        if (loaded && replaceOversizedPhases) {
+            for (const Phase &phase : existingProfile.phases) {
+                if (phase.duration > BREW_MAX_DURATION_MS / 1000.0f) {
+                    hasOversizedPhase = true;
+                    break;
+                }
+            }
+        }
+
+        if (!loaded || hasOversizedPhase) {
+            if (profileManager->saveProfile(expectedProfile)) {
+                ESP_LOGI("CleaningSchedulePlugin", "%s %s profile", loaded ? "Updated" : "Created", profileName);
+            } else {
+                ESP_LOGE("CleaningSchedulePlugin", "Failed to save %s profile", profileName);
+            }
+            return;
+        }
+
+        if (!existingProfile.utility) {
+            existingProfile.utility = true;
+            if (profileManager->saveProfile(existingProfile)) {
+                ESP_LOGI("CleaningSchedulePlugin", "Marked existing %s profile as utility", profileName);
+            } else {
+                ESP_LOGE("CleaningSchedulePlugin", "Failed to update %s utility flag", profileName);
+            }
+        }
+    };
+
+    ensureProfile(createBackflushProfile(), "backflush", false);
+    ensureProfile(createDescalingProfile(), "descaling", true);
 }
 
 void CleaningSchedulePlugin::loadCleaningProfile(const String &profileId) {

--- a/src/display/plugins/CleaningSchedulePlugin.h
+++ b/src/display/plugins/CleaningSchedulePlugin.h
@@ -1,0 +1,53 @@
+#ifndef CLEANINGSCHEDULEPLUGIN_H
+#define CLEANINGSCHEDULEPLUGIN_H
+
+#include <display/core/Plugin.h>
+#include <display/models/profile.h>
+
+struct Event;
+class Controller;
+class PluginManager;
+
+class CleaningSchedulePlugin : public Plugin {
+  public:
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+    // Public methods for triggering cleaning actions
+    void startBackflush();
+    void startDescaling();
+    void resetBackflushTimer();
+    void resetDescalingTimer();
+
+    // Status checks
+    bool isBackflushDue() const;
+    bool isDescalingDue() const;
+    int getDaysSinceLastBackflush() const;
+    int getWeeksSinceLastDescaling() const;
+
+  private:
+    Controller *controller = nullptr;
+    PluginManager *pluginManager = nullptr;
+
+    unsigned long lastCheckTime = 0;
+    static const unsigned long CHECK_INTERVAL = 60000; // Check every minute
+
+    // Create hardcoded profiles
+    Profile createBackflushProfile() const;
+    Profile createDescalingProfile() const;
+
+    // Profile management
+    void ensureCleaningProfilesExist();
+    void loadCleaningProfile(const String &profileId);
+
+    // Helper methods
+    unsigned long getCurrentTimeSeconds() const;
+    void triggerNotificationEvents();
+    void checkAndResetCleaningTimers();
+
+    // Profile IDs
+    static const String BACKFLUSH_PROFILE_ID;
+    static const String DESCALING_PROFILE_ID;
+};
+
+#endif // CLEANINGSCHEDULEPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -539,6 +539,10 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
                     client->text(toWsBuffer(resp));
                 } else if (msgType == "req:flush:start") {
                     handleFlushStart(client->id(), doc);
+                } else if (msgType == "req:cleaning:backflush:start") {
+                    pluginManager->trigger("cleaning:backflush:start");
+                } else if (msgType == "req:cleaning:descaling:start") {
+                    pluginManager->trigger("cleaning:descaling:start");
                 }
             }
         }
@@ -803,6 +807,14 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 }
                 settings->setAutoWakeupSchedules(schedules);
             }
+            if (request->hasArg("backflushIntervalDays"))
+                settings->setBackflushIntervalDays(std::max(1L, request->arg("backflushIntervalDays").toInt()));
+            if (request->hasArg("descalingIntervalWeeks"))
+                settings->setDescalingIntervalWeeks(std::max(1L, request->arg("descalingIntervalWeeks").toInt()));
+            if (request->hasArg("lastBackflushTime"))
+                settings->setLastBackflushTime(strtoul(request->arg("lastBackflushTime").c_str(), nullptr, 10));
+            if (request->hasArg("lastDescalingTime"))
+                settings->setLastDescalingTime(strtoul(request->arg("lastDescalingTime").c_str(), nullptr, 10));
             settings->save(true);
         });
         pluginManager->trigger("settings:changed");
@@ -883,6 +895,10 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
         }
     }
     doc["autowakeupSchedules"] = schedulesStr;
+    doc["backflushIntervalDays"] = settings.getBackflushIntervalDays();
+    doc["descalingIntervalWeeks"] = settings.getDescalingIntervalWeeks();
+    doc["lastBackflushTime"] = settings.getLastBackflushTime();
+    doc["lastDescalingTime"] = settings.getLastDescalingTime();
     serializeJson(doc, *response);
     request->send(response);
 

--- a/web/src/pages/Home/cards/ProfileCard.jsx
+++ b/web/src/pages/Home/cards/ProfileCard.jsx
@@ -174,6 +174,7 @@ export function ProfileCard({
     }
     let cancelled = false;
     setProfileLoading(true);
+    setProfileData(null);
     apiService
       .request({ tp: 'req:profiles:load', id: selectedProfileId })
       .then(res => {
@@ -252,7 +253,7 @@ export function ProfileCard({
         </div>
       </div>
       {!compact &&
-        (profileLoading || (!!selectedProfileId && !profileData) ? (
+        (profileLoading ? (
           <SkeletonBlock
             className='mt-1 w-full rounded-xl'
             style={{ height: `${profileChartHeightSignal.value}px` }}

--- a/web/src/pages/Home/cards/ProfileCard.jsx
+++ b/web/src/pages/Home/cards/ProfileCard.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRectangleList } from '@fortawesome/free-solid-svg-icons/faRectangleList';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faLemon } from '@fortawesome/free-solid-svg-icons/faLemon';
+import { faSoap } from '@fortawesome/free-solid-svg-icons/faSoap';
 import { ProcessProfileChart } from '../../../components/ProcessProfileChart.jsx';
 import { profileChartHeightSignal } from '../../../utils/dashboardManager.js';
 import { SkeletonBlock } from '../../../components/SkeletonBlock.jsx';
@@ -112,6 +114,10 @@ export function ProfileCard({
   isFinished,
   isBrewing,
   isGrinding,
+  backflushDue = false,
+  descalingDue = false,
+  startBackflush,
+  startDescaling,
   inCard = false,
   compact = false,
 }) {
@@ -216,12 +222,34 @@ export function ProfileCard({
         <span className='text-base-content truncate text-sm font-semibold'>
           {selectedProfile || 'Default'}
         </span>
-        <a href='/profiles'>
-          <FontAwesomeIcon
-            icon={faRectangleList}
-            className='text-base-content/40 shrink-0 text-sm'
-          />
-        </a>
+        <div className='flex items-center gap-1'>
+          {backflushDue && (
+            <button
+              type='button'
+              className='btn btn-ghost btn-xs text-warning'
+              title='Backflush due - load backflush profile'
+              onClick={startBackflush}
+            >
+              <FontAwesomeIcon icon={faSoap} className='text-xs' />
+            </button>
+          )}
+          {descalingDue && (
+            <button
+              type='button'
+              className='btn btn-ghost btn-xs text-warning'
+              title='Descaling due - load descaling profile'
+              onClick={startDescaling}
+            >
+              <FontAwesomeIcon icon={faLemon} className='text-xs' />
+            </button>
+          )}
+          <a href='/profiles'>
+            <FontAwesomeIcon
+              icon={faRectangleList}
+              className='text-base-content/40 shrink-0 text-sm'
+            />
+          </a>
+        </div>
       </div>
       {!compact &&
         (profileLoading || (!!selectedProfileId && !profileData) ? (
@@ -255,6 +283,10 @@ ProfileCard.propTypes = {
   isFinished: PropTypes.bool.isRequired,
   isBrewing: PropTypes.bool.isRequired,
   isGrinding: PropTypes.bool.isRequired,
+  backflushDue: PropTypes.bool,
+  descalingDue: PropTypes.bool,
+  startBackflush: PropTypes.func,
+  startDescaling: PropTypes.func,
   inCard: PropTypes.bool,
   compact: PropTypes.bool,
 };

--- a/web/src/pages/Home/useDashboardState.js
+++ b/web/src/pages/Home/useDashboardState.js
@@ -47,6 +47,18 @@ export function useDashboardState() {
         )
       : null;
 
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const backflushIntervalDays = settings?.backflushIntervalDays ?? 14;
+  const descalingIntervalWeeks = settings?.descalingIntervalWeeks ?? 6;
+  const lastBackflushTime = settings?.lastBackflushTime ?? 0;
+  const lastDescalingTime = settings?.lastDescalingTime ?? 0;
+  const backflushDue =
+    !!lastBackflushTime &&
+    (nowSeconds - lastBackflushTime) / (24 * 60 * 60) >= backflushIntervalDays;
+  const descalingDue =
+    !!lastDescalingTime &&
+    (nowSeconds - lastDescalingTime) / (7 * 24 * 60 * 60) >= descalingIntervalWeeks;
+
   // ── handlers ─────────────────────────────────────────────
   const send = tp => apiService.send({ tp });
 
@@ -80,6 +92,8 @@ export function useDashboardState() {
       tp: isGrinding ? 'req:change-grind-target' : 'req:change-brew-target',
       target,
     });
+  const startBackflush = () => send('req:cleaning:backflush:start');
+  const startDescaling = () => send('req:cleaning:descaling:start');
 
   return {
     // raw status
@@ -117,6 +131,8 @@ export function useDashboardState() {
     ledControl,
     albaCalibrated,
     waterLevelPercent,
+    backflushDue,
+    descalingDue,
     // settings
     isSmartGrindEnabled,
     altRelayFunction,
@@ -135,5 +151,7 @@ export function useDashboardState() {
     raiseTarget,
     lowerTarget,
     changeTarget,
+    startBackflush,
+    startDescaling,
   };
 }

--- a/web/src/pages/Settings/tabs/MachineTab.jsx
+++ b/web/src/pages/Settings/tabs/MachineTab.jsx
@@ -1,10 +1,13 @@
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import { computed } from '@preact/signals';
 import { machine } from '../../../services/ApiService.js';
 import Section from '../../../components/Card.jsx';
 import { Tooltip } from '../../../components/Tooltip.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCrosshairs } from '@fortawesome/free-solid-svg-icons/faCrosshairs';
+import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faLemon } from '@fortawesome/free-solid-svg-icons/faLemon';
+import { faSoap } from '@fortawesome/free-solid-svg-icons/faSoap';
 import { InputGroupField, SettingsFormField } from '../../../components/SettingsFormField.jsx';
 
 const ledControl = computed(() => machine.value.capabilities.ledControl);
@@ -60,6 +63,28 @@ function TankDistanceField({ id, label, value, onChange, onUseCurrent }) {
 
 export function MachineTab({ formData, onChange, setField }) {
   const [steamPumpDraft, setSteamPumpDraft] = useState(null);
+
+  const markCleaningComplete = useCallback(
+    async field => {
+      const previousValue = formData[field];
+      const now = Math.floor(Date.now() / 1000);
+      setField(field, now);
+
+      const data = new FormData();
+      data.set(field, String(now));
+      try {
+        const response = await fetch('/api/settings', { method: 'post', body: data });
+        if (!response.ok) throw new Error(`Settings request failed (${response.status})`);
+      } catch (error) {
+        console.error('Failed to save cleaning timer change:', error);
+        setField(field, previousValue);
+      }
+    },
+    [formData, setField],
+  );
+
+  const formatCleaningTimestamp = timestamp =>
+    timestamp ? new Date(timestamp * 1000).toLocaleString() : 'Never';
 
   return (
     <div className='space-y-4 sm:space-y-6 lg:grid lg:grid-cols-2 lg:gap-4'>
@@ -267,6 +292,80 @@ export function MachineTab({ formData, onChange, setField }) {
               onChange={onChange('targetWaterTemp')}
             />
           </InputGroupField>
+        </div>
+      </Section>
+      <Section title='Cleaning Schedule'>
+        <p className='text-base-content/60 mb-4 text-sm'>
+          Configure reminder intervals and reset maintenance timers after completing each cleaning
+          cycle.
+        </p>
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+          <InputGroupField
+            label='Backflush Interval'
+            htmlFor='backflushIntervalDays'
+            unit='days'
+            unitAriaLabel='days'
+            noMargin
+          >
+            <input
+              id='backflushIntervalDays'
+              name='backflushIntervalDays'
+              type='number'
+              min='1'
+              className='grow'
+              value={formData.backflushIntervalDays ?? 14}
+              onChange={onChange('backflushIntervalDays')}
+            />
+          </InputGroupField>
+          <InputGroupField
+            label='Descaling Interval'
+            htmlFor='descalingIntervalWeeks'
+            unit='weeks'
+            unitAriaLabel='weeks'
+            noMargin
+          >
+            <input
+              id='descalingIntervalWeeks'
+              name='descalingIntervalWeeks'
+              type='number'
+              min='1'
+              className='grow'
+              value={formData.descalingIntervalWeeks ?? 6}
+              onChange={onChange('descalingIntervalWeeks')}
+            />
+          </InputGroupField>
+        </div>
+        <div className='mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2'>
+          <div className='border-base-300 rounded-lg border p-3'>
+            <div className='mb-1 flex items-center gap-2 text-sm font-semibold'>
+              <FontAwesomeIcon icon={faSoap} className='text-warning' /> Backflush
+            </div>
+            <div className='text-base-content/60 text-sm'>
+              Last: {formatCleaningTimestamp(formData.lastBackflushTime)}
+            </div>
+            <button
+              type='button'
+              className='btn btn-warning btn-sm mt-2'
+              onClick={() => markCleaningComplete('lastBackflushTime')}
+            >
+              <FontAwesomeIcon icon={faCheck} /> Mark Complete
+            </button>
+          </div>
+          <div className='border-base-300 rounded-lg border p-3'>
+            <div className='mb-1 flex items-center gap-2 text-sm font-semibold'>
+              <FontAwesomeIcon icon={faLemon} className='text-warning' /> Descaling
+            </div>
+            <div className='text-base-content/60 text-sm'>
+              Last: {formatCleaningTimestamp(formData.lastDescalingTime)}
+            </div>
+            <button
+              type='button'
+              className='btn btn-warning btn-sm mt-2'
+              onClick={() => markCleaningComplete('lastDescalingTime')}
+            >
+              <FontAwesomeIcon icon={faCheck} /> Mark Complete
+            </button>
+          </div>
         </div>
       </Section>
       {/* Alba Settings */}

--- a/web/src/utils/panelDefinitions.js
+++ b/web/src/utils/panelDefinitions.js
@@ -65,6 +65,10 @@ export const PANEL_DEFINITIONS = [
       isFinished: ds.isFinished,
       isBrewing: ds.isBrewing,
       isGrinding: ds.isGrinding,
+      backflushDue: ds.backflushDue,
+      descalingDue: ds.descalingDue,
+      startBackflush: ds.startBackflush,
+      startDescaling: ds.startDescaling,
     }),
   },
   {


### PR DESCRIPTION
Add backflush and descaling automatic schedules based on set interval
Add backflush and descaling icons on webui indicating if either is due. Pressing the icon will load the appropriate utility profile if it exists (or will create it and load it, if it doesn't) and switch into brew mode from standby. 

Running the profile will mark backflush or descaling as complete. Can also be manually marked as complete in settings.

//
TODO: (Intentionally left out)
Add backflush/descale icons/buttons to physical display (possibly standby screen?). Pressing the button will load the appropriate profile and go into brew mode (as on webui)
//

<img width="1090" height="583" alt="image" src="https://github.com/user-attachments/assets/27bab915-6f9c-4d2d-a7b7-bc0a623e8428" />

<img width="1642" height="750" alt="image" src="https://github.com/user-attachments/assets/fd5c5ff7-4916-44f3-8b6e-264927103eb9" />

<img width="237" height="234" alt="image" src="https://github.com/user-attachments/assets/ba6101df-0220-46ce-8dfb-bc300dd6cb62" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable cleaning schedules for backflush and descaling, including intervals and last-completed times.
  - Added automatic due notifications and status tracking.
  - Added dashboard actions to start cleaning cycles directly.
  - Added Cleaning Schedule settings with interval controls and “Mark Complete” actions.
  - Cleaning profiles are created automatically and integrated into the machine workflow.

- **Bug Fixes**
  - Prevented stale profile information from appearing while loading a new profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->