### PR TITLE
Update MachineTab color input styles to fix iOS issue

### DIFF
--- a/web/src/pages/Settings/tabs/MachineTab.jsx
+++ b/web/src/pages/Settings/tabs/MachineTab.jsx
@@ -20,7 +20,7 @@ function SunriseColorField({ id, label, value, fallback, onChange }) {
             id={id}
             name={id}
             type='color'
-            className='input input-bordered invisible w-full'
+            className='input cursor-pointer opacity-0'
             value={value || fallback}
             onChange={onChange}
           />


### PR DESCRIPTION
- Replaced `invisible` class with `opacity-0` to fix issue in iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the sunrise color picker interaction with a transparent, clickable input and visible cursor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->