### PR TITLE
chore: drop unused TFT_eSPI from display lib_deps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -87,7 +87,6 @@ custom_nanopb_options =
 lib_deps =
     ${display_common.lib_deps_default}
     lewisxhe/SensorLib @ 0.2.3
-    bodmer/TFT_eSPI @ 2.5.43
 	lvgl/lvgl @ 8.4.0
 	moononournation/GFX Library for Arduino @ 1.5.9
 build_flags =


### PR DESCRIPTION
## Summary
- Remove unused `bodmer/TFT_eSPI @ 2.5.43` from `[env:display]` `lib_deps` (nothing in the tree includes it).
- Display paths already use ESP-IDF `esp_lcd_panel_*` (LilyGo/Waveshare) or Arduino_GFX (AMOLED); TFT_eSPI only added compile weight and Arduino-ESP32 3.x friction.
- Closes #864.

## Test plan
- [x] `pio run -e display` succeeds without TFT_eSPI
- [x] `pio run -e display-headless` succeeds
- [ ] Spot-check LilyGo / AMOLED / Waveshare if you have hardware handy
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused display library dependency from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
