### PR TITLE
feat: persist pumped water in shot history

### DIFF
--- a/src/display/models/shot_log_format.h
+++ b/src/display/models/shot_log_format.h
@@ -11,18 +11,19 @@
 //   Header fields set at start; sampleCount & durationMs patched at end.
 // Per-sample record fields are ALWAYS present in fixed order.
 //   elapsedMs(uint32_t), tt(uint16_t), ct(uint16_t), tp(uint16_t), cp(uint16_t), fl(int16_t), tf(int16_t), pf(int16_t), vf(int16_t),
-//   v(uint16_t), ev(uint16_t), pr(uint16_t), si(uint16_t)
+//   v(uint16_t), ev(uint16_t), pr(uint16_t), si(uint16_t), wp(uint16_t)
 // Values are stored as scaled integers (see comments per field below).
-// Sample size: v1-v5 = 26 bytes (13 x uint16_t); v6 = 28 bytes because t is uint32_t.
+// Sample size: v1-v5 = 26 bytes; v6 = 28 bytes because t is uint32_t;
+// v7 = 30 bytes with cumulative water pumped.
 // Phase data moved to header transitions in v5.
 // Older files may have fewer fields - use fieldsMask to determine layout.
 
 static constexpr uint32_t SHOT_LOG_MAGIC = 0x544F4853; // 'S''H''O''T' little-endian 0x54 0x4F 0x48 0x53
-static constexpr uint8_t SHOT_LOG_VERSION = 6;
+static constexpr uint8_t SHOT_LOG_VERSION = 7;
 static constexpr uint16_t SHOT_LOG_HEADER_SIZE = 512;
 static constexpr uint16_t SHOT_LOG_SAMPLE_INTERVAL_MS = 250; // nominal recording interval
-static constexpr uint32_t SHOT_LOG_FIELDS_MASK_ALL = 0x1FFF; // 13 fields present (removed phase number)
-static constexpr uint32_t SHOT_LOG_SAMPLE_SIZE = 28;
+static constexpr uint32_t SHOT_LOG_FIELDS_MASK_ALL = 0x3FFF; // 14 fields present
+static constexpr uint32_t SHOT_LOG_SAMPLE_SIZE = 30;
 
 // Field bit positions (for future expansion)
 static constexpr uint32_t SHOT_LOG_FIELD_T = 0x0001;  // elapsed time (bit 0)
@@ -38,7 +39,8 @@ static constexpr uint32_t SHOT_LOG_FIELD_V = 0x0200;  // volumetric weight (bit 
 static constexpr uint32_t SHOT_LOG_FIELD_EV = 0x0400; // estimated weight (bit 10)
 static constexpr uint32_t SHOT_LOG_FIELD_PR = 0x0800; // puck resistance (bit 11)
 static constexpr uint32_t SHOT_LOG_FIELD_SI = 0x1000; // system info (bit 12)
-// Bits 13-31 available for future fields
+static constexpr uint32_t SHOT_LOG_FIELD_WP = 0x2000; // cumulative water pumped (bit 13)
+// Bits 14-31 available for future fields
 
 // Phase transition structure for version 5+ headers
 // transitionReason was a reserved/padding byte through v5; repurposing it keeps the struct byte-identical,

--- a/web/src/pages/ShotAnalyzer/services/LibraryService.js
+++ b/web/src/pages/ShotAnalyzer/services/LibraryService.js
@@ -43,6 +43,7 @@ function normalizeShotSampleForHistoryExport(sample = {}) {
     v: round2(sample.v),
     ev: round2(sample.ev),
     pr: round2(sample.pr),
+    wp: round2(sample.wp),
     systemInfo: sample.systemInfo,
     phaseNumber: sample.phaseNumber,
     phaseDisplayNumber: sample.phaseDisplayNumber,

--- a/web/src/pages/ShotHistory/parseBinaryShot.js
+++ b/web/src/pages/ShotHistory/parseBinaryShot.js
@@ -28,6 +28,7 @@ const FIELD_BITS = {
   EV: 10, // estimated weight
   PR: 11, // puck resistance
   SI: 12, // system info (v2+)
+  WP: 13, // cumulative water pumped
   // Phase number moved to header transitions in v5+
 };
 
@@ -63,6 +64,7 @@ const FIELD_DEFS = {
       extendedRecording: !!(val & 0x0010),
     }),
   },
+  [FIELD_BITS.WP]: { name: 'wp', type: 'uint16', scale: WEIGHT_SCALE },
   // Phase number field removed in v5+, moved to header transitions
 };
 


### PR DESCRIPTION
- Add cumulative pumped water to the versioned shot-log field mask
- Bump the shot-log format to v7 and sample size to 30 bytes
- Parse `wp` in the web shot-history parser
- Preserve `wp` in Shot Analyzer exports