### PR TITLE
Update ShotHistoryPlugin: Add dirty notes tracking and flexible metadata update

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -552,10 +552,12 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         loadNotes(id, notes);
         response["notes"] = notes;
     } else if (type == "req:history:notes:save") {
+        bool isDirtyNotes = false; // Mark as dirty if notes are saved. It's more for keeping updateIndexMetadata flexible
         auto id = request["id"].as<String>();
         JsonDocument notes; // explicit document: variant->const JsonDocument& is ambiguous on clang
         notes.set(request["notes"]);
         saveNotes(id, notes);
+        isDirtyNotes = true; // when notes are saved the json is created even nothing has been changed (in fact taste notes are saved)
 
         // Update rating and volume in index
         uint8_t rating = notes["rating"].as<uint8_t>();
@@ -570,7 +572,7 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         }
 
         // Always use updateIndexMetadata - it handles both rating and optional volume
-        updateIndexMetadata(id.toInt(), rating, volume);
+        updateIndexMetadata(id.toInt(), rating, volume, isDirtyNotes);
 
         response["msg"] = "Ok";
     } else if (type == "req:history:rebuild") {
@@ -704,7 +706,7 @@ bool ShotHistoryPlugin::appendToIndex(const ShotIndexEntry &entry) {
     return true;
 }
 
-void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume) {
+void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes = false) {
     File indexFile = fs->open("/h/index.bin", "r+");
     if (!indexFile) {
         ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for metadata update");
@@ -721,12 +723,12 @@ void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uin
     if (entryPos >= 0) {
         ShotIndexEntry entry{};
         if (readEntryAtPosition(indexFile, entryPos, entry)) {
-            entry.rating = rating;
+            if (isDirtyNotes) entry.flags |= SHOT_FLAG_HAS_NOTES;
             if (volume > 0) {
                 entry.volume = volume;
             }
             if (rating > 0) {
-                entry.flags |= SHOT_FLAG_HAS_NOTES;
+                entry.rating = rating;
             }
 
             if (writeEntryAtPosition(indexFile, entryPos, entry)) {

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -556,8 +556,9 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
         auto id = request["id"].as<String>();
         JsonDocument notes; // explicit document: variant->const JsonDocument& is ambiguous on clang
         notes.set(request["notes"]);
-        saveNotes(id, notes);
-        isDirtyNotes = true; // when notes are saved the json is created even nothing has been changed (in fact taste notes are saved)
+        if (saveNotes(id, notes)) {
+            isDirtyNotes = true; // when notes are saved the json is created even if nothing has been changed (but in fact taste notes are saved)
+        }
 
         // Update rating and volume in index
         uint8_t rating = notes["rating"].as<uint8_t>();
@@ -582,14 +583,18 @@ void ShotHistoryPlugin::handleRequest(JsonDocument &request, JsonDocument &respo
     }
 }
 
-void ShotHistoryPlugin::saveNotes(const String &id, const JsonDocument &notes) {
+bool ShotHistoryPlugin::saveNotes(const String &id, const JsonDocument &notes) {
     File file = fs->open("/h/" + id + ".json", FILE_WRITE);
-    if (file) {
-        String notesStr;
-        serializeJson(notes, notesStr);
-        file.print(notesStr);
-        file.close();
+    if (!file) {
+        return false;
     }
+
+    String notesStr;
+    serializeJson(notes, notesStr);
+    size_t written = file.print(notesStr);
+    file.close();
+
+    return written == notesStr.length();
 }
 
 void ShotHistoryPlugin::loadNotes(const String &id, JsonDocument &notes) {
@@ -706,7 +711,7 @@ bool ShotHistoryPlugin::appendToIndex(const ShotIndexEntry &entry) {
     return true;
 }
 
-void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes = false) {
+void ShotHistoryPlugin::updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes) {
     File indexFile = fs->open("/h/index.bin", "r+");
     if (!indexFile) {
         ESP_LOGE("ShotHistoryPlugin", "Failed to open index file for metadata update");

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -26,7 +26,7 @@ class ShotHistoryPlugin : public Plugin {
 
     // Index management methods
     bool appendToIndex(const ShotIndexEntry &entry);
-    void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes);
+    void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes = false);
     void markIndexDeleted(uint32_t shotId);
     void rebuildIndex();
     void startAsyncRebuild();
@@ -44,7 +44,7 @@ class ShotHistoryPlugin : public Plugin {
     bool writeEntryAtPosition(File &indexFile, size_t position, const ShotIndexEntry &entry);
     bool createEarlyIndexEntry();
 
-    void saveNotes(const String &id, const JsonDocument &notes);
+    bool saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);
     void startRecording();
 

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -26,7 +26,7 @@ class ShotHistoryPlugin : public Plugin {
 
     // Index management methods
     bool appendToIndex(const ShotIndexEntry &entry);
-    void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume);
+    void updateIndexMetadata(uint32_t shotId, uint8_t rating, uint16_t volume, bool isDirtyNotes);
     void markIndexDeleted(uint32_t shotId);
     void rebuildIndex();
     void startAsyncRebuild();


### PR DESCRIPTION
- Introduced `isDirtyNotes` flag in `updateIndexMetadata` for improved note handling.
- Adjusted logic to set `SHOT_FLAG_HAS_NOTES` only when necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notes are now marked as saved only after the file is successfully written.
  * Failed note saves no longer appear successful.
  * Saving notes no longer depends on assigning a positive rating.
  * Volume and rating metadata are updated independently when changed.
  * Note availability, rating, and volume information now remain accurate when updates are made separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->