### PR TITLE
show reason for disabled update on the OTA firmware page

### DIFF
--- a/web/src/components/Tooltip.jsx
+++ b/web/src/components/Tooltip.jsx
@@ -73,6 +73,9 @@ export function Tooltip({ content, children, placement = 'top', disabled = false
       document.body,
     );
 
+  // onFocusIn/onFocusOut in addition to onFocus/onBlur: Preact maps onFocus to
+  // the native 'focus' event, which does not bubble, so a focusable child (e.g. a
+  // wrapped button) never triggers it. focusin/focusout do bubble.
   return (
     <>
       <span
@@ -81,6 +84,8 @@ export function Tooltip({ content, children, placement = 'top', disabled = false
         onMouseLeave={hide}
         onFocus={show}
         onBlur={hide}
+        onFocusIn={show}
+        onFocusOut={hide}
         className='inline-flex'
       >
         {children}

--- a/web/src/pages/Settings/tabs/SystemTab.jsx
+++ b/web/src/pages/Settings/tabs/SystemTab.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
 import { Spinner } from '../../../components/Spinner.jsx';
 import Section from '../../../components/Card.jsx';
+import { Tooltip } from '../../../components/Tooltip.jsx';
 
 const imageUrlToBase64 = async blob => {
   return new Promise((onSuccess, onError) => {
@@ -22,6 +23,24 @@ const imageUrlToBase64 = async blob => {
       onError(e instanceof Error ? e : new Error(String(e)));
     }
   });
+};
+
+// Why an update button is disabled, so hovering it explains itself instead of
+// looking broken. Returns null when the button is enabled.
+const getUpdateDisabledReason = (component, formData, submitting) => {
+  const isController = component === 'controller';
+  if (formData[isController ? 'controllerUpdateAvailable' : 'displayUpdateAvailable']) {
+    return submitting ? 'Checking for updates…' : null;
+  }
+  if (submitting) return 'Checking for updates…';
+  if (isController && !formData.controllerVersion) {
+    return 'No controller connected, so its version is unknown.';
+  }
+  if (!formData.latestVersion) {
+    return 'No release info yet. The update check runs every 30 minutes and is skipped while the machine is busy.';
+  }
+  const current = formData[isController ? 'controllerVersion' : 'displayVersion'];
+  return `Already up to date (${current}).`;
 };
 
 const getRssiStatusClass = rssi => {
@@ -56,6 +75,24 @@ function OtaProgressView({ phase, progress }) {
       )}
     </div>
   );
+}
+
+// A disabled <button> swallows mouse events in most browsers, so hover never
+// reaches the tooltip wrapper. pointer-events-none hands them back; the button
+// is unclickable anyway.
+function UpdateButton({ label, reason, onClick }) {
+  const button = (
+    <button
+      type='button'
+      className={`btn btn-secondary btn-sm${reason ? ' pointer-events-none' : ''}`}
+      disabled={!!reason}
+      title={reason || undefined}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+  return reason ? <Tooltip content={reason}>{button}</Tooltip> : button;
 }
 
 function StorageAndMemorySection({ formData }) {
@@ -360,14 +397,11 @@ export function SystemTab() {
                   Update available: {formData.latestVersion}
                 </span>
               )}
-              <button
-                type='button'
-                className='btn btn-secondary btn-sm'
-                disabled={!formData.controllerUpdateAvailable || submitting}
+              <UpdateButton
+                label='Update Controller'
+                reason={getUpdateDisabledReason('controller', formData, submitting)}
                 onClick={() => onUpdate('controller')}
-              >
-                Update Controller
-              </button>
+              />
             </div>
           </div>
 
@@ -382,14 +416,11 @@ export function SystemTab() {
                   Update available: {formData.latestVersion}
                 </span>
               )}
-              <button
-                type='button'
-                className='btn btn-secondary btn-sm'
-                disabled={!formData.displayUpdateAvailable || submitting}
+              <UpdateButton
+                label='Update Display'
+                reason={getUpdateDisabledReason('display', formData, submitting)}
                 onClick={() => onUpdate('display')}
-              >
-                Update Display
-              </button>
+              />
             </div>
           </div>
         </div>

--- a/web/src/pages/Settings/tabs/SystemTab.jsx
+++ b/web/src/pages/Settings/tabs/SystemTab.jsx
@@ -77,17 +77,17 @@ function OtaProgressView({ phase, progress }) {
   );
 }
 
-// A disabled <button> swallows mouse events in most browsers, so hover never
-// reaches the tooltip wrapper. pointer-events-none hands them back; the button
-// is unclickable anyway.
+// aria-disabled rather than disabled: a truly disabled button can't be focused
+// and swallows mouse events, so neither keyboard nor pointer users can read the
+// reason. Same approach as the pin buttons in ShotAnalyzer/Statistics.
 function UpdateButton({ label, reason, onClick }) {
   const button = (
     <button
       type='button'
-      className={`btn btn-secondary btn-sm${reason ? ' pointer-events-none' : ''}`}
-      disabled={!!reason}
+      className={`btn btn-secondary btn-sm${reason ? ' cursor-not-allowed opacity-50' : ''}`}
+      aria-disabled={!!reason}
       title={reason || undefined}
-      onClick={onClick}
+      onClick={reason ? undefined : onClick}
     >
       {label}
     </button>


### PR DESCRIPTION
I've been running GM 1.8.1 for a few months now and its been great. 

I wanted to switch to the nightly firmware but for some reason it was never allowing me, which drove me nuts.

I finally got some time to dig into it and turns out its because my machine is always in brew mode. I had no idea that was a limitation.

Ideally I think the OTA ux should be refactored a little to communicate a few more steps for users (e.g. "do the display before the controller) and so on, but thats a decision for the project owners, not me.

This PR adds a small solution to at least communicate why an OTA is not available.

I dont feel strongly about this solution. if there is a preference for a better solution that still communicates to the user what the blockers are, I support that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Added tooltips to disabled controller and display firmware update buttons to explain why the action isn’t available (e.g., update in progress, missing release info, or disconnected controller).
  * Disabled update buttons now provide improved accessibility with appropriate disabled state behavior and hover/focus guidance.
* **Bug Fixes**
  * Fixed tooltip behavior so it reliably appears/disappears when navigating to nested focusable elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->