### PR TITLE
chore: remove remaining SPIFFS usage from BLE OTA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The `web/` directory contains a Preact + Vite project. The README inside explain
 - `npm run build` - Builds for production, emitting to `dist/`
 - `npm run preview` - Starts a server at <http://localhost:4173/> to test production build locally
 
-When building the firmware, the `scripts/build_webui.sh` script installs the web dependencies and copies the compiled files to the data/ directory for inclusion in the device’s SPIFFS image.
+When building the firmware, the `scripts/build_webui.sh` script installs the web dependencies and prepares assets for the display firmware (LittleFS / embedded `webassets`).
 
 ### Next Steps for Learning
 

--- a/lib/GaggiMateController/library.json
+++ b/lib/GaggiMateController/library.json
@@ -13,7 +13,7 @@
   "platforms": ["esp32"],
   "dependencies": {
     "FS": "*",
-    "SPIFFS": "*",
+    "LittleFS": "*",
     "ble_ota_dfu": "file://lib/ble_ota_dfu",
     "NanoPbComm": "file://lib/NanoPbComm",
     "nanopb/Nanopb": "^0.4.9",

--- a/lib/NanoPbComm/src/ble/BleServerTransport.cpp
+++ b/lib/NanoPbComm/src/ble/BleServerTransport.cpp
@@ -32,8 +32,11 @@ void BleServerTransport::init(const String &deviceName) {
     service->start();
 
     // OTA DFU shares the same server (separate service/UUIDs).
-    _otaDfu.configure_OTA(_server);
-    _otaDfu.start_OTA();
+    if (_otaDfu.configure_OTA(_server)) {
+        _otaDfu.start_OTA();
+    } else {
+        ESP_LOGE(LOG_TAG, "OTA initialization failed");
+    }
 
     _deviceName = deviceName;
     _advertising = NimBLEDevice::getAdvertising();

--- a/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
+++ b/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
@@ -307,7 +307,7 @@ void BLEOverTheAirDeviceFirmwareUpdate::onWrite(BLECharacteristic *pCharacterist
 
 bool BLE_OTA_DFU::configure_OTA(NimBLEServer *pServer) {
     // Init FLASH (LittleFS on the board's filesystem partition)
-    if (!LittleFS.begin(FORMAT_FLASH_IF_MOUNT_FAILED)) {
+    if (!LittleFS.begin(FORMAT_FLASH_IF_MOUNT_FAILED, "/littlefs", 10, "spiffs")) {
         ESP_LOGE(TAG, "LittleFS Mount Failed");
         return false;
     }

--- a/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
+++ b/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
@@ -376,7 +376,9 @@ bool BLE_OTA_DFU::begin(String local_name) {
         return false;
     }
 
-    this->configure_OTA(pServer);
+    if (!this->configure_OTA(pServer)) {
+        return false;
+    }
 
     // Start advertising
     pServer->getAdvertising()->addServiceUUID(pServiceOTA->getUUID());

--- a/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
+++ b/lib/ble_ota_dfu/src/ble_ota_dfu.cpp
@@ -27,7 +27,7 @@ void task_install_update(void *parameters) {
 
     // If the file cannot be loaded, return.
     if (!update_binary) {
-        ESP_LOGE(TAG, "Could not load update.bin from spiffs root");
+        ESP_LOGE(TAG, "Could not load update.bin from littlefs root");
         vTaskDelete(NULL);
     }
 
@@ -84,7 +84,7 @@ void task_install_update(void *parameters) {
 
     update_binary.close();
 
-    // When finished remove the binary from spiffs
+    // When finished remove the binary from littlefs
     // to indicate the end of the process
     ESP_LOGI(TAG, "Removing update file");
     FLASH.remove(path);
@@ -306,22 +306,12 @@ void BLEOverTheAirDeviceFirmwareUpdate::onWrite(BLECharacteristic *pCharacterist
 }
 
 bool BLE_OTA_DFU::configure_OTA(NimBLEServer *pServer) {
-    // Init FLASH
-#ifdef USE_SPIFFS
-    if (!SPIFFS.begin(FORMAT_FLASH_IF_MOUNT_FAILED)) {
-        ESP_LOGE(TAG, "SPIFFS Mount Failed");
+    // Init FLASH (LittleFS on the board's filesystem partition)
+    if (!LittleFS.begin(FORMAT_FLASH_IF_MOUNT_FAILED)) {
+        ESP_LOGE(TAG, "LittleFS Mount Failed");
         return false;
     }
-    ESP_LOGI(TAG, "SPIFFS Mounted");
-#else
-    if (!FFat.begin()) {
-        ESP_LOGE(TAG, "FFat Mount Failed");
-        if (FORMAT_FLASH_IF_MOUNT_FAILED)
-            FFat.format();
-        return false;
-    }
-    ESP_LOGI(TAG, "FFat Mounted");
-#endif
+    ESP_LOGI(TAG, "LittleFS Mounted");
 
     // Get the pointer to the pServer
     this->pServer = pServer;

--- a/lib/ble_ota_dfu/src/ble_ota_dfu.hpp
+++ b/lib/ble_ota_dfu/src/ble_ota_dfu.hpp
@@ -11,21 +11,11 @@
 #include <Update.h>
 #include <string>
 
-// comment to use FFat
-#define USE_SPIFFS
-
-#ifdef USE_SPIFFS
-// SPIFFS write is slower
-#include <SPIFFS.h>
-#define FLASH SPIFFS
+// Stage OTA payload on LittleFS (same FS as display). Keep FASTMODE false so
+// the existing ControllerOTA ACK protocol (0xF1) is unchanged.
+#include <LittleFS.h>
+#define FLASH LittleFS
 const bool FASTMODE = false;
-#else
-// FFat is faster
-#include <FFat.h>
-#define FLASH FFat
-const bool FASTMODE = true;
-#endif
-// #endif
 
 constexpr char SERVICE_OTA_BLE_UUID[] = "fe590001-54ae-4a28-9f74-dfccb248601d";
 constexpr char CHARACTERISTIC_OTA_BL_UUID_RX[] =

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,7 +51,6 @@ build_flags =
     -DDEFAULT_MAX_WS_CLIENTS=3
 lib_deps_default =
     FS
-    SPIFFS
     LittleFS
     Wire
     SPI
@@ -108,6 +107,7 @@ board = seeed_xiao_esp32s3
 
 [env:controller]
 board = Gaggimate-Controller
+board_build.filesystem = littlefs
 build_src_filter = -<*> +<controller/> +<version.h>
 extra_scripts =
     pre:scripts/auto_firmware_version.py
@@ -118,7 +118,7 @@ custom_nanopb_options =
 lib_deps =
 	GaggiMateController
 	FS
-	SPIFFS
+	LittleFS
 	ble_ota_dfu
 	NanoPbComm
 	h2zero/NimBLE-Arduino@^1.4.0


### PR DESCRIPTION
## Summary
- Stage BLE OTA payloads on **LittleFS** instead of unmaintained SPIFFS in `lib/ble_ota_dfu`.
- Drop `SPIFFS` from `platformio.ini` / `GaggiMateController` deps; keep `FASTMODE = false` so the existing ControllerOTA ACK path (`0xF1`) is unchanged.
- Do not use FFat: controller board uses `default_8MB.csv` (`spiffs` partition label); Arduino LittleFS mounts that partition.
- Fix stale CONTRIBUTING.md wording (Web UI is LittleFS / embedded `webassets`, not a SPIFFS image).
- Closes #863.

## Test plan
- [x] `pio run -e controller`
- [x] `pio run -e display`
- [ ] Hardware: BLE controller OTA from display (first boot after upgrade may format the old SPIFFS staging partition — ephemeral `/update.bin` only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display firmware compatibility by standardizing web assets and OTA update storage on LittleFS.
  * OTA updates now use LittleFS consistently, including automatic formatting when mounting fails.
  * Improved OTA reliability by stopping startup when filesystem setup fails.
  * Aligned filesystem handling across supported display firmware configurations.

* **Documentation**
  * Updated web UI build documentation to describe LittleFS-based asset preparation for display firmware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->