### PR TITLE
fix: call MQTTClient::loop() from MQTTPlugin

### DIFF
--- a/src/display/plugins/MQTTPlugin.h
+++ b/src/display/plugins/MQTTPlugin.h
@@ -12,7 +12,7 @@ class MQTTPlugin : public Plugin {
     void setup(Controller *controller, PluginManager *pluginManager) override;
     bool connect(Controller *controller);
     void loop() override {
-        // Event based plugin, no loop needed
+        client.loop();
     };
 
   private:


### PR DESCRIPTION
## Summary
- Call `client.loop()` from `MQTTPlugin::loop()` so keepalive and inbound MQTT traffic are serviced.
- `PluginManager` already pumps plugin loops from the display main loop; the previous empty override left the client idle after Wi-Fi connect.
- Closes #857.
- Out of scope: reconnect (would block on `delay()` in `connect()`), TLS (#302).

## Test plan
- [ ] Enable MQTT / Home Assistant, confirm initial connect in serial log
- [ ] Leave Wi-Fi up past the 10s keep-alive; session should stay alive
- [ ] Temperature / mode publishes still work after idle<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT communication reliability by ensuring the client regularly processes incoming and outgoing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->