### PR TITLE
feat(display): Print The Shot upload plugin with WebUI settings and manual print

### DIFF
--- a/sim/platform/HTTPClient.h
+++ b/sim/platform/HTTPClient.h
@@ -1,36 +1,190 @@
-// Host shim for HTTPClient.h: outbound HTTP is unavailable in the simulator.
+// Host shim for HTTPClient.h: a minimal real HTTP/1.1 client over POSIX
+// sockets, plain HTTP only (no TLS). The simulator has no wifi stack, but the
+// host loopback network works, which lets plugins that push data out (e.g.
+// ShotUploadPlugin) be exercised end-to-end against a local server.
 #pragma once
 
 #include "WString.h"
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstdlib>
+#include <fcntl.h>
+#include <netdb.h>
 #include <stdint.h>
+#include <string>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #define HTTP_CODE_OK 200
 
 class HTTPClient {
   public:
-    bool begin(const String &url) {
-        (void)url;
-        return true;
-    }
+    HTTPClient() = default;
+    ~HTTPClient() { end(); }
+    HTTPClient(const HTTPClient &) = delete;
+    HTTPClient &operator=(const HTTPClient &) = delete;
+
+    bool begin(const String &url) { return begin(url.c_str()); }
     bool begin(const char *url) {
-        (void)url;
+        end();
+        _host.clear();
+        _path = "/";
+        _port = 80;
+
+        // Accept only http:// URLs; anything else fails like a real client would.
+        const std::string u(url ? url : "");
+        if (u.compare(0, 7, "http://") != 0) {
+            return false;
+        }
+        std::string rest = u.substr(7);
+        size_t slash = rest.find('/');
+        std::string authority = slash == std::string::npos ? rest : rest.substr(0, slash);
+        if (slash != std::string::npos) {
+            _path = rest.substr(slash);
+        }
+        size_t colon = authority.rfind(':');
+        if (colon != std::string::npos) {
+            _host = authority.substr(0, colon);
+            _port = atoi(authority.substr(colon + 1).c_str());
+            if (_port <= 0 || _port > 65535) {
+                return false;
+            }
+        } else {
+            _host = authority;
+        }
+        if (_host.empty()) {
+            return false;
+        }
+        _headers.clear();
         return true;
     }
-    void end() {}
-    void setTimeout(uint16_t t) { (void)t; }
-    void setConnectTimeout(int t) { (void)t; }
-    void addHeader(const String &name, const String &value) {
-        (void)name;
-        (void)value;
+
+    void end() {
+        if (_fd >= 0) {
+            close(_fd);
+            _fd = -1;
+        }
+        _lastBody.clear();
     }
-    int GET() { return -1; }
-    int POST(const String &payload) {
-        (void)payload;
-        return -1;
-    }
-    String getString() { return String(); }
+
+    void setTimeout(uint16_t t) { _timeoutMs = t; }
+    void setConnectTimeout(int t) { _connectTimeoutMs = t; }
+    void addHeader(const String &name, const String &value) { _headers += std::string(name.c_str()) + ": " + value.c_str() + "\r\n"; }
+
+    int GET() { return request("GET", std::string()); }
+    int POST(const String &payload) { return request("POST", std::string(payload.c_str(), payload.length())); }
+
+    String getString() { return String(_lastBody.c_str()); }
     String errorToString(int code) {
         (void)code;
-        return String("disabled in simulator");
+        return String("sim socket error");
     }
+
+  private:
+    bool connectSocket() {
+        struct addrinfo hints{};
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        struct addrinfo *res = nullptr;
+        if (getaddrinfo(_host.c_str(), std::to_string(_port).c_str(), &hints, &res) != 0 || !res) {
+            return false;
+        }
+        // getaddrinfo may hand out IPv6 (::1) first while the target listens on
+        // IPv4 only (or vice versa); try every address until one connects.
+        bool ok = false;
+        for (struct addrinfo *p = res; p && !ok; p = p->ai_next) {
+            _fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+            if (_fd < 0) {
+                continue;
+            }
+            // Non-blocking connect so a dead host cannot hang the sim window.
+            int flags = fcntl(_fd, F_GETFL, 0);
+            fcntl(_fd, F_SETFL, flags | O_NONBLOCK);
+            if (connect(_fd, p->ai_addr, p->ai_addrlen) == 0) {
+                ok = true;
+            } else if (errno == EINPROGRESS) {
+                fd_set wset;
+                FD_ZERO(&wset);
+                FD_SET(_fd, &wset);
+                struct timeval tv{};
+                tv.tv_sec = _connectTimeoutMs / 1000;
+                tv.tv_usec = (_connectTimeoutMs % 1000) * 1000;
+                if (select(_fd + 1, nullptr, &wset, nullptr, &tv) == 1) {
+                    int err = 0;
+                    socklen_t len = sizeof(err);
+                    if (getsockopt(_fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0 && err == 0) {
+                        ok = true;
+                    }
+                }
+            }
+            fcntl(_fd, F_SETFL, flags); // back to blocking for the read
+            if (!ok) {
+                close(_fd);
+                _fd = -1;
+            }
+        }
+        freeaddrinfo(res);
+        if (!ok) {
+            end();
+        }
+        return ok;
+    }
+
+    int request(const std::string &method, const std::string &payload) {
+        _lastBody.clear();
+        if (_host.empty() || !connectSocket()) {
+            return -1;
+        }
+        struct timeval tv{};
+        tv.tv_sec = _timeoutMs / 1000;
+        tv.tv_usec = (_timeoutMs % 1000) * 1000;
+        setsockopt(_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+        std::string req = method + " " + _path + " HTTP/1.1\r\nHost: " + _host + "\r\n" + _headers;
+        if (_headers.find("Content-Type") == std::string::npos && !payload.empty()) {
+            req += "Content-Type: application/x-www-form-urlencoded\r\n";
+        }
+        req += "Content-Length: " + std::to_string(payload.size()) + "\r\nConnection: close\r\n\r\n" + payload;
+
+        size_t sentTotal = 0;
+        while (sentTotal < req.size()) {
+            ssize_t sent = send(_fd, req.data() + sentTotal, req.size() - sentTotal, 0);
+            if (sent <= 0) {
+                end();
+                return -1;
+            }
+            sentTotal += (size_t)sent;
+        }
+        std::string response;
+        char buf[4096];
+        ssize_t n;
+        while ((n = recv(_fd, buf, sizeof(buf), 0)) > 0) {
+            response.append(buf, (size_t)n);
+        }
+        end();
+
+        // Parse "HTTP/1.1 200 OK" and split headers from body.
+        if (response.compare(0, 5, "HTTP/") != 0) {
+            return -1;
+        }
+        size_t sp1 = response.find(' ');
+        size_t sp2 = response.find(' ', sp1 + 1);
+        if (sp1 == std::string::npos || sp2 == std::string::npos) {
+            return -1;
+        }
+        int code = atoi(response.substr(sp1 + 1, sp2 - sp1 - 1).c_str());
+        size_t headerEnd = response.find("\r\n\r\n");
+        _lastBody = headerEnd == std::string::npos ? std::string() : response.substr(headerEnd + 4);
+        return code;
+    }
+
+    std::string _host;
+    std::string _path;
+    std::string _headers;
+    std::string _lastBody;
+    int _port = 80;
+    int _fd = -1;
+    int _timeoutMs = 10000;
+    int _connectTimeoutMs = 5000;
 };

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -18,6 +18,7 @@
 #include <display/plugins/BoilerFillPlugin.h>
 #include <display/plugins/LedControlPlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
+#include <display/plugins/ShotUploadPlugin.h>
 #include <display/plugins/SmartGrindPlugin.h>
 #include <display/plugins/WebUIPlugin.h>
 #ifndef GAGGIMATE_SIM // network/BLE plugins are device-only
@@ -99,6 +100,7 @@ void Controller::setup() {
     pluginManager->registerPlugin(new ImprovPlugin());
 #endif
     pluginManager->registerPlugin(&ShotHistory);
+    pluginManager->registerPlugin(&ShotUpload);
 #ifndef GAGGIMATE_SIM
     pluginManager->registerPlugin(&BLEScales);
 #endif

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -161,18 +161,18 @@ void Settings::setHomeAssistantPassword(const String &homeAssistantPassword) {
     this->homeAssistantPassword.set(homeAssistantPassword);
 }
 
-void Settings::setShotUploadEnabled(const bool shotUploadEnabled) { this->shotUploadEnabled.set(shotUploadEnabled); }
+void Settings::setShotUploadEnabled(const bool enabled) { this->shotUploadEnabled.set(enabled); }
 
-void Settings::setShotUploadServer(const String &shotUploadServer) { this->shotUploadServer.set(shotUploadServer); }
+void Settings::setShotUploadServer(const String &server) { this->shotUploadServer.set(server); }
 
-void Settings::setShotUploadEndpoint(const String &shotUploadEndpoint) { this->shotUploadEndpoint.set(shotUploadEndpoint); }
+void Settings::setShotUploadEndpoint(const String &endpoint) { this->shotUploadEndpoint.set(endpoint); }
 
-void Settings::setShotUploadMachineId(const String &shotUploadMachineId) {
-    this->shotUploadMachineId.set(shotUploadMachineId);
+void Settings::setShotUploadMachineId(const String &machineId) {
+    this->shotUploadMachineId.set(machineId);
 }
 
-void Settings::setShotUploadRetries(const int shotUploadRetries) {
-    this->shotUploadRetries.set(std::clamp(shotUploadRetries, 0, 10));
+void Settings::setShotUploadRetries(const int retries) {
+    this->shotUploadRetries.set(std::clamp(retries, 0, 10));
 }
 
 void Settings::setMomentaryButtons(bool momentary_buttons) { momentaryButtons.set(momentary_buttons); }

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -161,6 +161,20 @@ void Settings::setHomeAssistantPassword(const String &homeAssistantPassword) {
     this->homeAssistantPassword.set(homeAssistantPassword);
 }
 
+void Settings::setShotUploadEnabled(const bool shotUploadEnabled) { this->shotUploadEnabled.set(shotUploadEnabled); }
+
+void Settings::setShotUploadServer(const String &shotUploadServer) { this->shotUploadServer.set(shotUploadServer); }
+
+void Settings::setShotUploadEndpoint(const String &shotUploadEndpoint) { this->shotUploadEndpoint.set(shotUploadEndpoint); }
+
+void Settings::setShotUploadMachineId(const String &shotUploadMachineId) {
+    this->shotUploadMachineId.set(shotUploadMachineId);
+}
+
+void Settings::setShotUploadRetries(const int shotUploadRetries) {
+    this->shotUploadRetries.set(std::clamp(shotUploadRetries, 0, 10));
+}
+
 void Settings::setMomentaryButtons(bool momentary_buttons) { momentaryButtons.set(momentary_buttons); }
 
 void Settings::setTimezone(String timezone) { this->timezone.set(timezone); }

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -105,6 +105,11 @@ class Settings {
     String getHomeAssistantPassword() const { return homeAssistantPassword.get(); }
     int getHomeAssistantPort() const { return homeAssistantPort.get(); }
     String getHomeAssistantTopic() const { return homeAssistantTopic.get(); }
+    bool isShotUploadEnabled() const { return shotUploadEnabled.get(); }
+    String getShotUploadServer() const { return shotUploadServer.get(); }
+    String getShotUploadEndpoint() const { return shotUploadEndpoint.get(); }
+    String getShotUploadMachineId() const { return shotUploadMachineId.get(); }
+    int getShotUploadRetries() const { return shotUploadRetries.get(); }
     bool isMomentaryButtons() const { return momentaryButtons.get(); }
     String getTimezone() const { return timezone.get(); }
     bool isClock24hFormat() const { return clock24hFormat.get(); }
@@ -192,6 +197,11 @@ class Settings {
     void setHomeAssistantIP(const String &homeAssistantIP);
     void setHomeAssistantPort(int homeAssistantPort);
     void setHomeAssistantTopic(const String &homeAssistantTopic);
+    void setShotUploadEnabled(bool shotUploadEnabled);
+    void setShotUploadServer(const String &shotUploadServer);
+    void setShotUploadEndpoint(const String &shotUploadEndpoint);
+    void setShotUploadMachineId(const String &shotUploadMachineId);
+    void setShotUploadRetries(const int shotUploadRetries);
     void setMomentaryButtons(bool momentary_buttons);
     void setTimezone(String timezone);
     void setClockFormat(bool format_24h);
@@ -275,6 +285,11 @@ class Settings {
     Property<String> homeAssistantIP{registry, "ha_i", ""};
     Property<int> homeAssistantPort{registry, "ha_p", 1883};
     Property<String> homeAssistantTopic{registry, "ha_t", DEFAULT_HOME_ASSISTANT_TOPIC};
+    Property<bool> shotUploadEnabled{registry, "su_en", false};
+    Property<String> shotUploadServer{registry, "su_s", ""};
+    Property<String> shotUploadEndpoint{registry, "su_e", "upload"};
+    Property<String> shotUploadMachineId{registry, "su_m", "Gaggimate"};
+    Property<int> shotUploadRetries{registry, "su_r", 3};
     Property<bool> momentaryButtons{registry, "mb", false};
     Property<String> timezone{registry, "tz", DEFAULT_TIMEZONE};
     Property<bool> clock24hFormat{registry, "clk_24h", true};

--- a/src/display/plugins/ShotUploadPlugin.cpp
+++ b/src/display/plugins/ShotUploadPlugin.cpp
@@ -45,7 +45,7 @@ void ShotUploadPlugin::loop() {
 #endif
 }
 
-void ShotUploadPlugin::taskLoop(void *arg) {
+[[noreturn]] void ShotUploadPlugin::taskLoop(void *arg) {
     auto *plugin = static_cast<ShotUploadPlugin *>(arg);
     while (true) {
         plugin->processOnce();
@@ -63,7 +63,7 @@ void ShotUploadPlugin::requestUpload(uint32_t shotId) {
 }
 
 void ShotUploadPlugin::processOnce() {
-    Settings &settings = controller->getSettings();
+    const Settings &settings = controller->getSettings();
 
     uint32_t shotId = 0;
     {
@@ -91,7 +91,7 @@ void ShotUploadPlugin::processOnce() {
     // Not on the network: drop the shot (no offline queueing).
     if (WiFi.status() != WL_CONNECTED) {
         ESP_LOGW("ShotUploadPlugin", "Shot %u: not connected, dropped", shotId);
-        String id = String(shotId, 10);
+        auto id = String(shotId, 10);
         while (id.length() < 6) {
             id = "0" + id;
         }
@@ -122,7 +122,7 @@ void ShotUploadPlugin::processOnce() {
         ESP_LOGI("ShotUploadPlugin", "Shot %u uploaded successfully (%u bytes)", shotId, json.length());
     } else {
         ESP_LOGW("ShotUploadPlugin", "Shot %u: dropped after %d failed attempts", shotId, retries + 1);
-        String id = String(shotId, 10);
+        auto id = String(shotId, 10);
         while (id.length() < 6) {
             id = "0" + id;
         }
@@ -132,11 +132,22 @@ void ShotUploadPlugin::processOnce() {
     }
 }
 
-bool ShotUploadPlugin::upload(const String &json, uint32_t shotId, String &error) {
+bool ShotUploadPlugin::upload(const String &json, uint32_t, String &error) {
     // The Decent plugin passes a clean alphanumeric machine id in the query.
     String machineId = cleanMachineId(controller->getSettings().getShotUploadMachineId());
-    String url = "http://" + controller->getSettings().getShotUploadServer() + "/"
-                 + controller->getSettings().getShotUploadEndpoint() + "?machine_id=" + machineId;
+    // The shot server is typically a LAN-only service (Decent's own print
+    // plugin talks plain HTTP to a local host). Honour an explicit scheme in
+    // the configured server (e.g. https://...) so TLS setups work too, and
+    // fall back to http for the default LAN case.
+    String server = controller->getSettings().getShotUploadServer();
+    // NOSONAR: the shot server is a user-configured LAN endpoint and the
+    // Decent print ecosystem is plain-HTTP based; operators who need TLS can
+    // configure an https:// server, which is honoured verbatim above.
+    if (server.indexOf("://") < 0) {
+        server = "http://" + server;
+    }
+    String url = server + "/" + controller->getSettings().getShotUploadEndpoint()
+                 + "?machine_id=" + machineId;
 
     HTTPClient http;
     http.setConnectTimeout(5000);
@@ -170,7 +181,7 @@ String ShotUploadPlugin::cleanMachineId(const String &raw) const {
 
 bool ShotUploadPlugin::buildShotJson(uint32_t shotId, String &outJson) {
     // ShotHistoryPlugin writes .slog files zero-padded to 6 digits (/h/000000.slog).
-    String id = String(shotId, 10);
+    auto id = String(shotId, 10);
     while (id.length() < 6) {
         id = "0" + id;
     }

--- a/src/display/plugins/ShotUploadPlugin.cpp
+++ b/src/display/plugins/ShotUploadPlugin.cpp
@@ -1,0 +1,238 @@
+#include <display/plugins/ShotUploadPlugin.h>
+
+#include <HTTPClient.h>
+#include <LittleFS.h>
+#include <SD_MMC.h>
+#include <WiFi.h>
+#include <ctype.h>
+#include <display/core/Controller.h>
+#include <display/core/Settings.h>
+#include <display/util/PsramAllocator.h>
+#include <version.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+// .slog stores scaled integers; these divisors (same values as the encoder in
+// ShotHistoryPlugin) convert back to physical units for the JSON payload.
+static constexpr float TEMP_SCALE_DIV = 10.0f;      // °C * 10
+static constexpr float PRESSURE_SCALE_DIV = 10.0f;  // bar * 10
+static constexpr float FLOW_SCALE_DIV = 100.0f;     // ml/s * 100
+static constexpr float WEIGHT_SCALE_DIV = 10.0f;    // g * 10
+static constexpr float RESISTANCE_SCALE_DIV = 100.0f; // puck resistance * 100
+
+ShotUploadPlugin ShotUpload;
+
+void ShotUploadPlugin::setup(Controller *c, PluginManager *pm) {
+    controller = c;
+    pluginManager = pm;
+    if (controller->isSDCard()) {
+        fs = &SD_MMC;
+    }
+
+    // A shot is fully persisted (file closed, header patched, index entry
+    // appended) by the time ShotHistoryPlugin fires evt:history-shot-saved.
+    pm->on("evt:history-shot-saved", [this](Event const &event) { enqueueShot(static_cast<uint32_t>(event.getInt("id"))); });
+
+#ifndef GAGGIMATE_SIM // the simulator drives loop() cooperatively instead
+    xTaskCreatePinnedToCore(taskLoop, "ShotUploadPlugin", configMINIMAL_STACK_SIZE * 8, this, 1, &taskHandle, 0);
+#endif
+}
+
+void ShotUploadPlugin::loop() {
+#ifdef GAGGIMATE_SIM
+    processOnce();
+#endif
+}
+
+void ShotUploadPlugin::taskLoop(void *arg) {
+    auto *plugin = static_cast<ShotUploadPlugin *>(arg);
+    while (true) {
+        plugin->processOnce();
+        vTaskDelay(pdMS_TO_TICKS(200));
+    }
+}
+
+void ShotUploadPlugin::enqueueShot(uint32_t shotId) {
+    std::lock_guard<std::mutex> guard(queueMutex);
+    uploadQueue.push(shotId);
+}
+
+void ShotUploadPlugin::requestUpload(uint32_t shotId) {
+    enqueueShot(shotId);
+}
+
+void ShotUploadPlugin::processOnce() {
+    Settings &settings = controller->getSettings();
+
+    uint32_t shotId = 0;
+    {
+        std::lock_guard<std::mutex> guard(queueMutex);
+        if (uploadQueue.empty()) {
+            return;
+        }
+        shotId = uploadQueue.front();
+        uploadQueue.pop();
+    }
+
+    // Feature disabled or misconfigured: drop queued shots instead of
+    // accumulating them forever.
+    if (!settings.isShotUploadEnabled() || settings.getShotUploadServer().isEmpty()) {
+        ESP_LOGW("ShotUploadPlugin", "Shot %u dropped: upload disabled or server not configured", shotId);
+        return;
+    }
+
+    String json;
+    if (!buildShotJson(shotId, json)) {
+        ESP_LOGW("ShotUploadPlugin", "Shot %u: failed to read .slog", shotId);
+        return;
+    }
+
+    // Not on the network: drop the shot (no offline queueing).
+    if (WiFi.status() != WL_CONNECTED) {
+        ESP_LOGW("ShotUploadPlugin", "Shot %u: not connected, dropped", shotId);
+        String id = String(shotId, 10);
+        while (id.length() < 6) {
+            id = "0" + id;
+        }
+        pluginManager->trigger("evt:shot-upload:failed",
+                               "msg", "shot #" + id + ": not connected, not uploaded");
+        return;
+    }
+
+    bool ok = false;
+    String error;
+    int retries = settings.getShotUploadRetries();
+    if (retries < 0) {
+        retries = 0;
+    }
+    // retries = extra attempts after the initial one (setting su_r, default 3).
+    for (int attempt = 0; attempt <= retries && !ok; attempt++) {
+        if (attempt > 0) {
+            vTaskDelay(pdMS_TO_TICKS(RETRY_DELAY_MS));
+        }
+        ok = upload(json, shotId, error);
+        if (!ok) {
+            ESP_LOGW("ShotUploadPlugin", "Shot %u: upload attempt %d/%d failed: %s", shotId, attempt + 1, retries + 1,
+                     error.c_str());
+        }
+    }
+
+    if (ok) {
+        ESP_LOGI("ShotUploadPlugin", "Shot %u uploaded successfully (%u bytes)", shotId, json.length());
+    } else {
+        ESP_LOGW("ShotUploadPlugin", "Shot %u: dropped after %d failed attempts", shotId, retries + 1);
+        String id = String(shotId, 10);
+        while (id.length() < 6) {
+            id = "0" + id;
+        }
+        // Surfaced in the WebUI Print The Shot card so the user sees the failure.
+        pluginManager->trigger("evt:shot-upload:failed",
+                               "msg", "shot #" + id + ": upload failed after " + String(retries) + " retries (" + error + ")");
+    }
+}
+
+bool ShotUploadPlugin::upload(const String &json, uint32_t shotId, String &error) {
+    // The Decent plugin passes a clean alphanumeric machine id in the query.
+    String machineId = cleanMachineId(controller->getSettings().getShotUploadMachineId());
+    String url = "http://" + controller->getSettings().getShotUploadServer() + "/"
+                 + controller->getSettings().getShotUploadEndpoint() + "?machine_id=" + machineId;
+
+    HTTPClient http;
+    http.setConnectTimeout(5000);
+    http.setTimeout(10000);
+    if (!http.begin(url)) {
+        error = "begin failed";
+        return false;
+    }
+    http.addHeader("Content-Type", "application/json");
+    int code = http.POST(json);
+    if (code < 0) {
+        error = "HTTP error " + http.errorToString(code);
+    } else {
+        error = "HTTP " + String(code);
+    }
+    http.end();
+    return code >= 200 && code < 300;
+}
+
+String ShotUploadPlugin::cleanMachineId(const String &raw) const {
+    String cleaned;
+    cleaned.reserve(20);
+    for (size_t i = 0; i < raw.length() && cleaned.length() < 20; i++) {
+        char ch = raw[i];
+        if (isalnum(ch)) {
+            cleaned += ch;
+        }
+    }
+    return cleaned.isEmpty() ? String("UNKNOWN") : cleaned;
+}
+
+bool ShotUploadPlugin::buildShotJson(uint32_t shotId, String &outJson) {
+    // ShotHistoryPlugin writes .slog files zero-padded to 6 digits (/h/000000.slog).
+    String id = String(shotId, 10);
+    while (id.length() < 6) {
+        id = "0" + id;
+    }
+    String path = "/h/" + id + ".slog";
+    File f = fs->open(path, "r");
+    if (!f) {
+        return false;
+    }
+
+    ShotLogHeader header{};
+    if (f.read(reinterpret_cast<uint8_t *>(&header), sizeof(header)) != sizeof(header) || header.magic != SHOT_LOG_MAGIC) {
+        f.close();
+        return false;
+    }
+
+    JsonDocument doc(&psramAllocator);
+    doc["version"] = "2";
+    doc["clock"] = header.startEpoch;
+    doc["timestamp"] = header.startEpoch;
+    JsonArray elapsed = doc["elapsed"].to<JsonArray>();
+    JsonArray pressure = doc["pressure"]["pressure"].to<JsonArray>();
+    JsonArray pressureGoal = doc["pressure"]["goal"].to<JsonArray>();
+    JsonArray flow = doc["flow"]["flow"].to<JsonArray>();
+    JsonArray flowGoal = doc["flow"]["goal"].to<JsonArray>();
+    JsonArray byWeight = doc["flow"]["by_weight"].to<JsonArray>();
+    JsonArray basketTemp = doc["temperature"]["basket"].to<JsonArray>();
+    JsonArray mixTemp = doc["temperature"]["mix"].to<JsonArray>();
+    JsonArray tempGoal = doc["temperature"]["goal"].to<JsonArray>();
+    JsonArray resistance = doc["resistance"]["resistance"].to<JsonArray>();
+    JsonArray weight = doc["totals"]["weight"].to<JsonArray>();
+
+    ShotLogSample sample{};
+    f.seek(header.headerSize, SeekSet);
+    for (uint32_t s = 0; s < header.sampleCount; s++) {
+        if (f.read(reinterpret_cast<uint8_t *>(&sample), sizeof(sample)) != sizeof(sample)) {
+            break;
+        }
+        elapsed.add(s * (SHOT_LOG_SAMPLE_INTERVAL_MS / 1000.0));
+        pressure.add(sample.cp / PRESSURE_SCALE_DIV);
+        pressureGoal.add(sample.tp / PRESSURE_SCALE_DIV);
+        flow.add(sample.fl / FLOW_SCALE_DIV);
+        flowGoal.add(sample.tf / FLOW_SCALE_DIV);
+        byWeight.add(sample.pf / FLOW_SCALE_DIV);
+        basketTemp.add(sample.ct / TEMP_SCALE_DIV);
+        mixTemp.add(sample.ct / TEMP_SCALE_DIV);
+        tempGoal.add(sample.tt / TEMP_SCALE_DIV);
+        resistance.add(sample.pr / RESISTANCE_SCALE_DIV);
+        weight.add(sample.ev / WEIGHT_SCALE_DIV);
+    }
+    f.close();
+
+    doc["profile"]["title"] = header.profileName;
+    doc["profile"]["notes"] = "";
+    doc["meta"]["in"] = 0;
+    doc["meta"]["out"] = header.finalWeight / WEIGHT_SCALE_DIV;
+    doc["meta"]["time"] = header.durationMs / 1000.0;
+    doc["meta"]["bean"].to<JsonObject>(); // present but empty, mirrors Decent schema
+    doc["app"]["app_name"] = "GaggiMate";
+    doc["app"]["app_version"] = BUILD_GIT_VERSION;
+
+    if (serializeJson(doc, outJson) == 0) {
+        return false;
+    }
+    return true;
+}

--- a/src/display/plugins/ShotUploadPlugin.cpp
+++ b/src/display/plugins/ShotUploadPlugin.cpp
@@ -140,11 +140,8 @@ bool ShotUploadPlugin::upload(const String &json, uint32_t, String &error) {
     // the configured server (e.g. https://...) so TLS setups work too, and
     // fall back to http for the default LAN case.
     String server = controller->getSettings().getShotUploadServer();
-    // NOSONAR: the shot server is a user-configured LAN endpoint and the
-    // Decent print ecosystem is plain-HTTP based; operators who need TLS can
-    // configure an https:// server, which is honoured verbatim above.
     if (server.indexOf("://") < 0) {
-        server = "http://" + server;
+        server = "http://" + server; // NOSONAR: LAN-only Decent print server; https:// in the configured server is honoured above
     }
     String url = server + "/" + controller->getSettings().getShotUploadEndpoint()
                  + "?machine_id=" + machineId;

--- a/src/display/plugins/ShotUploadPlugin.h
+++ b/src/display/plugins/ShotUploadPlugin.h
@@ -59,7 +59,7 @@ class ShotUploadPlugin : public Plugin {
     std::queue<uint32_t> uploadQueue; // shot ids awaiting upload
     std::mutex queueMutex;
 
-    static void taskLoop(void *arg);
+    [[noreturn]] static void taskLoop(void *arg);
 };
 
 extern ShotUploadPlugin ShotUpload;

--- a/src/display/plugins/ShotUploadPlugin.h
+++ b/src/display/plugins/ShotUploadPlugin.h
@@ -1,0 +1,67 @@
+#ifndef SHOTUPLOADPLUGIN_H
+#define SHOTUPLOADPLUGIN_H
+
+#include <Arduino.h>
+#include <FS.h>
+#include <LittleFS.h>
+#include <display/core/Plugin.h>
+#include <display/models/shot_log_format.h>
+
+#include <mutex>
+#include <queue>
+
+// Push completed shots to a remote server as Decent-style v2 shot JSON.
+//
+// Subscribes to evt:history-shot-saved (fired by ShotHistoryPlugin once the
+// .slog is finalized and the index entry is persisted), converts the binary
+// .slog into the JSON format consumed by Decent shot visualization/printing
+// servers (see shot_log_format.h for the source mapping), and POSTs it via
+// plain HTTP with a 3-attempt retry. Shots that fail all attempts are dropped
+// (no offline queueing), so nothing is re-uploaded on the next boot.
+//
+// Settings: su_en (enabled), su_s (server URL, e.g. 192.168.1.5:8000),
+// su_e (endpoint, default "upload"), su_m (machine id shown in query params),
+// su_r (retries after the initial upload attempt, default 3). Fires
+// evt:shot-upload:failed (payload "msg") when a shot is dropped.
+class ShotUploadPlugin : public Plugin {
+  public:
+    ShotUploadPlugin() = default;
+
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+    // Manually enqueue a shot for upload (e.g. "print this past shot" from the
+    // WebUI). No-op-safe: the shot is processed by the same queue as auto-saved
+    // shots, on the next processOnce() tick.
+    void requestUpload(uint32_t shotId);
+
+  private:
+    // Delay between retry attempts (attempt count comes from setting su_r).
+    static constexpr int RETRY_DELAY_MS = 2000;
+
+    void processOnce(); // state machine, run from task (device) or loop (sim)
+    void enqueueShot(uint32_t shotId);
+
+    // Parse /h/<id>.slog into Decent v2 JSON; returns false if the file is
+    // missing or its header is corrupt.
+    bool buildShotJson(uint32_t shotId, String &outJson);
+    // POST json to the configured server; true on any 2xx.
+    bool upload(const String &json, uint32_t shotId, String &error);
+    // Clean machine id: alphanumeric only, max 20 chars, "UNKNOWN" fallback
+    // (same rules as the Decent print_the_shot plugin).
+    String cleanMachineId(const String &raw) const;
+
+    Controller *controller = nullptr;
+    PluginManager *pluginManager = nullptr;
+    FS *fs = &LittleFS;
+    xTaskHandle taskHandle = nullptr;
+
+    std::queue<uint32_t> uploadQueue; // shot ids awaiting upload
+    std::mutex queueMutex;
+
+    static void taskLoop(void *arg);
+};
+
+extern ShotUploadPlugin ShotUpload;
+
+#endif // SHOTUPLOADPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -10,6 +10,7 @@
 #include <display/models/profile.h>
 #include <display/plugins/BLEScalePlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
+#include <display/plugins/ShotUploadPlugin.h>
 #include <display/util/PsramStlAllocator.h>
 #include <display/util/PsramWsBuffer.h>
 #include <display/webassets/web_ui_manifest.h>
@@ -539,6 +540,8 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
                     client->text(toWsBuffer(resp));
                 } else if (msgType == "req:flush:start") {
                     handleFlushStart(client->id(), doc);
+                } else if (msgType == "req:shot-upload:start") {
+                    handleShotUploadStart(client->id(), doc);
                 }
             }
         }
@@ -709,6 +712,15 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
                 settings->setHomeAssistantPort(request->arg("haPort").toInt());
             if (request->hasArg("haTopic"))
                 settings->setHomeAssistantTopic(request->arg("haTopic"));
+            settings->setShotUploadEnabled(request->hasArg("shotUploadEnabled"));
+            if (request->hasArg("shotUploadServer"))
+                settings->setShotUploadServer(request->arg("shotUploadServer"));
+            if (request->hasArg("shotUploadEndpoint"))
+                settings->setShotUploadEndpoint(request->arg("shotUploadEndpoint"));
+            if (request->hasArg("shotUploadMachineId"))
+                settings->setShotUploadMachineId(request->arg("shotUploadMachineId"));
+            if (request->hasArg("shotUploadRetries"))
+                settings->setShotUploadRetries(request->arg("shotUploadRetries").toInt());
             settings->setMomentaryButtons(request->hasArg("momentaryButtons"));
             settings->setDelayAdjust(request->hasArg("delayAdjust"));
             if (request->hasArg("brewDelay"))
@@ -824,6 +836,11 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["haIP"] = settings.getHomeAssistantIP();
     doc["haPort"] = settings.getHomeAssistantPort();
     doc["haTopic"] = settings.getHomeAssistantTopic();
+    doc["shotUploadEnabled"] = settings.isShotUploadEnabled();
+    doc["shotUploadServer"] = settings.getShotUploadServer();
+    doc["shotUploadEndpoint"] = settings.getShotUploadEndpoint();
+    doc["shotUploadMachineId"] = settings.getShotUploadMachineId();
+    doc["shotUploadRetries"] = settings.getShotUploadRetries();
     doc["pid"] = settings.getPid();
     doc["pumpModelCoeffs"] = settings.getPumpModelCoeffs();
     doc["pumpSlipCoeffs"] = settings.getPumpSlipCoeffs();
@@ -1048,6 +1065,44 @@ void WebUIPlugin::handleFlushStart(uint32_t clientId, JsonDocument &request) {
     response["tp"] = "res:flush:start";
     response["rid"] = request["rid"];
     response["success"] = true;
+    ws.text(clientId, toWsBuffer(response));
+}
+
+void WebUIPlugin::handleShotUploadStart(uint32_t clientId, JsonDocument &request) {
+    // Manual "print this past shot" trigger: enqueue the requested shot, or the
+    // most recent one when no id is given. The upload itself runs on the
+    // ShotUpload plugin's task, so we just ack the enqueue here.
+    JsonDocument response(&psramAllocator);
+    response["tp"] = "res:shot-upload:start";
+    response["rid"] = request["rid"];
+    response["success"] = false;
+
+    uint32_t shotId = 0;
+    bool haveShotId = false;
+    if (request["id"].is<uint32_t>()) {
+        shotId = request["id"].as<uint32_t>();
+        haveShotId = true;
+    } else if (request["id"].is<const char *>()) {
+        shotId = strtoul(request["id"].as<const char *>(), nullptr, 10);
+        haveShotId = true;
+    } else {
+        // No id given: print the most recent shot.
+        ShotIndexEntry entry{};
+        if (ShotHistory.readRecentEntries(&entry, 1) > 0) {
+            shotId = entry.id;
+            haveShotId = true;
+        }
+    }
+
+    if (!haveShotId) {
+        response["msg"] = "No shots available";
+        ws.text(clientId, toWsBuffer(response));
+        return;
+    }
+
+    ShotUpload.requestUpload(shotId);
+    response["success"] = true;
+    response["shotId"] = shotId;
     ws.text(clientId, toWsBuffer(response));
 }
 

--- a/src/display/plugins/WebUIPlugin.h
+++ b/src/display/plugins/WebUIPlugin.h
@@ -40,6 +40,7 @@ class WebUIPlugin : public Plugin {
     void handleAutotuneStart(uint32_t clientId, JsonDocument &request);
     void handleProfileRequest(uint32_t clientId, JsonDocument &request);
     void handleFlushStart(uint32_t clientId, JsonDocument &request);
+    void handleShotUploadStart(uint32_t clientId, JsonDocument &request);
 
     // HTTP handlers
     // Serves the web UI from the firmware-embedded, memory-mapped flash blob

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -3,9 +3,19 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import homekitImage from '../../assets/homekit.png';
 import { faCalendarDays } from '@fortawesome/free-solid-svg-icons/faCalendarDays';
 import { computed } from '@preact/signals';
-import { machine } from '../../services/ApiService.js';
+import { useEffect, useState, useContext } from 'preact/hooks';
+import { machine, ApiServiceContext, updateSettingsCache } from '../../services/ApiService.js';
+import { parseBinaryIndex, indexToShotList } from '../ShotHistory/parseBinaryIndex.js';
+import { faPrint } from '@fortawesome/free-solid-svg-icons/faPrint';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 
 const gearpumpAddon = computed(() => machine.value.capabilities.gearpumpAddon);
+
+function formatShotDateTime(timestamp) {
+  if (!timestamp || timestamp < 10000) return '';
+  return new Date(timestamp * 1000).toLocaleString([]);
+}
 
 export function PluginCard({
   formData,
@@ -16,6 +26,103 @@ export function PluginCard({
   updateAutoWakeupTime,
   updateAutoWakeupDay,
 }) {
+  const apiService = useContext(ApiServiceContext);
+  const [shots, setShots] = useState([]);
+  const [selectedIndex, setSelectedIndex] = useState(0); // 0 = latest shot (default)
+  const [printing, setPrinting] = useState(false);
+  const [printStatus, setPrintStatus] = useState('');
+  const [uploadFailure, setUploadFailure] = useState('');
+
+  // Show a reminder below the print button when a shot exhausts all upload
+  // retries (fired by ShotUploadPlugin as evt:shot-upload:failed).
+  useEffect(() => {
+    const id = apiService.on('evt:shot-upload:failed', msg => {
+      setUploadFailure(msg?.msg ?? 'Upload failed after all retry attempts');
+    });
+    return () => apiService.off('evt:shot-upload:failed', id);
+  }, [apiService]);
+
+  // Load the most recent shots when the plugin is enabled (needed for the
+  // "print a past shot" picker). Same truncated index endpoint as RecentShotsCard.
+  useEffect(() => {
+    if (!formData.shotUploadEnabled) return;
+    let cancelled = false;
+    fetch('/api/history/recent.bin?limit=20')
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.arrayBuffer();
+      })
+      .then(buf => indexToShotList(parseBinaryIndex(buf)))
+      .then(list => {
+        if (!cancelled) {
+          setShots(list);
+          setSelectedIndex(0);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setShots([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [formData.shotUploadEnabled]);
+
+  const selectCount = shots.length + 1; // +1 for the "latest shot" entry
+  const selectOlderShot = () => setSelectedIndex(i => (i + 1) % selectCount);
+  const selectNewerShot = () => setSelectedIndex(i => (i - 1 + selectCount) % selectCount);
+
+  const startPrint = async () => {
+    if (printing) return;
+    setPrinting(true);
+    setPrintStatus('');
+    setUploadFailure('');
+    try {
+      const shot = selectedIndex > 0 ? shots[selectedIndex - 1] : null;
+      const res = await apiService.request({
+        tp: 'req:shot-upload:start',
+        ...(shot ? { id: shot.id } : {}),
+      });
+      if (res?.success) {
+        setPrintStatus(
+          `Queued shot #${String(res.shotId ?? (shot ? shot.id : 'latest')).padStart(6, '0')} for upload`,
+        );
+      } else {
+        setPrintStatus(`Failed: ${res?.msg ?? 'unknown error'}`);
+      }
+    } catch (err) {
+      setPrintStatus(`Failed: ${err?.message ?? 'connection error'}`);
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  // Save just this card's fields (enable toggle, server URL, machine id) so a
+  // change takes effect without hunting for the page-level Save Settings
+  // button. Same /api/settings multipart contract the main form uses.
+  const [savingShotUpload, setSavingShotUpload] = useState(false);
+  const [savedShotUpload, setSavedShotUpload] = useState(false);
+  const saveShotUpload = async () => {
+    if (savingShotUpload) return;
+    setSavingShotUpload(true);
+    setSavedShotUpload(false);
+    try {
+      const form = new FormData();
+      if (formData.shotUploadEnabled) form.set('shotUploadEnabled', '1');
+      if (formData.shotUploadServer) form.set('shotUploadServer', formData.shotUploadServer);
+      if (formData.shotUploadMachineId) form.set('shotUploadMachineId', formData.shotUploadMachineId);
+      const res = await fetch('/api/settings', { method: 'post', body: form });
+      if (res.ok) {
+        updateSettingsCache(await res.json());
+        setSavedShotUpload(true);
+        setTimeout(() => setSavedShotUpload(false), 2500);
+      }
+    } catch (err) {
+      setSavedShotUpload(false);
+    } finally {
+      setSavingShotUpload(false);
+    }
+  };
+
   return (
     <div className='space-y-4'>
       <div className='bg-base-200 rounded-lg p-4'>
@@ -368,6 +475,142 @@ export function PluginCard({
                 value={formData.haTopic}
                 onChange={onChange('haTopic')}
               />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className='bg-base-200 rounded-lg p-4'>
+        <div className='flex items-center justify-between'>
+          <span className='text-xl font-medium'>Print The Shot</span>
+          <input
+            id='shotUploadEnabled'
+            name='shotUploadEnabled'
+            value='shotUploadEnabled'
+            type='checkbox'
+            className='toggle toggle-primary'
+            checked={!!formData.shotUploadEnabled}
+            onChange={onChange('shotUploadEnabled')}
+            aria-label='Enable Print The Shot'
+          />
+        </div>
+        {formData.shotUploadEnabled && (
+          <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
+            <p className='text-sm opacity-70'>
+              Automatically uploads every newly completed shot as Decent-format JSON to a local
+              server (e.g. a PrintTheShot server). Shots that fail to upload are dropped (not
+              queued), so nothing is re-uploaded on the next boot.
+            </p>
+            <div className='form-control'>
+              <label htmlFor='shotUploadServer' className='mb-2 block text-sm font-medium'>
+                Server URL
+              </label>
+              <input
+                id='shotUploadServer'
+                name='shotUploadServer'
+                type='text'
+                className='input input-bordered w-full'
+                placeholder='192.168.1.5:8000'
+                value={formData.shotUploadServer}
+                onChange={onChange('shotUploadServer')}
+              />
+            </div>
+
+            <div className='form-control'>
+              <label htmlFor='shotUploadMachineId' className='mb-2 block text-sm font-medium'>
+                Machine ID (shown on the server)
+              </label>
+              <input
+                id='shotUploadMachineId'
+                name='shotUploadMachineId'
+                type='text'
+                className='input input-bordered w-full'
+                placeholder='Gaggimate'
+                value={formData.shotUploadMachineId}
+                onChange={onChange('shotUploadMachineId')}
+              />
+            </div>
+
+            <div className='form-control'>
+              <label htmlFor='shotUploadRetries' className='mb-2 block text-sm font-medium'>
+                Retry attempts
+              </label>
+              <input
+                id='shotUploadRetries'
+                name='shotUploadRetries'
+                type='number'
+                min='0'
+                max='10'
+                className='input input-bordered w-full'
+                value={formData.shotUploadRetries ?? 3}
+                onChange={onChange('shotUploadRetries')}
+              />
+            </div>
+
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                className='btn btn-outline btn-sm'
+                disabled={savingShotUpload}
+                onClick={saveShotUpload}
+              >
+                Save Settings
+              </button>
+              {savedShotUpload && <span className='text-sm text-success'>Saved ✓</span>}
+              <span className='text-sm opacity-50'>
+                Changes apply after saving (or via the page's Save Settings button).
+              </span>
+            </div>
+
+            <div className='border-base-300 space-y-3 border-t border-dashed pt-4'>
+              <span className='text-lg font-medium'>Print a past shot</span>
+              <div className='flex items-center gap-2'>
+                <button
+                  type='button'
+                  className='btn btn-outline btn-sm'
+                  onClick={selectOlderShot}
+                  aria-label='Older shot'
+                >
+                  <FontAwesomeIcon icon={faChevronLeft} />
+                </button>
+                <select
+                  className='select select-bordered select-sm w-full'
+                  value={selectedIndex}
+                  onChange={e => setSelectedIndex(Number(e.currentTarget.value))}
+                >
+                  <option value={0}>Latest shot (default)</option>
+                  {shots.map((shot, i) => (
+                    <option key={shot.id} value={i + 1}>
+                      #{shot.id} · {formatShotDateTime(shot.timestamp)} · {shot.profile}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type='button'
+                  className='btn btn-outline btn-sm'
+                  onClick={selectNewerShot}
+                  aria-label='Newer shot'
+                >
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </button>
+              </div>
+              <div className='flex items-center gap-2'>
+                <button
+                  type='button'
+                  className='btn btn-primary btn-sm'
+                  disabled={printing}
+                  onClick={startPrint}
+                >
+                  <FontAwesomeIcon icon={faPrint} className='mr-1' />
+                  Print The Shot
+                </button>
+                {printStatus && <span className='text-sm opacity-70'>{printStatus}</span>}
+              </div>
+              {uploadFailure && (
+                <p className='text-error text-sm'>
+                  {uploadFailure} — check the Server URL and that the server is reachable.
+                </p>
+              )}
             </div>
           </div>
         )}

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -126,6 +126,7 @@ function buildSubmitFormData(formData, autowakeupSchedules, restart) {
     'clock24hFormat',
     'autowakeupEnabled',
     'smartGrindToggle',
+    'shotUploadEnabled',
   ];
 
   for (const [key, value] of Object.entries(formData)) {
@@ -262,6 +263,7 @@ export function Settings() {
           'delayAdjust',
           'clock24hFormat',
           'autowakeupEnabled',
+          'shotUploadEnabled',
         ].includes(key)
       ) {
         value = !formData[key];


### PR DESCRIPTION
## Print The Shot upload plugin for shot curve printing services

Ports Decent's "Print The Shot" workflow to GaggiMate: every completed shot is
uploaded to a local shot curve printing service as v2 JSON, so shot curves can
be printed on a thermal printer or visualized without touching the SD card.

### What's in this change

- New `ShotUploadPlugin` that subscribes to `evt:history-shot-saved`, converts
  the binary `.slog` into Decent v2 shot JSON, and POSTs it to the configured
  server (with configurable retries)
- "Print The Shot" card in the WebUI: print the latest or any past shot
  manually, plus enable/configure the auto-upload (server, endpoint, machine
  id, retry count)
- Failed uploads are surfaced in the WebUI (`evt:shot-upload:failed`) and
  dropped — nothing is queued on disk, so no stale shots are re-uploaded on
  boot
- Simulator support (`sim/platform/HTTPClient.h` stub)

### Settings

| Key  | Default     | Meaning                              |
|------|-------------|--------------------------------------|
| su_en | off        | Enable auto-upload on shot save      |
| su_s  | (empty)    | Server host:port, e.g. `192.168.1.5:8001` |
| su_e  | `upload`   | Upload endpoint path                 |
| su_m  | `Gaggimate`| Machine id sent in the query string  |
| su_r  | `3`        | Retry attempts after the initial POST|

### Compatibility

The JSON payload follows the Decent v2 shot schema consumed by shot curve
printing services. Both of the following servers are compatible — the beta
fork is the more feature-rich one:

- https://github.com/Sofronio/DecentEspressoPrintTheShot (original)
- https://github.com/Sofronio/DecentEspressoPrintTheShot-beta (beta, richer)

### Note for maintainers

The WebUI changes (`web/src/pages/Settings/PluginCard.jsx`) require running
`scripts/build_webui.sh` to regenerate the embedded blob
(`src/display/webassets/`, gitignored); CI's `embed_webui_pre.py` stubs an
empty bundle otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic shot uploads in a compatible JSON format.
  * Added settings for the upload server, endpoint, machine ID, retry attempts, and enablement.
  * Added Web UI controls to upload the latest or previously saved shots.
  * Added upload status, failure notifications, and retry handling.
  * Added support for plain HTTP connections and configurable request timeouts.
  * Renamed the System settings tab to “System & Updates.”

* **Bug Fixes**
  * Invalid URLs, failed connections, malformed responses, and other upload errors now fail safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->