### PR TITLE
fix(web): prevent Shot Analyzer navigation from reverting deep-linked…

### DIFF
--- a/web/src/pages/ShotAnalyzer/components/analyzerActionBar/AnalyzerActionBar.jsx
+++ b/web/src/pages/ShotAnalyzer/components/analyzerActionBar/AnalyzerActionBar.jsx
@@ -71,6 +71,7 @@ export function AnalyzerActionBar({
         direction,
         listSnapshot: shotList,
         targetIndex,
+        debounceMs: 0,
       });
     },
     [onNavigate, shotList],

--- a/web/src/pages/ShotAnalyzer/services/LibraryService.js
+++ b/web/src/pages/ShotAnalyzer/services/LibraryService.js
@@ -306,14 +306,15 @@ class LibraryService {
    * Load full shot data
    * @param {string} id - Shot ID
    * @param {string} source - 'gaggimate' or 'browser'
+   * @param {{ signal?: AbortSignal }} options - Optional request controls for GaggiMate fetches
    * @returns {Promise<Object>} Full shot data with samples
    */
-  async loadShot(id, source) {
+  async loadShot(id, source, { signal } = {}) {
     const idStr = String(id);
 
     if (source === 'gaggimate') {
       const paddedId = idStr.padStart(6, '0');
-      const response = await fetch(`/api/history/${paddedId}.slog`);
+      const response = await fetch(`/api/history/${paddedId}.slog`, { signal });
 
       if (!response.ok) {
         throw new Error(`Failed to load shot ${idStr}: HTTP ${response.status}`);

--- a/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
+++ b/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
@@ -94,6 +94,8 @@ export function ShotAnalyzer() {
   const compareSelectionRequestIdRef = useRef(0);
   const primarySelectionAbortRef = useRef(null);
   const handledDeepLinkKeyRef = useRef('');
+  const clearPendingPrimarySelectionRef = useRef(null);
+  const handleShotSelectRef = useRef(null);
   const currentShotRef = useRef(currentShot);
   const compareShotsRef = useRef(compareShots);
   const pendingPrimarySelectionRef = useRef(pendingPrimarySelection);
@@ -576,6 +578,9 @@ export function ShotAnalyzer() {
     ],
   );
 
+  clearPendingPrimarySelectionRef.current = clearPendingPrimarySelection;
+  handleShotSelectRef.current = handleShotSelect;
+
   useEffect(() => {
     if (!params.source || !params.id) {
       handledDeepLinkKeyRef.current = '';
@@ -591,7 +596,7 @@ export function ShotAnalyzer() {
     if (handledDeepLinkKeyRef.current === deepLinkKey) return undefined;
     handledDeepLinkKeyRef.current = deepLinkKey;
 
-    const requestId = handleShotSelect({
+    const requestId = handleShotSelectRef.current({
       item: {
         id: params.id,
         source: serviceSource,
@@ -602,9 +607,9 @@ export function ShotAnalyzer() {
 
     return () => {
       if (requestId == null || requestId !== primarySelectionRequestIdRef.current) return;
-      clearPendingPrimarySelection();
+      clearPendingPrimarySelectionRef.current();
     };
-  }, [apiService, clearPendingPrimarySelection, handleShotSelect, params.id, params.source]);
+  }, [apiService, params.id, params.source]);
 
   const handleProfileLoad = (data, name, source) => {
     cancelPrimaryProfileSearch();

--- a/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
+++ b/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
@@ -32,7 +32,6 @@ import {
   getNextDirectionalSelection,
   getShotSelectionProfileName,
   hasLoadedShotPayload,
-  isAlreadyLoadedDeepLink,
   loadPreferredAutoMatchedProfile,
   loadShotSelection,
   normalizeMatchedProfileSource,
@@ -93,6 +92,8 @@ export function ShotAnalyzer() {
   const compareSelectionTimerRef = useRef(null);
   const primarySelectionRequestIdRef = useRef(0);
   const compareSelectionRequestIdRef = useRef(0);
+  const primarySelectionAbortRef = useRef(null);
+  const handledDeepLinkKeyRef = useRef('');
   const currentShotRef = useRef(currentShot);
   const compareShotsRef = useRef(compareShots);
   const pendingPrimarySelectionRef = useRef(pendingPrimarySelection);
@@ -114,6 +115,16 @@ export function ShotAnalyzer() {
     pendingCompareSelectionRef.current = pendingCompareSelection;
   }, [pendingCompareSelection]);
 
+  const updateCurrentShot = useCallback(nextShot => {
+    currentShotRef.current = nextShot;
+    setCurrentShot(nextShot);
+  }, []);
+
+  const updatePendingPrimarySelection = useCallback(nextSelection => {
+    pendingPrimarySelectionRef.current = nextSelection;
+    setPendingPrimarySelection(nextSelection);
+  }, []);
+
   const clearPrimarySelectionTimer = useCallback(() => {
     if (primarySelectionTimerRef.current) {
       clearTimeout(primarySelectionTimerRef.current);
@@ -126,6 +137,16 @@ export function ShotAnalyzer() {
       clearTimeout(compareSelectionTimerRef.current);
       compareSelectionTimerRef.current = null;
     }
+  }, []);
+
+  const abortPrimarySelectionLoad = useCallback(requestId => {
+    const activeRequest = primarySelectionAbortRef.current;
+    if (!activeRequest) return false;
+    if (requestId != null && activeRequest.requestId !== requestId) return false;
+
+    primarySelectionAbortRef.current = null;
+    activeRequest.controller?.abort();
+    return true;
   }, []);
 
   const cancelPrimaryProfileSearch = useCallback(() => {
@@ -146,10 +167,11 @@ export function ShotAnalyzer() {
 
   const clearPendingPrimarySelection = useCallback(() => {
     clearPrimarySelectionTimer();
+    abortPrimarySelectionLoad();
     primarySelectionRequestIdRef.current += 1;
-    setPendingPrimarySelection(null);
+    updatePendingPrimarySelection(null);
     setLoading(false);
-  }, [clearPrimarySelectionTimer]);
+  }, [abortPrimarySelectionLoad, clearPrimarySelectionTimer, updatePendingPrimarySelection]);
 
   const clearPendingCompareSelection = useCallback(() => {
     clearCompareSelectionTimer();
@@ -182,12 +204,20 @@ export function ShotAnalyzer() {
 
   // Cleanup pending profile search on unmount
   useEffect(() => {
+    const handleBeforeUnload = () => {
+      abortPrimarySelectionLoad();
+    };
+    globalThis.addEventListener?.('beforeunload', handleBeforeUnload);
+
     return () => {
+      globalThis.removeEventListener?.('beforeunload', handleBeforeUnload);
+      primarySelectionRequestIdRef.current += 1;
+      abortPrimarySelectionLoad();
       if (profileSearchTimerRef.current) clearTimeout(profileSearchTimerRef.current);
       if (primarySelectionTimerRef.current) clearTimeout(primarySelectionTimerRef.current);
       if (compareSelectionTimerRef.current) clearTimeout(compareSelectionTimerRef.current);
     };
-  }, []);
+  }, [abortPrimarySelectionLoad]);
 
   // --- Effects ---
   useEffect(() => {
@@ -300,13 +330,13 @@ export function ShotAnalyzer() {
       const currentShotKey = previousShot ? getShotIdentityKey(previousShot) : '';
 
       clearPrimarySelectionTimer();
-      setPendingPrimarySelection(null);
+      updatePendingPrimarySelection(null);
 
       if (!preserveCompare && currentShotKey && nextShotKey && currentShotKey !== nextShotKey) {
         resetCompareState();
       }
 
-      setCurrentShot(shotWithMetadata);
+      updateCurrentShot(shotWithMetadata);
       setCurrentShotName(name);
 
       cancelPrimaryProfileSearch();
@@ -398,41 +428,20 @@ export function ShotAnalyzer() {
 
       setLoading(false);
     },
-    [cancelPrimaryProfileSearch, clearPrimarySelectionTimer, importMode, resetCompareState],
+    [
+      cancelPrimaryProfileSearch,
+      clearPrimarySelectionTimer,
+      importMode,
+      resetCompareState,
+      updateCurrentShot,
+      updatePendingPrimarySelection,
+    ],
   );
 
-  useEffect(() => {
-    const loadDeepLink = async () => {
-      if (!params.source || !params.id) return;
-
-      let serviceSource = params.source;
-      if (params.source === 'internal') serviceSource = 'gaggimate';
-      if (params.source === 'external') serviceSource = 'browser';
-
-      if (isAlreadyLoadedDeepLink({ currentShot, params: { id: params.id }, serviceSource }))
-        return;
-
-      try {
-        setLoading(true);
-        const shot = await libraryService.loadShot(params.id, serviceSource);
-
-        if (shot) {
-          // URL sources are aliases; normalize them before the analyzer stores the shot.
-          shot.source = serviceSource;
-          commitPrimaryShotLoad(shot, shot.name || params.id);
-        }
-      } catch (e) {
-        console.error('Deep Link Load Failed:', e);
-      }
-    };
-
-    if (apiService) {
-      loadDeepLink();
-    }
-  }, [apiService, commitPrimaryShotLoad, currentShot, params.id, params.source]);
-
   const tryLoadPrimarySelection = useCallback(
-    async (requestId, selectionRequest) => {
+    async (requestId, selectionRequest, signal) => {
+      if (requestId !== primarySelectionRequestIdRef.current) return false;
+
       const { item, name, preserveCompare } = selectionRequest;
       const targetShotKey = getShotIdentityKey(item);
       const activeCompareShot =
@@ -440,7 +449,7 @@ export function ShotAnalyzer() {
       const activeCompareShotKey = activeCompareShot ? getShotIdentityKey(activeCompareShot) : '';
 
       if (!targetShotKey) {
-        setPendingPrimarySelection(null);
+        updatePendingPrimarySelection(null);
         setLoading(false);
         return false;
       }
@@ -448,50 +457,63 @@ export function ShotAnalyzer() {
       if (preserveCompare && activeCompareShotKey && targetShotKey === activeCompareShotKey) {
         const nextSelection = getNextDirectionalSelection(selectionRequest);
         if (nextSelection) {
-          setPendingPrimarySelection({
+          updatePendingPrimarySelection({
             shot: nextSelection.item,
             name: nextSelection.name,
           });
-          return tryLoadPrimarySelection(requestId, nextSelection);
+          return tryLoadPrimarySelection(requestId, nextSelection, signal);
         }
 
-        setPendingPrimarySelection(null);
+        abortPrimarySelectionLoad(requestId);
+        updatePendingPrimarySelection(null);
         setLoading(false);
         return false;
       }
 
       try {
         setLoading(true);
-        const { shotWithMetadata, shotName } = await loadShotSelection({ item, importMode });
+        const { shotWithMetadata, shotName } = await loadShotSelection({
+          item,
+          importMode,
+          signal,
+        });
         if (requestId !== primarySelectionRequestIdRef.current) return false;
 
+        abortPrimarySelectionLoad(requestId);
         commitPrimaryShotLoad(shotWithMetadata, name || shotName, selectionRequest);
         return true;
       } catch (error) {
         if (requestId !== primarySelectionRequestIdRef.current) return false;
+        if (error?.name === 'AbortError') {
+          abortPrimarySelectionLoad(requestId);
+          updatePendingPrimarySelection(null);
+          setLoading(false);
+          return false;
+        }
 
         console.warn('Failed to load shot:', error);
 
         const nextSelection = getNextDirectionalSelection(selectionRequest);
         if (nextSelection) {
-          setPendingPrimarySelection({
+          updatePendingPrimarySelection({
             shot: nextSelection.item,
             name: nextSelection.name,
           });
-          return tryLoadPrimarySelection(requestId, nextSelection);
+          return tryLoadPrimarySelection(requestId, nextSelection, signal);
         }
 
-        setPendingPrimarySelection(null);
+        abortPrimarySelectionLoad(requestId);
+        updatePendingPrimarySelection(null);
         setLoading(false);
         return false;
       }
     },
-    [commitPrimaryShotLoad, importMode],
+    [abortPrimarySelectionLoad, commitPrimaryShotLoad, importMode, updatePendingPrimarySelection],
   );
 
   const launchPrimarySelectionLoad = useCallback(
-    (requestId, selectionRequest) => {
-      tryLoadPrimarySelection(requestId, selectionRequest).catch(error => {
+    (requestId, selectionRequest, signal) => {
+      tryLoadPrimarySelection(requestId, selectionRequest, signal).catch(error => {
         console.error('Primary selection load failed:', error);
       });
     },
@@ -511,35 +533,78 @@ export function ShotAnalyzer() {
 
       if (targetShotKey === currentShotKey) {
         clearPrimarySelectionTimer();
+        abortPrimarySelectionLoad();
         primarySelectionRequestIdRef.current += 1;
-        setPendingPrimarySelection(null);
+        updatePendingPrimarySelection(null);
         setLoading(false);
         return;
       }
 
+      abortPrimarySelectionLoad();
       const requestId = ++primarySelectionRequestIdRef.current;
       clearPrimarySelectionTimer();
-      setPendingPrimarySelection({
+      updatePendingPrimarySelection({
         shot: selectionRequest.item,
         name: selectionRequest.name,
       });
+      const controller =
+        typeof globalThis.AbortController === 'function' ? new globalThis.AbortController() : null;
+      primarySelectionAbortRef.current = { requestId, controller };
+      const signal = controller?.signal;
 
       if (
         hasLoadedShotPayload(selectionRequest.item) ||
         !currentCommittedShot ||
         selectionRequest.debounceMs <= 0
       ) {
-        launchPrimarySelectionLoad(requestId, selectionRequest);
-        return;
+        launchPrimarySelectionLoad(requestId, selectionRequest, signal);
+        return requestId;
       }
 
       primarySelectionTimerRef.current = setTimeout(() => {
         primarySelectionTimerRef.current = null;
-        launchPrimarySelectionLoad(requestId, selectionRequest);
+        launchPrimarySelectionLoad(requestId, selectionRequest, signal);
       }, selectionRequest.debounceMs);
+      return requestId;
     },
-    [clearPrimarySelectionTimer, launchPrimarySelectionLoad, normalizePrimarySelectionRequest],
+    [
+      abortPrimarySelectionLoad,
+      clearPrimarySelectionTimer,
+      launchPrimarySelectionLoad,
+      normalizePrimarySelectionRequest,
+      updatePendingPrimarySelection,
+    ],
   );
+
+  useEffect(() => {
+    if (!params.source || !params.id) {
+      handledDeepLinkKeyRef.current = '';
+      return undefined;
+    }
+    if (!apiService) return undefined;
+
+    let serviceSource = params.source;
+    if (params.source === 'internal') serviceSource = 'gaggimate';
+    if (params.source === 'external') serviceSource = 'browser';
+
+    const deepLinkKey = `${serviceSource}:${params.id}`;
+    if (handledDeepLinkKeyRef.current === deepLinkKey) return undefined;
+    handledDeepLinkKeyRef.current = deepLinkKey;
+
+    const requestId = handleShotSelect({
+      item: {
+        id: params.id,
+        source: serviceSource,
+      },
+      name: params.id,
+      debounceMs: 0,
+    });
+
+    return () => {
+      if (requestId == null || requestId !== primarySelectionRequestIdRef.current) return;
+      clearPendingPrimarySelection();
+    };
+  }, [apiService, clearPendingPrimarySelection, handleShotSelect, params.id, params.source]);
 
   const handleProfileLoad = (data, name, source) => {
     cancelPrimaryProfileSearch();
@@ -824,7 +889,7 @@ export function ShotAnalyzer() {
     const previousPrimaryProfileName = currentProfileName;
     const previousPrimaryProfileSelectionMode = currentProfileSelectionMode;
 
-    setCurrentShot(secondaryEntry.shot);
+    updateCurrentShot(secondaryEntry.shot);
     setCurrentShotName(secondaryEntry.shotName || getShotDisplayName(secondaryEntry.shot));
     setCurrentProfile(secondaryEntry.profile || null);
     setCurrentProfileName(secondaryEntry.profileName || 'No Profile Loaded');
@@ -908,7 +973,7 @@ export function ShotAnalyzer() {
               clearPendingCompareSelection();
               resetCompareState({ disableMode: true });
               cancelPrimaryProfileSearch();
-              setCurrentShot(null);
+              updateCurrentShot(null);
               setCurrentShotName('No Shot Loaded');
               setCurrentProfile(null);
               setCurrentProfileName('No Profile Loaded');

--- a/web/src/pages/ShotAnalyzer/shotAnalyzer/shotSelection.js
+++ b/web/src/pages/ShotAnalyzer/shotAnalyzer/shotSelection.js
@@ -180,11 +180,11 @@ export function buildShotWithMetadata({ item, loadedShot, importMode, loadKey })
   };
 }
 
-export async function loadShotSelection({ item, importMode }) {
+export async function loadShotSelection({ item, importMode, signal }) {
   const loadKey = getShotStorageKey(item);
   const loadedShot = hasLoadedShotPayload(item)
     ? item
-    : await libraryService.loadShot(loadKey, item.source);
+    : await libraryService.loadShot(loadKey, item.source, { signal });
   const shotWithMetadata = buildShotWithMetadata({
     item,
     loadedShot,
@@ -197,8 +197,4 @@ export async function loadShotSelection({ item, importMode }) {
     shotName: getShotSelectionName(item, loadKey),
     shotWithMetadata,
   };
-}
-
-export function isAlreadyLoadedDeepLink({ currentShot, params, serviceSource }) {
-  return currentShot?.id === params.id && currentShot?.source === serviceSource;
 }


### PR DESCRIPTION
… shots

Route History deep-link loads through the primary selection flow, so stale or aborted requests can no longer overwrite the latest arrow or library selection. GM shot fetches now support abort signals and previous/next navigation starts immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shot navigation by cancelling in-flight primary selection loading when changing selections to avoid outdated results.
  * Prevented stale/aborted loads from replacing the currently selected shot, including during deep-link navigation.
  * Added more reliable cancellation support for shot loading (including fetch) to reduce interrupted-state issues.
  * Improved analyzer cleanup by aborting pending work and clearing related timers when leaving/unmounting.
  * Ensured navigation callbacks consistently include `debounceMs: 0` when moving to a target shot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->