### PR TITLE
feat(shot-analyzer): improve sharing and library actions

### DIFF
--- a/web/src/pages/ShotAnalyzer/components/ShotChart.jsx
+++ b/web/src/pages/ShotAnalyzer/components/ShotChart.jsx
@@ -6,6 +6,7 @@ import './ShotChart.css';
 
 export function ShotChart({
   shotData,
+  profileData,
   results,
   compareEntries = [],
   isCompareActive = false,
@@ -28,6 +29,11 @@ export function ShotChart({
   }
 
   return (
-    <SingleShotChart shotData={shotData} results={results} desktopCardHeight={desktopCardHeight} />
+    <SingleShotChart
+      shotData={shotData}
+      profileData={profileData}
+      results={results}
+      desktopCardHeight={desktopCardHeight}
+    />
   );
 }

--- a/web/src/pages/ShotAnalyzer/components/analyzerActionBar/ActionBarButtons.jsx
+++ b/web/src/pages/ShotAnalyzer/components/analyzerActionBar/ActionBarButtons.jsx
@@ -77,7 +77,7 @@ export function ActionBarStatisticsAction({
   const content = (
     <>
       <FontAwesomeIcon icon={statisticsIcon} className='text-sm' />
-      <span>{compareMode ? 'Multi-Compare' : 'Statistics'}</span>
+      <span>{compareMode ? 'Multi-Compare' : 'Profile Stats'}</span>
     </>
   );
 

--- a/web/src/pages/ShotAnalyzer/components/library/LibraryActionsMenu.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/LibraryActionsMenu.jsx
@@ -1,0 +1,167 @@
+import { createPortal } from 'preact/compat';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons/faEllipsisVertical';
+import {
+  getAnalyzerIconButtonClasses,
+  getAnalyzerTextButtonClasses,
+} from '../analyzerControlStyles';
+
+const MENU_WIDTH = 176;
+const MENU_GAP = 8;
+const VIEWPORT_MARGIN = 12;
+
+function getMenuPosition(anchor, actionCount, preferredPlacement) {
+  if (!anchor) return { top: VIEWPORT_MARGIN, left: VIEWPORT_MARGIN, width: MENU_WIDTH };
+
+  const rect = anchor.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const width = Math.min(MENU_WIDTH, viewportWidth - VIEWPORT_MARGIN * 2);
+  const estimatedHeight = actionCount * 36 + 8;
+  const spaceAbove = rect.top - VIEWPORT_MARGIN;
+  const spaceBelow = viewportHeight - rect.bottom - VIEWPORT_MARGIN;
+  let openAbove = preferredPlacement === 'top';
+
+  if (openAbove && spaceAbove < estimatedHeight && spaceBelow > spaceAbove) openAbove = false;
+  if (!openAbove && spaceBelow < estimatedHeight && spaceAbove > spaceBelow) openAbove = true;
+
+  const desiredTop = openAbove ? rect.top - estimatedHeight - MENU_GAP : rect.bottom + MENU_GAP;
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - estimatedHeight - VIEWPORT_MARGIN);
+
+  return {
+    top: Math.min(Math.max(VIEWPORT_MARGIN, desiredTop), maxTop),
+    left: Math.min(
+      Math.max(VIEWPORT_MARGIN, rect.right - width),
+      Math.max(VIEWPORT_MARGIN, viewportWidth - width - VIEWPORT_MARGIN),
+    ),
+    width,
+  };
+}
+
+export function LibraryActionsMenu({ actions, ariaLabel, buttonClassName, placement = 'bottom' }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({
+    top: VIEWPORT_MARGIN,
+    left: VIEWPORT_MARGIN,
+    width: MENU_WIDTH,
+  });
+  const detailsRef = useRef(null);
+  const menuRef = useRef(null);
+
+  const closeMenu = useCallback(() => {
+    if (detailsRef.current) detailsRef.current.open = false;
+  }, []);
+
+  const updateMenuPosition = useCallback(() => {
+    setMenuPosition(getMenuPosition(detailsRef.current, actions.length, placement));
+  }, [actions.length, placement]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = event => {
+      if (detailsRef.current?.contains(event.target) || menuRef.current?.contains(event.target)) {
+        return;
+      }
+      closeMenu();
+    };
+    const handleKeyDown = event => {
+      if (event.key === 'Escape') closeMenu();
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', closeMenu, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', closeMenu, true);
+    };
+  }, [closeMenu, isOpen, updateMenuPosition]);
+
+  const handleAction = (event, onSelect) => {
+    event.stopPropagation();
+    closeMenu();
+    onSelect?.();
+  };
+
+  const menu = (
+    <div
+      ref={menuRef}
+      role='menu'
+      tabIndex={-1}
+      className='app-card-surface fixed z-[10000] rounded-xl p-1.5 shadow-xl'
+      style={{
+        top: `${menuPosition.top}px`,
+        left: `${menuPosition.left}px`,
+        width: `${menuPosition.width}px`,
+      }}
+    >
+      <div className='grid gap-1'>
+        {actions.map(action => {
+          const content = (
+            <>
+              <FontAwesomeIcon icon={action.icon} className='w-4' />
+              <span>{action.label}</span>
+            </>
+          );
+          const className = getAnalyzerTextButtonClasses({
+            tone: action.tone,
+            className: 'w-full gap-2 px-2.5 py-2 text-left text-xs font-medium',
+          });
+
+          return action.href ? (
+            <a
+              key={action.label}
+              href={action.href}
+              role='menuitem'
+              className={className}
+              onClick={event => handleAction(event, action.onSelect)}
+            >
+              {content}
+            </a>
+          ) : (
+            <button
+              key={action.label}
+              type='button'
+              role='menuitem'
+              className={className}
+              onClick={event => handleAction(event, action.onSelect)}
+            >
+              {content}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <details
+      ref={detailsRef}
+      onToggle={event => {
+        const open = event.currentTarget.open;
+        if (open) updateMenuPosition();
+        setIsOpen(open);
+      }}
+    >
+      <summary
+        onClick={event => event.stopPropagation()}
+        className={getAnalyzerIconButtonClasses({
+          tone: 'subtle',
+          className: `cursor-pointer list-none ${buttonClassName} [&::-webkit-details-marker]:hidden`,
+        })}
+        aria-label={ariaLabel}
+        title='More actions'
+      >
+        <FontAwesomeIcon icon={faEllipsisVertical} size='sm' />
+      </summary>
+
+      {isOpen ? createPortal(menu, document.body) : null}
+    </details>
+  );
+}

--- a/web/src/pages/ShotAnalyzer/components/library/LibraryPanel.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/LibraryPanel.jsx
@@ -4,8 +4,7 @@
  */
 
 import { ApiServiceContext } from '../../../../services/ApiService';
-import { downloadJson } from '../../../../utils/download';
-import { libraryService } from '../../services/LibraryService';
+import { exportLibraryItems } from '../../services/LibraryExportService';
 import {
   ANALYZER_DB_KEYS,
   cleanName,
@@ -297,14 +296,9 @@ export function LibraryPanel({
     [getEffectiveShotPinBucketKey, getPinnedShotBucketKey, shotsPinnedFirst],
   );
 
-  // Uses libraryService.exportItem to fetch data, then uses UI helper 'downloadJson'
   const handleExport = async (item, isShot) => {
     try {
-      // 1. Fetch data via service (now returns { exportData, filename })
-      const { exportData, filename } = await libraryService.exportItem(item, isShot);
-
-      // 2. Use existing UI helper for consistent downloading
-      downloadJson(exportData, filename);
+      await exportLibraryItems([{ item, isShot }]);
     } catch (e) {
       alert(`Export failed: ${e.message}`);
       console.error(e);

--- a/web/src/pages/ShotAnalyzer/components/library/LibraryRow.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/LibraryRow.jsx
@@ -13,6 +13,7 @@ import { cleanName, formatTimestamp, getProfileDisplayLabel } from '../../utils/
 import { buildStatisticsProfileHref } from '../../../Statistics/utils/statisticsRoute';
 import { SourceMarker } from '../SourceMarker';
 import { getAnalyzerIconButtonClasses } from '../analyzerControlStyles';
+import { LibraryActionsMenu } from './LibraryActionsMenu';
 
 const ACTIVE_ROW_CLASSES = 'bg-primary/18';
 const COMPARE_PENDING_ROW_CLASSES = 'bg-primary/10 opacity-75';
@@ -128,51 +129,38 @@ function LibraryActionsCell({
   onDelete,
   statisticsIcon,
 }) {
-  return (
-    <div className='flex justify-end gap-2'>
-      {!isShot && (
-        <a
-          href={profileStatsHref || '/statistics'}
-          onClick={event => {
-            stopRowClick(event);
-            onShowStats?.(item);
-          }}
-          className={getAnalyzerIconButtonClasses({
+  const actions = [
+    ...(!isShot
+      ? [
+          {
+            label: 'Profile Statistics',
+            icon: statisticsIcon,
             tone: 'success',
-            className: 'h-6 w-6',
-          })}
-          title='Profile statistics'
-        >
-          <FontAwesomeIcon icon={statisticsIcon} size='xs' />
-        </a>
-      )}
-      <button
-        type='button'
-        onClick={event => {
-          stopRowClick(event);
-          onExport(item);
-        }}
-        className={getAnalyzerIconButtonClasses({
-          tone: 'subtle',
-          className: 'h-6 w-6',
-        })}
-      >
-        <FontAwesomeIcon icon={faFileExport} size='xs' />
-      </button>
-      <button
-        type='button'
-        onClick={event => {
-          stopRowClick(event);
-          onDelete(item);
-        }}
-        className={getAnalyzerIconButtonClasses({
-          tone: 'error',
-          className: 'h-6 w-6',
-        })}
-      >
-        <FontAwesomeIcon icon={faTrashCan} size='xs' />
-      </button>
-    </div>
+            href: profileStatsHref || '/statistics',
+            onSelect: () => onShowStats?.(item),
+          },
+        ]
+      : []),
+    {
+      label: 'Export',
+      icon: faFileExport,
+      onSelect: () => onExport(item),
+    },
+    {
+      label: 'Delete',
+      icon: faTrashCan,
+      tone: 'error',
+      onSelect: () => onDelete(item),
+    },
+  ];
+
+  return (
+    <LibraryActionsMenu
+      actions={actions}
+      ariaLabel={`Open ${isShot ? 'shot' : 'profile'} actions menu`}
+      buttonClassName='h-6 w-6'
+      placement='top'
+    />
   );
 }
 

--- a/web/src/pages/ShotAnalyzer/components/library/LibrarySection.css
+++ b/web/src/pages/ShotAnalyzer/components/library/LibrarySection.css
@@ -30,8 +30,8 @@
 
 .shot-analyzer-page .library-row-grid {
   --library-row-trailing-gap: 1rem;
-  --library-shot-actions-width: 3.5rem;
-  --library-profile-actions-width: 5.5rem;
+  --library-shot-actions-width: 1.5rem;
+  --library-profile-actions-width: 1.5rem;
   display: grid;
   min-width: 0;
   max-width: 100%;

--- a/web/src/pages/ShotAnalyzer/components/library/LibrarySection.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/LibrarySection.jsx
@@ -3,6 +3,7 @@
  */
 
 import { LibraryRow } from './LibraryRow';
+import { LibraryActionsMenu } from './LibraryActionsMenu';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
@@ -184,28 +185,23 @@ export function LibrarySection({
               {items.length}
             </span>
           </h3>
-          <div className='flex gap-2'>
-            <button
-              onClick={onExportAll}
-              className={getAnalyzerIconButtonClasses({
-                tone: 'subtle',
-                className: 'h-7 w-7 p-1.5',
-              })}
-              title='Export All'
-            >
-              <FontAwesomeIcon icon={faFileExport} size='sm' />
-            </button>
-            <button
-              onClick={onDeleteAll}
-              className={getAnalyzerIconButtonClasses({
+          <LibraryActionsMenu
+            ariaLabel={`Open ${title.toLowerCase()} actions menu`}
+            buttonClassName='h-7 w-7 p-1.5'
+            actions={[
+              {
+                label: 'Export All',
+                icon: faFileExport,
+                onSelect: onExportAll,
+              },
+              {
+                label: 'Delete All',
+                icon: faTrashCan,
                 tone: 'error',
-                className: 'h-7 w-7 p-1.5',
-              })}
-              title='Delete All'
-            >
-              <FontAwesomeIcon icon={faTrashCan} size='sm' />
-            </button>
-          </div>
+                onSelect: onDeleteAll,
+              },
+            ]}
+          />
         </div>
         <div className='flex min-w-0 gap-2'>
           <input

--- a/web/src/pages/ShotAnalyzer/components/library/StatusBar.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/StatusBar.jsx
@@ -126,8 +126,8 @@ function getStatusBarViewModel({
     profileBadgeClasses,
     activeBadgeIconButtonClasses,
     compareBadgeClasses: getCompareSlotBadgeClasses({ currentShot, ghosted }),
-    showShotChevron: !currentShot,
-    showProfileChevron: !currentProfile && !isSearchingProfile,
+    showShotChevron: true,
+    showProfileChevron: Boolean(currentProfile) || !isSearchingProfile,
   };
 }
 

--- a/web/src/pages/ShotAnalyzer/components/shotChart/controls/ShotChartControls.jsx
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/controls/ShotChartControls.jsx
@@ -86,6 +86,7 @@ export function ShotChartControls({
   onCloseExportMenu,
   onExportAction,
   onExportMenuToggle,
+  profileExportAvailable,
   onExportTypeChange,
   onExportFormatChange,
   onExportFormatInfoToggle,
@@ -155,6 +156,7 @@ export function ShotChartControls({
             onCloseExportMenu={onCloseExportMenu}
             onExportAction={onExportAction}
             onExportMenuToggle={onExportMenuToggle}
+            profileExportAvailable={profileExportAvailable}
             onExportTypeChange={onExportTypeChange}
             onExportFormatChange={onExportFormatChange}
             onExportFormatInfoToggle={onExportFormatInfoToggle}

--- a/web/src/pages/ShotAnalyzer/components/shotChart/controls/chartReplayControls.jsx
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/controls/chartReplayControls.jsx
@@ -1,8 +1,8 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons/faArrowUpRightFromSquare';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons/faCircleInfo';
 import { faDownLeftAndUpRightToCenter } from '@fortawesome/free-solid-svg-icons/faDownLeftAndUpRightToCenter';
 import { faPause } from '@fortawesome/free-solid-svg-icons/faPause';
-import { faPhotoFilm } from '@fortawesome/free-solid-svg-icons/faPhotoFilm';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 import { faStop } from '@fortawesome/free-solid-svg-icons/faStop';
 import { faUpRightAndDownLeftFromCenter } from '@fortawesome/free-solid-svg-icons/faUpRightAndDownLeftFromCenter';
@@ -34,6 +34,7 @@ function ShotMediaExportMenu({
   onCloseExportMenu,
   onExportAction,
   onExportMenuToggle,
+  profileExportAvailable,
   onExportTypeChange,
   onExportFormatChange,
   onExportFormatInfoToggle,
@@ -45,6 +46,17 @@ function ShotMediaExportMenu({
   buttonIconStyle = ANALYZER_ACTION_ICON_STYLE,
   menuClassName = 'absolute top-full right-0 z-[70] mt-2',
 }) {
+  const fileExportTypes = ['shot', 'profile'].filter(type =>
+    exportMenuState.exportType?.includes(type),
+  );
+
+  const handleFileExportTypeToggle = fileExportType => {
+    const nextExportType = fileExportTypes.includes(fileExportType)
+      ? fileExportTypes.filter(type => type !== fileExportType)
+      : [...fileExportTypes, fileExportType];
+    onExportTypeChange(nextExportType.join('+') || null);
+  };
+
   return (
     <div ref={exportMenuRef} className='relative flex'>
       <button
@@ -52,12 +64,12 @@ function ShotMediaExportMenu({
         onClick={onExportMenuToggle}
         className={`${buttonClassName} ${exportMenuState.open ? 'text-base-content/90' : ''}`}
         disabled={isControlsLocked}
-        aria-label='Open media export menu'
+        aria-label='Share'
         aria-expanded={exportMenuState.open}
-        title='Open media export menu'
+        title='Share'
       >
         <FontAwesomeIcon
-          icon={faPhotoFilm}
+          icon={faArrowUpRightFromSquare}
           className={buttonIconClassName}
           style={buttonIconStyle}
         />
@@ -111,6 +123,29 @@ function ShotMediaExportMenu({
             />
             <span className='text-sm'>Include legend</span>
           </label>
+          <div className='mt-3 mb-2 text-xs font-medium opacity-60'>Export File</div>
+          {[
+            { value: 'shot', label: 'Shot', disabled: false },
+            { value: 'profile', label: 'Profile', disabled: !profileExportAvailable },
+          ].map(option => (
+            <label
+              key={option.value}
+              className={getAnalyzerSurfaceTriggerClasses({
+                className: `flex w-full items-center gap-2 px-2 py-1.5 ${
+                  option.disabled ? 'cursor-not-allowed opacity-30' : 'cursor-pointer'
+                }`,
+              })}
+            >
+              <input
+                type='checkbox'
+                className='checkbox checkbox-xs'
+                checked={fileExportTypes.includes(option.value)}
+                disabled={option.disabled}
+                onChange={() => handleFileExportTypeToggle(option.value)}
+              />
+              <span className='text-sm'>{option.label}</span>
+            </label>
+          ))}
           {exportMenuState.exportType === 'video' && shouldShowWebmToggle ? (
             <div
               className={getAnalyzerSurfaceTriggerClasses({
@@ -242,6 +277,7 @@ function ReplayAndExportActions({
   onCloseExportMenu,
   onExportAction,
   onExportMenuToggle,
+  profileExportAvailable,
   onExportTypeChange,
   onExportFormatChange,
   onExportFormatInfoToggle,
@@ -286,6 +322,7 @@ function ReplayAndExportActions({
             onCloseExportMenu={onCloseExportMenu}
             onExportAction={onExportAction}
             onExportMenuToggle={onExportMenuToggle}
+            profileExportAvailable={profileExportAvailable}
             onExportTypeChange={onExportTypeChange}
             onExportFormatChange={onExportFormatChange}
             onExportFormatInfoToggle={onExportFormatInfoToggle}
@@ -313,6 +350,7 @@ export function ShotChartMobileReplayActions({
   onCloseExportMenu,
   onExportAction,
   onExportMenuToggle,
+  profileExportAvailable,
   onExportTypeChange,
   onExportFormatChange,
   onExportFormatInfoToggle,
@@ -356,6 +394,7 @@ export function ShotChartMobileReplayActions({
           onCloseExportMenu={onCloseExportMenu}
           onExportAction={onExportAction}
           onExportMenuToggle={onExportMenuToggle}
+          profileExportAvailable={profileExportAvailable}
           onExportTypeChange={onExportTypeChange}
           onExportFormatChange={onExportFormatChange}
           onExportFormatInfoToggle={onExportFormatInfoToggle}
@@ -418,6 +457,7 @@ export function ChartActionGroup({
   onCloseExportMenu,
   onExportAction,
   onExportMenuToggle,
+  profileExportAvailable,
   onExportTypeChange,
   onExportFormatChange,
   onExportFormatInfoToggle,
@@ -450,6 +490,7 @@ export function ChartActionGroup({
           onCloseExportMenu={onCloseExportMenu}
           onExportAction={onExportAction}
           onExportMenuToggle={onExportMenuToggle}
+          profileExportAvailable={profileExportAvailable}
           onExportTypeChange={onExportTypeChange}
           onExportFormatChange={onExportFormatChange}
           onExportFormatInfoToggle={onExportFormatInfoToggle}

--- a/web/src/pages/ShotAnalyzer/components/shotChart/single/SingleShotChart.jsx
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/single/SingleShotChart.jsx
@@ -81,7 +81,7 @@ import {
 
 Chart.register(annotationPlugin);
 
-export function SingleShotChart({ shotData, results, desktopCardHeight = 0 }) {
+export function SingleShotChart({ shotData, profileData, results, desktopCardHeight = 0 }) {
   // These refs point to the mounted DOM and Chart.js instances. They stay local
   // to the component because only the top-level orchestrator owns mounting and teardown.
   const hoverAreaRef = useRef(null);
@@ -218,6 +218,7 @@ export function SingleShotChart({ shotData, results, desktopCardHeight = 0 }) {
     abortActiveExport,
   } = useShotChartReplayExport({
     shotData,
+    profileData,
     exportMenuRef,
     chartRefs: { mainChartInstance, tempChartInstance, hoverAreaRef },
     legendColorByLabel,
@@ -688,6 +689,7 @@ export function SingleShotChart({ shotData, results, desktopCardHeight = 0 }) {
       onCloseExportMenu={closeExportMenu}
       onExportAction={handleExportAction}
       onExportMenuToggle={toggleExportMenu}
+      profileExportAvailable={Boolean(profileData)}
       onExportTypeChange={handleExportTypeChange}
       onExportFormatChange={handleExportFormatChange}
       onExportFormatInfoToggle={handleExportFormatInfoToggle}
@@ -792,6 +794,7 @@ export function SingleShotChart({ shotData, results, desktopCardHeight = 0 }) {
             onCloseExportMenu={closeExportMenu}
             onExportAction={handleExportAction}
             onExportMenuToggle={toggleExportMenu}
+            profileExportAvailable={Boolean(profileData)}
             onExportTypeChange={handleExportTypeChange}
             onExportFormatChange={handleExportFormatChange}
             onExportFormatInfoToggle={handleExportFormatInfoToggle}

--- a/web/src/pages/ShotAnalyzer/components/shotChart/single/useShotChartReplayExport.js
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/single/useShotChartReplayExport.js
@@ -8,13 +8,13 @@
  */
 
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { downloadBlob, downloadJson } from '../../../../../utils/download';
+import { downloadBlob } from '../../../../../utils/download';
 import {
   exportReplayImage,
   exportReplayVideo,
   getVideoExportCapabilities,
 } from '../../../services/ReplayVideoExportService';
-import { libraryService } from '../../../services/LibraryService';
+import { exportLibraryItems } from '../../../services/LibraryExportService';
 import {
   DEFAULT_REPLAY_EXPORT_CONFIG,
   getReplayExportStatusHint,
@@ -119,6 +119,7 @@ function setChartReplayReveal(chart, enabled, revealX) {
 
 export function useShotChartReplayExport({
   shotData,
+  profileData,
   exportMenuRef,
   chartRefs,
   legendColorByLabel,
@@ -734,27 +735,6 @@ export function useShotChartReplayExport({
     }
   };
 
-  const handleShotJsonExport = async () => {
-    beginExportSession('json');
-    setReplayExportStatusSafely({ status: 'preparingJson', error: null });
-
-    try {
-      // Keep JSON export routed through LibraryService so naming and file contents
-      // stay identical to the analyzer/library export path elsewhere in the app.
-      const { exportData, filename } = await libraryService.exportItem(shotData, true);
-      setReplayExportStatusSafely({ status: 'downloading', error: null });
-      downloadJson(exportData, filename);
-      setReplayExportStatusSafely({ status: 'idle', error: null });
-    } catch (error) {
-      setReplayExportStatusSafely({
-        status: 'error',
-        error: error?.message || 'Shot JSON export failed.',
-      });
-    } finally {
-      finishExportSession();
-    }
-  };
-
   const closeExportMenu = () => {
     setExportMenuState(prev => ({ ...prev, open: false }));
   };
@@ -822,8 +802,25 @@ export function useShotChartReplayExport({
     if (isExportingRef.current) return;
 
     closeExportMenu();
-    if (exportMenuState.exportType === 'json') {
-      await handleShotJsonExport();
+    const fileExportTypes = ['shot', 'profile'].filter(type =>
+      exportMenuState.exportType?.includes(type),
+    );
+    if (fileExportTypes.length > 0) {
+      try {
+        const items = fileExportTypes
+          .map(type => {
+            if (type === 'shot') return { item: shotData, isShot: true };
+            if (type === 'profile' && profileData) return { item: profileData, isShot: false };
+            return null;
+          })
+          .filter(Boolean);
+        await exportLibraryItems(items);
+      } catch (error) {
+        setReplayExportStatusSafely({
+          status: 'error',
+          error: error?.message || 'File export failed.',
+        });
+      }
       return;
     }
     if (exportMenuState.exportType === 'image') {

--- a/web/src/pages/ShotAnalyzer/components/shotChart/tooltip/ShotChartExternalTooltip.jsx
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/tooltip/ShotChartExternalTooltip.jsx
@@ -52,6 +52,10 @@ function getTooltipStyle({ isStatic, layout }) {
   };
 }
 
+function hasTooltipContent(state) {
+  return state.titleLines.length > 0 || state.phaseSummaries.length > 0 || state.rows.length > 0;
+}
+
 export function ShotChartExternalTooltip({
   tooltipRef,
   state,
@@ -64,9 +68,10 @@ export function ShotChartExternalTooltip({
   emptyContent = null,
 }) {
   if (!state.visible && !isStatic) return null;
+  const hasVisibleContent = state.visible && hasTooltipContent(state);
   const isTitleOnly = state.visible && state.titleLines.length > 0 && state.rows.length === 0;
-  const shouldShowEmptyContent = isStatic && !state.visible && Boolean(emptyContent);
-  const shouldShowStaticContent = isStatic && state.visible;
+  const shouldShowEmptyContent = isStatic && !hasVisibleContent && Boolean(emptyContent);
+  const shouldShowStaticContent = isStatic && hasVisibleContent;
   const style = getTooltipStyle({ isStatic, layout });
 
   return (

--- a/web/src/pages/ShotAnalyzer/services/LibraryExportService.js
+++ b/web/src/pages/ShotAnalyzer/services/LibraryExportService.js
@@ -1,0 +1,15 @@
+import { downloadJson, downloadJsonQueue } from '../../../utils/download';
+import { libraryService } from './LibraryService';
+
+export async function exportLibraryItems(items) {
+  const exports = await Promise.all(
+    items.map(({ item, isShot }) => libraryService.exportItem(item, isShot)),
+  );
+  const files = exports.map(({ exportData, filename }) => ({ json: exportData, filename }));
+
+  if (files.length > 1) {
+    await downloadJsonQueue(files);
+  } else if (files[0]) {
+    downloadJson(files[0].json, files[0].filename);
+  }
+}

--- a/web/src/pages/ShotAnalyzer/shotAnalyzer/ActiveAnalysisView.jsx
+++ b/web/src/pages/ShotAnalyzer/shotAnalyzer/ActiveAnalysisView.jsx
@@ -174,6 +174,7 @@ export function ActiveAnalysisView({
   compareCollectionWithAccents,
   compareTargetDisplayMode,
   currentShot,
+  currentProfile,
   handleSwapCompareSlots,
   isCompareActive,
   mobileSubpageNavigation,
@@ -286,6 +287,7 @@ export function ActiveAnalysisView({
             >
               <ShotChart
                 shotData={currentShot}
+                profileData={currentProfile}
                 results={analysisResults}
                 compareEntries={compareCollectionWithAccents}
                 isCompareActive={isCompareActive}

--- a/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
+++ b/web/src/pages/ShotAnalyzer/shotAnalyzer/ShotAnalyzer.jsx
@@ -964,6 +964,7 @@ export function ShotAnalyzer() {
             compareCollectionWithAccents={compareCollectionWithAccents}
             compareTargetDisplayMode={compareTargetDisplayMode}
             currentShot={currentShot}
+            currentProfile={currentProfile}
             handleSwapCompareSlots={handleSwapCompareSlots}
             isCompareActive={isCompareActive}
             mobileSubpageNavigation={mobileSubpageNavigation}

--- a/web/src/utils/download.js
+++ b/web/src/utils/download.js
@@ -10,7 +10,7 @@ export function downloadBlob(blob, filename) {
   document.body.appendChild(a);
   setTimeout(() => {
     a.click();
-    document.body.removeChild(a);
+    a.remove();
     URL.revokeObjectURL(url);
   }, 10);
 }
@@ -19,4 +19,13 @@ export function downloadJson(json, filename) {
   const jsonStr = JSON.stringify(json, undefined, 2);
   const blob = new Blob([jsonStr], { type: 'application/json' });
   downloadBlob(blob, filename);
+}
+
+export async function downloadJsonQueue(files, delayMs = 500) {
+  for (const [index, file] of files.entries()) {
+    downloadJson(file.json, file.filename);
+    if (index < files.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
 }


### PR DESCRIPTION
- rename the media export action to Share and update its icon
- add selectable shot and profile exports to the Share menu
- consolidate library actions into ellipsis menus
- add Profile Stats to profile row actions
- improve navigation cues for loaded shots and profiles
- fix mobile shot detail information initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable actions menu for library items and bulk actions.
  * Added profile exports alongside shot exports, including multi-file downloads.
  * Improved export menus with clearer sharing labels and icons.
  * Renamed “Statistics” to “Profile Stats” in standard analysis mode.

* **Bug Fixes & Improvements**
  * Improved library action spacing and menu positioning.
  * Enhanced chart tooltips to display content more reliably.
  * Updated navigation indicators for shot and profile selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->