### PR TITLE
Fix shot history sample timestamps

### DIFF
--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -7,24 +7,25 @@
 // All values little-endian. Floats are IEEE-754 32-bit.
 // File extension: .slog
 // Layout:
-//   Header (fixed size = 128 bytes) followed by contiguous sample records.
+//   Header (v1-v4 = 128 bytes, v5+ = 512 bytes) followed by contiguous sample records.
 //   Header fields set at start; sampleCount & durationMs patched at end.
 // Per-sample record fields are ALWAYS present in fixed order.
-//   tick(uint16_t), tt(uint16_t), ct(uint16_t), tp(uint16_t), cp(uint16_t), fl(int16_t), tf(int16_t), pf(int16_t), vf(int16_t),
+//   elapsedMs(uint32_t), tt(uint16_t), ct(uint16_t), tp(uint16_t), cp(uint16_t), fl(int16_t), tf(int16_t), pf(int16_t), vf(int16_t),
 //   v(uint16_t), ev(uint16_t), pr(uint16_t), si(uint16_t)
 // Values are stored as scaled integers (see comments per field below).
-// Sample size = 13 fields * 2 bytes = 26 bytes (v5+ format). Phase data moved to header transitions.
+// Sample size: v1-v5 = 26 bytes (13 x uint16_t); v6 = 28 bytes because t is uint32_t.
+// Phase data moved to header transitions in v5.
 // Older files may have fewer fields - use fieldsMask to determine layout.
 
 static constexpr uint32_t SHOT_LOG_MAGIC = 0x544F4853; // 'S''H''O''T' little-endian 0x54 0x4F 0x48 0x53
-static constexpr uint8_t SHOT_LOG_VERSION = 5;
+static constexpr uint8_t SHOT_LOG_VERSION = 6;
 static constexpr uint16_t SHOT_LOG_HEADER_SIZE = 512;
 static constexpr uint16_t SHOT_LOG_SAMPLE_INTERVAL_MS = 250; // nominal recording interval
 static constexpr uint32_t SHOT_LOG_FIELDS_MASK_ALL = 0x1FFF; // 13 fields present (removed phase number)
-static constexpr uint32_t SHOT_LOG_SAMPLE_SIZE = 26;
+static constexpr uint32_t SHOT_LOG_SAMPLE_SIZE = 28;
 
 // Field bit positions (for future expansion)
-static constexpr uint32_t SHOT_LOG_FIELD_T = 0x0001;  // tick (bit 0)
+static constexpr uint32_t SHOT_LOG_FIELD_T = 0x0001;  // elapsed time (bit 0)
 static constexpr uint32_t SHOT_LOG_FIELD_TT = 0x0002; // target temp (bit 1)
 static constexpr uint32_t SHOT_LOG_FIELD_CT = 0x0004; // current temp (bit 2)
 static constexpr uint32_t SHOT_LOG_FIELD_TP = 0x0008; // target pressure (bit 3)
