### PR TITLE
fix: Reset puck-flow filter accumulators on tare/reset (fixes part of #839)

### DIFF
--- a/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
+++ b/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
@@ -45,7 +45,10 @@ float DimmedPump::getPuckFlow() { return _pressureController.getCoffeeFlowRate()
 
 float DimmedPump::getPuckResistance() { return _pressureController.getPuckResistance(); }
 
-void DimmedPump::tare() { _pressureController.tare(); }
+void DimmedPump::tare() {
+    _pressureController.tare();
+    _pressureController.reset();
+}
 
 void DimmedPump::loopTask(void *arg) {
     auto *pump = static_cast<DimmedPump *>(arg);

--- a/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
+++ b/lib/GaggiMateController/src/peripherals/DimmedPump.cpp
@@ -45,10 +45,7 @@ float DimmedPump::getPuckFlow() { return _pressureController.getCoffeeFlowRate()
 
 float DimmedPump::getPuckResistance() { return _pressureController.getPuckResistance(); }
 
-void DimmedPump::tare() {
-    _pressureController.tare();
-    _pressureController.reset();
-}
+void DimmedPump::tare() { _pressureController.tare(); }
 
 void DimmedPump::loopTask(void *arg) {
     auto *pump = static_cast<DimmedPump *>(arg);

--- a/lib/NayrodPID/src/PressureController/PressureController.cpp
+++ b/lib/NayrodPID/src/PressureController/PressureController.cpp
@@ -1,5 +1,6 @@
 #include "PressureController.h"
 #include "SimpleKalmanFilter/SimpleKalmanFilter.h"
+#include <Arduino.h> // ESP_LOGI (reset())
 #include <algorithm>
 #include <math.h>
 
@@ -146,14 +147,14 @@ void PressureController::setGains(float commutationGain, float convergenceGain, 
 }
 
 void PressureController::tare() {
+    // reset() owns the control-loop and puck-arming-state fields (including
+    // the IIR-filtered accumulators that, unreset, used to carry a shot's
+    // end-of-brew depressurization transient into the next shot's puck-
+    // conductance-derivative arming signature — GH #839). tare() adds the
+    // estimator-output fields that are specific to starting a fresh shot.
+    reset();
     _coffeeOutput = 0.0f;
     _pumpVolume = 0.0f;
-    _puckSaturationVolume = 0.0f;
-    _puckState[0] = false;
-    _puckState[1] = false;
-    _puckState[2] = false;
-    _puckCounter = 0;
-    _pumpFlowRate = 0.0f;
     _puckConductanceDerivative = 0.0f;
     _coffeeFlowRate = 0.0f;
     _puckResistance = INFINITY;
@@ -306,5 +307,9 @@ void PressureController::reset() {
     _puckState[1] = false;
     _puckState[2] = false;
     _puckCounter = 0;
+    _filteredPressureDerivative = 0.0f;
+    _waterThroughPuckFlowRate = 0.0f;
+    _lastPuckConductance = 0.0f;
+    _puckConductance = 0.0f;
     ESP_LOGI("", "RESET");
 }

--- a/lib/NayrodPID/src/PressureController/PressureController.cpp
+++ b/lib/NayrodPID/src/PressureController/PressureController.cpp
@@ -147,14 +147,21 @@ void PressureController::setGains(float commutationGain, float convergenceGain, 
 }
 
 void PressureController::tare() {
-    // reset() owns the control-loop and puck-arming-state fields (including
-    // the IIR-filtered accumulators that, unreset, used to carry a shot's
-    // end-of-brew depressurization transient into the next shot's puck-
-    // conductance-derivative arming signature — GH #839). tare() adds the
-    // estimator-output fields that are specific to starting a fresh shot.
-    reset();
     _coffeeOutput = 0.0f;
     _pumpVolume = 0.0f;
+    _puckSaturationVolume = 0.0f;
+    _puckState[0] = false;
+    _puckState[1] = false;
+    _puckState[2] = false;
+    _puckCounter = 0;
+    _pumpFlowRate = 0.0f;
+    // IIR-filtered accumulators: unreset, these carry a shot's end-of-brew
+    // depressurization transient into the next shot's puck-conductance-
+    // derivative arming signature, suppressing arming — GH #839.
+    _filteredPressureDerivative = 0.0f;
+    _waterThroughPuckFlowRate = 0.0f;
+    _lastPuckConductance = 0.0f;
+    _puckConductance = 0.0f;
     _puckConductanceDerivative = 0.0f;
     _coffeeFlowRate = 0.0f;
     _puckResistance = INFINITY;
@@ -307,9 +314,5 @@ void PressureController::reset() {
     _puckState[1] = false;
     _puckState[2] = false;
     _puckCounter = 0;
-    _filteredPressureDerivative = 0.0f;
-    _waterThroughPuckFlowRate = 0.0f;
-    _lastPuckConductance = 0.0f;
-    _puckConductance = 0.0f;
     ESP_LOGI("", "RESET");
 }

--- a/lib/NayrodPID/src/PressureController/PressureController.h
+++ b/lib/NayrodPID/src/PressureController/PressureController.h
@@ -7,6 +7,7 @@ static constexpr float M_PI = 3.14159265358979323846f;
 
 #include "SimpleKalmanFilter/SimpleKalmanFilter.h"
 #include <algorithm>
+#include <cmath> // std::fmax (getCoffeeOutputEstimate())
 
 class PressureController {
   private:
@@ -23,7 +24,13 @@ class PressureController {
     void setPressureLimit(float lim) { /* Pressure limit not currently implemented */ };
 
     void update(ControlMode mode);
+    // Full reset for a new shot (volumetric tare): composes reset() with the
+    // estimator-output fields that only tare() owns. Call this alone; it
+    // covers reset()'s state too. See PressureController.cpp for the exact
+    // field ownership split.
     void tare();
+    // Control-loop + puck-arming-state reset. Safe to call standalone if a
+    // future caller needs to reset control state without a full tare.
     void reset();
 
     float getCoffeeOutputEstimate() { return std::fmax(0.0f, _coffeeOutput); };

--- a/lib/NayrodPID/src/PressureController/PressureController.h
+++ b/lib/NayrodPID/src/PressureController/PressureController.h
@@ -24,13 +24,7 @@ class PressureController {
     void setPressureLimit(float lim) { /* Pressure limit not currently implemented */ };
 
     void update(ControlMode mode);
-    // Full reset for a new shot (volumetric tare): composes reset() with the
-    // estimator-output fields that only tare() owns. Call this alone; it
-    // covers reset()'s state too. See PressureController.cpp for the exact
-    // field ownership split.
     void tare();
-    // Control-loop + puck-arming-state reset. Safe to call standalone if a
-    // future caller needs to reset control state without a full tare.
     void reset();
 
     float getCoffeeOutputEstimate() { return std::fmax(0.0f, _coffeeOutput); };

--- a/lib/NayrodPID/src/SimpleKalmanFilter/SimpleKalmanFilter.cpp
+++ b/lib/NayrodPID/src/SimpleKalmanFilter/SimpleKalmanFilter.cpp
@@ -1,5 +1,4 @@
 #include "SimpleKalmanFilter.h"
-#include "Arduino.h"
 #include <math.h>
 
 SimpleKalmanFilter::SimpleKalmanFilter(float mea_e, float est_e, float q) {

--- a/lib/NayrodPID/src/SimpleKalmanFilter/SimpleKalmanFilter.h
+++ b/lib/NayrodPID/src/SimpleKalmanFilter/SimpleKalmanFilter.h
@@ -1,8 +1,6 @@
 #ifndef SimpleKalmanFilter_h
 #define SimpleKalmanFilter_h
 
-#include "Arduino.h"
-
 class SimpleKalmanFilter {
   public:
     // Constructor

--- a/platformio.ini
+++ b/platformio.ini
@@ -151,6 +151,30 @@ build_flags =
 	-Wno-unused-variable
 	-Wno-unused-function
 
+; Native-host env for PressureController puck-flow-estimator tests (GH #839).
+; `pio test -e native_puckflow` runs host-side, no ESP32/Arduino runtime.
+[env:native_puckflow]
+platform = native
+framework =
+lib_ldf_mode = off
+lib_deps =
+	throwtheswitch/Unity@^2.6.0
+test_framework = unity
+test_filter = test_puckflow_latch
+; Test TU includes PressureController.cpp and SimpleKalmanFilter.cpp
+; directly (see #include at top of test_puckflow_latch.cpp). SimpleKalmanFilter
+; has no Arduino dependency; PressureController.cpp includes <Arduino.h> only
+; for the ESP_LOGI() macro in reset() — native_stubs/Arduino.h is a scoped,
+; documented stand-in for just that, picked up first via -I ordering below.
+build_unflags =
+	-std=gnu++11
+build_flags =
+	-std=c++17
+	-I test/test_puckflow_latch/native_stubs
+	-I lib/NayrodPID/src
+	-Wno-unused-variable
+	-Wno-unused-function
+
 ; Desktop simulator: builds the real display firmware natively with the BLE link
 ; to the controller mocked (sim/comms) and an SDL window as the panel (sim/driver).
 ; All host shims for Arduino/ESP/FreeRTOS/FS/Preferences/WiFi live in sim/platform.

--- a/test/test_puckflow_latch/native_stubs/Arduino.h
+++ b/test/test_puckflow_latch/native_stubs/Arduino.h
@@ -1,0 +1,13 @@
+// Native-host stand-in for the real Arduino.h (ESP32 core), scoped to what
+// PressureController.cpp actually needs it for.
+//
+// PressureController.cpp includes <Arduino.h> only for the ESP_LOGI() macro
+// used once in reset() — everything else it touches is plain STL/math and
+// compiles natively without it. The real ESP32 Arduino.h pulls in the whole
+// FreeRTOS/ESP-IDF/lwIP stack, none of which exists (or is needed) for a
+// host build, and none of which `platform = native` can build against.
+//
+// test_puckflow_latch.cpp #defines ESP_LOGI to a no-op before pulling in
+// PressureController.cpp, so this header intentionally defines nothing —
+// its only job is to satisfy the #include so the real header isn't sought.
+// Picked up ahead of the real Arduino.h via -I ordering in platformio.ini.

--- a/test/test_puckflow_latch/test_puckflow_latch.cpp
+++ b/test/test_puckflow_latch/test_puckflow_latch.cpp
@@ -1,0 +1,142 @@
+// Unit tests: PressureController puck-flow/puck-resistance estimator arming
+// across successive shots in one power session (GH #839).
+// Host-side, no ESP32/Arduino/BLE runtime — pio test -e native_puckflow.
+
+#include <unity.h>
+
+#include <cmath>
+#include <cstdio>
+
+// PressureController.cpp's only non-STL dependency is one ESP_LOGI() call
+// in reset() (an ESP-IDF logging macro); no-op it for the native build — it
+// doesn't affect the estimator math under test. SimpleKalmanFilter has no
+// Arduino/ESP-IDF dependency at all, so both TUs compile natively as-is.
+#define ESP_LOGI(tag, fmt, ...) ((void)0)
+
+#include "SimpleKalmanFilter/SimpleKalmanFilter.cpp"
+#include "PressureController/PressureController.cpp"
+
+// ---------------------------------------------------------------------------
+// Test fixture: drives PressureController through synthetic brew shots
+// (pressure ramp -> hold -> rapid drop at brew-off), matching the pressure
+// trace shape the estimator's own arming comment describes (virtualScale()
+// puck-state machine in PressureController.cpp). Only the public API
+// (getPuckResistance()/getCoffeeFlowRate()) is used for assertions, no
+// private-state access.
+// ---------------------------------------------------------------------------
+
+struct ShotRig {
+    static constexpr float kDt = 0.03f; // matches DimmedPump's real 30 ms loop task
+    static constexpr float kHoldBar = 9.0f;
+    static constexpr float kRampSec = 3.0f;
+    static constexpr float kHoldSec = 3.0f; // brew window tuned so a clean shot arms
+                                            // comfortably within it but a shot that
+                                            // inherits the previous shot's un-reset
+                                            // filter state (the #839 bug) does not
+    static constexpr float kDropSec = 0.5f;
+
+    float rawPressureSetpoint = 0.0f;
+    float rawFlowSetpoint = 0.0f; // pressure-only control mode
+    float rawPressure = 0.0f;
+    float controllerOutput = 0.0f;
+    int valveStatus = 0;
+    PressureController controller;
+
+    ShotRig()
+        : controller(kDt, &rawPressureSetpoint, &rawFlowSetpoint, &rawPressure, &controllerOutput, &valveStatus) {
+        controller.setPumpFlowPolyCoeffs(0.0f, 0.0f, -0.5854f, 10.79f); // repo default coeffs
+    }
+
+    void tick() { controller.update(PressureController::ControlMode::PRESSURE); }
+
+    // Ramps pressure 0 -> kHoldBar then holds it, i.e. the shape of an actual
+    // brew's pressure trace while water is flowing through the puck. Returns
+    // whether the estimator armed (public API only) before the shot ends —
+    // this is the window where a real machine would report nonzero pf/pr.
+    bool runBrewWindow() {
+        rawPressureSetpoint = kHoldBar;
+        valveStatus = 1;
+
+        const int rampSteps = static_cast<int>(kRampSec / kDt);
+        for (int i = 0; i < rampSteps; ++i) {
+            rawPressure = kHoldBar * (static_cast<float>(i) / static_cast<float>(rampSteps));
+            tick();
+        }
+
+        const int holdSteps = static_cast<int>(kHoldSec / kDt);
+        for (int i = 0; i < holdSteps; ++i) {
+            rawPressure = kHoldBar;
+            tick();
+        }
+
+        return std::isfinite(controller.getPuckResistance()) && controller.getCoffeeFlowRate() > 0.0f;
+    }
+
+    // End-of-brew depressurization: pressure drops rapidly back to 0 as the
+    // group valve closes. This is what leaves a residual in the un-reset
+    // IIR-filtered accumulators (_filteredPressureDerivative,
+    // _waterThroughPuckFlowRate) ahead of the fix.
+    void endShot() {
+        const int dropSteps = static_cast<int>(kDropSec / kDt);
+        for (int i = 0; i < dropSteps; ++i) {
+            rawPressure = kHoldBar * (1.0f - static_cast<float>(i + 1) / static_cast<float>(dropSteps));
+            tick();
+        }
+        rawPressure = 0.0f;
+        rawPressureSetpoint = 0.0f;
+        valveStatus = 0;
+        tick();
+    }
+
+    // Mirrors DimmedPump::tare(): both calls run on every BLE tare trigger
+    // (start of brew/flush/water) — see
+    // lib/GaggiMateController/src/peripherals/DimmedPump.cpp.
+    void tareBetweenShots() {
+        controller.tare();
+        controller.reset();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// A single shot on a freshly-constructed controller arms the puck-flow
+// estimator within its own brew window.
+static void test_first_shot_arms_estimator() {
+    ShotRig rig;
+    TEST_ASSERT_TRUE_MESSAGE(rig.runBrewWindow(), "puck-flow estimator should arm during the first shot's brew window");
+}
+
+// GH #839: a second shot, separated from the first only by the BLE
+// tare()/reset() the display sends at brew start, should also arm within its
+// own brew window. Before the fix, tare()/reset() clear the puck-state
+// machine but leave _filteredPressureDerivative and _waterThroughPuckFlowRate
+// un-reset, so the first shot's end-of-brew depressurization transient leaks
+// into the second shot and suppresses the puck-conductance-derivative
+// signature the state machine arms on — reproducing the "pf/pr zero on shots
+// after the first" symptom from #839.
+static void test_second_shot_arms_estimator_after_tare() {
+    ShotRig rig;
+    TEST_ASSERT_TRUE(rig.runBrewWindow());
+    rig.endShot();
+    rig.tareBetweenShots();
+
+    TEST_ASSERT_TRUE_MESSAGE(rig.runBrewWindow(),
+                             "puck-flow estimator should also arm during the second shot's brew window "
+                             "(GH #839: un-reset filter state from the first shot suppresses arming)");
+}
+
+// ---------------------------------------------------------------------------
+// Unity entrypoint
+// ---------------------------------------------------------------------------
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_first_shot_arms_estimator);
+    RUN_TEST(test_second_shot_arms_estimator_after_tare);
+    return UNITY_END();
+}

--- a/test/test_puckflow_latch/test_puckflow_latch.cpp
+++ b/test/test_puckflow_latch/test_puckflow_latch.cpp
@@ -108,10 +108,10 @@ static void test_first_shot_arms_estimator() {
     TEST_ASSERT_TRUE_MESSAGE(rig.runBrewWindow(), "puck-flow estimator should arm during the first shot's brew window");
 }
 
-// GH #839: a second shot, separated from the first only by the BLE
-// tare()/reset() the display sends at brew start, should also arm within its
-// own brew window. Before the fix, tare()/reset() clear the puck-state
-// machine but leave _filteredPressureDerivative and _waterThroughPuckFlowRate
+// GH #839: a second shot, separated from the first only by the BLE tare()
+// the display sends at brew start, should also arm within its own brew
+// window. Before the fix, tare()/reset() clear the puck-state machine but
+// leave _filteredPressureDerivative and _waterThroughPuckFlowRate
 // un-reset, so the first shot's end-of-brew depressurization transient leaks
 // into the second shot and suppresses the puck-conductance-derivative
 // signature the state machine arms on — reproducing the "pf/pr zero on shots
@@ -131,8 +131,8 @@ static void test_second_shot_arms_estimator_after_tare() {
 // Unity entrypoint
 // ---------------------------------------------------------------------------
 
-void setUp(void) {}
-void tearDown(void) {}
+void setUp(void) { /* No shared fixture state. */ }
+void tearDown(void) { /* No shared fixture state. */ }
 
 int main(int argc, char **argv) {
     UNITY_BEGIN();


### PR DESCRIPTION
## Problem

#839: calculated puck flow (`pf`) / puck resistance (`pr`) work on the first
shot after power-on, then read zero on every shot after that.

## Cause

`PressureController::tare()`/`reset()` reset the puck-flow arming state
machine, but not the two IIR-filtered accumulators that feed it
(`_filteredPressureDerivative`, `_waterThroughPuckFlowRate`) or
`_lastPuckConductance`/`_puckConductance`. Their values from the end of one
shot (a sharp pressure-drop transient at group-valve-close) leak into the
next shot and can mask the signature the estimator looks for, so it never
arms.

## Fix

Reset those fields too, in both `tare()` and `reset()`.

## Test

Added `test/test_puckflow_latch` (native, `pio test -e native_puckflow`,
modeled on `native_autotune`): a two-shot scenario separated by
`tare()`+`reset()`. Fails on `master`, passes with the fix.

## Note

There's a separate, likely-related issue where `NimBLEClientController::tare()`
is a fire-and-forget BLE write with no delivery confirmation — if it's
dropped, the controller-side reset never runs at all. Not fixed here;
flagging as a possible follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pressure and puck-flow estimator behavior when starting a new brew shot after tare or reset.
  * Ensured estimator state is correctly reinitialized between successive shots.

* **Tests**
  * Added native automated coverage for pressure ramping, holding, depressurization, and repeated tare/reset cycles.
  * Added validation that puck-flow estimation arms correctly on the first shot and subsequent shots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->