### PR TITLE
Remove early index creation

### DIFF
--- a/src/display/plugins/ShotHistoryPlugin.cpp
+++ b/src/display/plugins/ShotHistoryPlugin.cpp
@@ -200,11 +200,6 @@ void ShotHistoryPlugin::record() {
             }
         }
 
-        // Check for early index insertion (once per shot after 7.5s)
-        if (!indexEntryCreated && (millis() - shotStart) > 7500) {
-            indexEntryCreated = createEarlyIndexEntry();
-        }
-
         // Check for weight stabilization during extended recording
         if (extendedRecording) {
             const unsigned long now = millis();
@@ -257,11 +252,6 @@ void ShotHistoryPlugin::record() {
         unsigned long duration = header.durationMs;
         if (duration <= 7500) { // Exclude failed shots and flushes
             fs->remove("/h/" + currentId + ".slog");
-
-            // If we created an early index entry, mark it as deleted
-            if (indexEntryCreated) {
-                markIndexDeleted(currentId.toInt());
-            }
         } else {
             controller->getSettings().setHistoryIndex(controller->getSettings().getHistoryIndex() + 1);
             cleanupHistory();
@@ -331,7 +321,6 @@ void ShotHistoryPlugin::startRecording() {
     currentProfileName = controller->getProfileManager()->getSelectedProfile().label;
     recording = true;
     extendedRecording = false;
-    indexEntryCreated = false; // Reset flag for new shot
     sampleCount = 0;
     ioBufferPos = 0;
     tempSumScaled = 0;
@@ -1093,28 +1082,4 @@ bool ShotHistoryPlugin::writeEntryAtPosition(File &indexFile, size_t position, c
         return false;
     }
     return true;
-}
-
-bool ShotHistoryPlugin::createEarlyIndexEntry() {
-    Profile profile = controller->getProfileManager()->getSelectedProfile();
-
-    ShotIndexEntry indexEntry{};
-    indexEntry.id = currentId.toInt();
-    indexEntry.timestamp = header.startEpoch;
-    indexEntry.duration = 0; // Will be overwritten on completion
-    indexEntry.volume = 0;   // Will be overwritten on completion
-    indexEntry.rating = 0;
-    indexEntry.flags = 0; // No SHOT_FLAG_COMPLETED - indicates in-progress shot
-    strncpy(indexEntry.profileId, profile.id.c_str(), sizeof(indexEntry.profileId) - 1);
-    indexEntry.profileId[sizeof(indexEntry.profileId) - 1] = '\0';
-    strncpy(indexEntry.profileName, profile.label.c_str(), sizeof(indexEntry.profileName) - 1);
-    indexEntry.profileName[sizeof(indexEntry.profileName) - 1] = '\0';
-
-    bool success = appendToIndex(indexEntry);
-    if (success) {
-        ESP_LOGD("ShotHistoryPlugin", "Created early index entry for shot %u", indexEntry.id);
-    } else {
-        ESP_LOGE("ShotHistoryPlugin", "Failed to create early index entry for shot %u", indexEntry.id);
-    }
-    return success;
 }

--- a/src/display/plugins/ShotHistoryPlugin.h
+++ b/src/display/plugins/ShotHistoryPlugin.h
@@ -42,8 +42,6 @@ class ShotHistoryPlugin : public Plugin {
     int findEntryPosition(File &indexFile, const ShotIndexHeader &header, uint32_t shotId);
     bool readEntryAtPosition(File &indexFile, size_t position, ShotIndexEntry &entry);
     bool writeEntryAtPosition(File &indexFile, size_t position, const ShotIndexEntry &entry);
-    bool createEarlyIndexEntry();
-
     void saveNotes(const String &id, const JsonDocument &notes);
     void loadNotes(const String &id, JsonDocument &notes);
     void startRecording();
@@ -73,7 +71,6 @@ class ShotHistoryPlugin : public Plugin {
 
     bool recording = false;
     bool extendedRecording = false;
-    bool indexEntryCreated = false;     // Track if early index entry was created
     bool shotStartedVolumetric = false; // Track initial volumetric mode
     double currentBrewDelay = 0.0;      // Brew delay (ms) the active shot was started with
     unsigned long shotStart = 0;


### PR DESCRIPTION
- Early index creation was causing a delay during the shot due to long SD card operations
- Removed early index creation
- Rely on index rebuild if shots are interrupted due to power outages/crashes etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shot history entries are now added only after a recording completes successfully.
  * Short or failed recordings are removed without leaving incomplete history entries.
  * Recording startup no longer creates or resets temporary shot history entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->