@@ -95,15 +96,17 @@ struct ShotLogHeader {
 #pragma pack(pop)
 
 // Scaled values:
-//   tick: sample index (0.25 s steps) -> milliseconds = tick * SHOT_LOG_SAMPLE_INTERVAL_MS
+//   t: actual elapsed milliseconds from shotStart (v6+). In v1-v5 this was a
+//      uint16_t sample index converted with sampleInterval.
 //   tt / ct: temperature in °C * 10 (0.1 °C resolution)
 //   tp / cp: pressure in bar * 10 (0.1 bar resolution)
 //   fl / tf / pf / vf: flow in ml/s * 100 (0.01 ml/s resolution)
 //   v / ev: weight in g * 10 (0.1 g resolution)
 //   pr: puck resistance * 100 (0.01 step, saturates at uint16_t max)
 //   si: system info bit-packed (see SYSTEM_INFO_* constants)
+#pragma pack(push, 1)
 struct ShotLogSample {
-    uint16_t t;  // sample index (0.25 s ticks)
+    uint32_t t;  // actual elapsed milliseconds from shotStart
     uint16_t tt; // target temp * 10
     uint16_t ct; // current temp * 10
     uint16_t tp; // target pressure * 10
@@ -117,6 +120,7 @@ struct ShotLogSample {
     uint16_t pr; // puck resistance * 100
     uint16_t si; // system info bit-packed
 };
+#pragma pack(pop)
 
 static_assert(sizeof(ShotLogHeader) == SHOT_LOG_HEADER_SIZE, "ShotLogHeader size mismatch");
 static_assert(sizeof(ShotLogSample) == SHOT_LOG_SAMPLE_SIZE, "ShotLogSample size mismatch");

--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -148,8 +148,10 @@ void ShotHistoryPlugin::record() {
         lastBluetoothWeight = btWeight;
 
         ShotLogSample sample{};
-        uint32_t tick = sampleCount <= 0xFFFF ? sampleCount : 0xFFFF;
-        sample.t = static_cast<uint16_t>(tick);
+        // Capture when this sampling pass actually runs. Older formats inferred
+        // time from sampleCount, which compressed the chart whenever task/SD
+        // overhead made the nominal 250 ms loop run late.
+        sample.t = millis() - shotStart;
         sample.tt = encodeUnsigned(controller->getTargetTemp(), TEMP_SCALE, TEMP_MAX_VALUE);
         sample.ct = encodeUnsigned(currentTemperature, TEMP_SCALE, TEMP_MAX_VALUE);
         sample.tp = encodeUnsigned(controller->getTargetPressure(), PRESSURE_SCALE, PRESSURE_MAX_VALUE);
@@ -601,10 +603,24 @@ void ShotHistoryPlugin::loadNotes(const String &id, JsonDocument &notes) {
 
 void ShotHistoryPlugin::loopTask(void *arg) {
     auto *plugin = static_cast<ShotHistoryPlugin *>(arg);
+    TickType_t lastWakeTime = xTaskGetTickCount();
+    const TickType_t interval = pdMS_TO_TICKS(SHOT_LOG_SAMPLE_INTERVAL_MS);
     while (true) {
         plugin->record();
-        // Use canonical interval from shot log format to avoid divergence.
-        vTaskDelay(SHOT_LOG_SAMPLE_INTERVAL_MS / portTICK_PERIOD_MS);
+
+        // If record() ran past the next deadline, the measurements that should
+        // have occurred during that gap cannot be recovered. Rebase the cadence
+        // from now instead of running immediate catch-up passes with nearly
+        // identical capture times. The v6 timestamps preserve the visible gap.
+        const TickType_t now = xTaskGetTickCount();
+        const TickType_t nextDeadline = lastWakeTime + interval;
+        if (static_cast<int32_t>(now - nextDeadline) >= 0) {
+            lastWakeTime = now;
+        }
+
+        // Keep the cadence tied to an absolute schedule so time spent in
+        // record() does not accumulate into every subsequent interval.
+        vTaskDelayUntil(&lastWakeTime, interval);
     }
 }
 
@@ -964,9 +980,20 @@ void ShotHistoryPlugin::rebuildIndex() {
             ShotLogSample sample{};
             shotFile.seek(shotHeader.headerSize, SeekSet);
             for (uint32_t s = 0; s < shotHeader.sampleCount; s++) {
-                if (shotFile.read(reinterpret_cast<uint8_t *>(&sample), sizeof(sample)) != sizeof(sample)) {
+                // v1-v5 used a 26-byte record with a 16-bit t field. The
+                // aggregate fields begin two bytes later in v6 because t is
+                // now uint32_t; decode both layouts while rebuilding indexes.
+                const size_t expectedSampleSize = shotHeader.version >= 6 ? 28 : 26;
+                const size_t sampleSize = shotHeader.reserved0 ? shotHeader.reserved0 : expectedSampleSize;
+                if (sampleSize != expectedSampleSize) {
                     break;
                 }
+                uint8_t raw[sizeof(ShotLogSample)]{};
+                if (shotFile.read(raw, sampleSize) != sampleSize) {
+                    break;
+                }
+                const size_t valueOffset = shotHeader.version >= 6 ? 4 : 2;
+                memcpy(reinterpret_cast<uint8_t *>(&sample.tt), raw + valueOffset, sampleSize - valueOffset);
                 tempSum += sample.ct;
                 tempCount++;
                 if (sample.cp > maxPressure) {

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -190,9 +190,10 @@ export function parseBinaryShot(arrayBuffer, id) {
     brewDelay = view.getUint16(110 + 12 * 29 + 2, true);
   }
 
-  // Calculate expected sample size from fieldsMask
+  // v6 stores the timestamp as uint32 elapsed milliseconds. Older versions
+  // store a uint16 sample index which is multiplied by sampleInterval.
   const fieldCount = countSetBits(fieldsMask);
-  const expectedSampleSize = fieldCount * 2; // Each field is 16 bits = 2 bytes
+  const expectedSampleSize = fieldCount * 2 + (version >= 6 ? 2 : 0);
 
   if (deviceSampleSize !== expectedSampleSize) {
     throw new Error(
@@ -238,20 +239,25 @@ export function parseBinaryShot(arrayBuffer, id) {
     const base = headerSize + i * sampleSize;
     const sample = {};
 
-    // Parse each field dynamically
+    // Parse each field dynamically. The first field grew from 2 to 4 bytes in
+    // v6; all remaining fields retain their existing order and width.
+    let offset = base;
     for (let fieldIdx = 0; fieldIdx < fieldLayout.length; fieldIdx++) {
       const field = fieldLayout[fieldIdx];
-      const offset = base + fieldIdx * 2; // Each field is 2 bytes
 
       let rawValue;
-      if (field.type === 'int16') {
+      if (version >= 6 && field.bitPos === FIELD_BITS.T) {
+        rawValue = view.getUint32(offset, true);
+      } else if (field.type === 'int16') {
         rawValue = view.getInt16(offset, true);
       } else {
         rawValue = view.getUint16(offset, true);
       }
 
       let finalValue;
-      if (field.transform) {
+      if (version >= 6 && field.bitPos === FIELD_BITS.T) {
+        finalValue = rawValue;
+      } else if (field.transform) {
         finalValue = field.transform(rawValue, sampleInterval);
       } else if (field.scale) {
         finalValue = rawValue / field.scale;
@@ -260,6 +266,7 @@ export function parseBinaryShot(arrayBuffer, id) {
       }
 
       sample[field.name] = finalValue;
+      offset += version >= 6 && field.bitPos === FIELD_BITS.T ? 4 : 2;
     }
 
     // For v5+ files, reconstruct phase information from transitions


### PR DESCRIPTION
- Use actual elapsed time for each recorded tick
- Change to TaskDelayUntil to delay to 250ms inclusive (not 250ms + processing)
- Shot history format incremented to v6 to accommodate larger timestamp field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shot history now records elapsed time in milliseconds for longer, more accurate recordings.
  * Updated the shot log format to version 6 with expanded sample data.

* **Bug Fixes**
  * Improved recording reliability by preventing catch-up cycles after timing overruns.
  * Added compatibility for reading both legacy and current shot history files.
  * Improved timestamp handling when viewing version 6 shot history files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->