### PR TITLE
feat: Add Double Tap Tare plugin with configurable tap detection (double tap → tare, triple tap → timer)

### DIFF
--- a/sim/main.cpp
+++ b/sim/main.cpp
@@ -57,6 +57,26 @@ int main(int argc, char **argv) {
             }
         }
 
+        // Simulated BLE scale weight stream: emits a double-tap waveform every
+        // 5 s through the same BLUETOOTH measurement path a real scale driver
+        // uses, so the DoubleTapTarePlugin's tap detection can be exercised
+        // without hardware. Two 26-28 g peaks ~250 ms apart, well inside the
+        // default 350 ms window.
+        {
+            static unsigned long simPhaseStart = 0;
+            static const float WAVE[][2] = {
+                {0, 0}, {100, 12}, {200, 26}, {250, 4},
+                {350, 14}, {450, 28}, {500, 6}, {700, 0},
+            };
+            static constexpr unsigned long WAVE_MS = 5000;
+            unsigned long t = (millis() - simPhaseStart) % WAVE_MS;
+            float w = 0.0f;
+            for (auto &p : WAVE) {
+                if (t >= (unsigned long)p[0]) w = p[1];
+            }
+            controller.onVolumetricMeasurement(w, VolumetricMeasurementSource::BLUETOOTH);
+        }
+
         if (ui) {
             ui->loop();
             ui->loopProfiles();

--- a/sim/web/remote_scales.h
+++ b/sim/web/remote_scales.h
@@ -41,6 +41,10 @@ class RemoteScales {
     ScaleWeightUnit getWeightUnit() { return ScaleWeightUnit::UNKNOWN; }
     bool hasScaleTimer() { return false; }
     uint32_t getScaleTimerMs() { return 0; }
+    bool hasTimerControl() { return false; }
+    void startTimer() {}
+    void stopTimer() {}
+    void resetTimer() {}
 };
 
 class RemoteScalesScanner {

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -16,6 +16,7 @@
 #include <display/core/zones.h>
 #include <display/plugins/AutoWakeupPlugin.h>
 #include <display/plugins/BoilerFillPlugin.h>
+#include <display/plugins/DoubleTapTarePlugin.h>
 #include <display/plugins/LedControlPlugin.h>
 #include <display/plugins/ShotHistoryPlugin.h>
 #include <display/plugins/SmartGrindPlugin.h>
@@ -104,6 +105,7 @@ void Controller::setup() {
 #endif
     pluginManager->registerPlugin(new LedControlPlugin());
     pluginManager->registerPlugin(new AutoWakeupPlugin());
+    pluginManager->registerPlugin(new DoubleTapTarePlugin());
     pluginManager->setup(this);
 
     pluginManager->on("profiles:profile:save", [this](Event const &event) {

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -246,6 +246,16 @@ void Settings::setAltRelayFunction(int alt_relay_function) { altRelayFunction.se
 
 void Settings::setAutoWakeupEnabled(bool enabled) { autowakeupEnabled.set(enabled); }
 
+void Settings::setDoubleTapTareEnabled(bool enabled) { doubleTapTareEnabled.set(enabled); }
+
+void Settings::setDoubleTapTareActionEnabled(bool enabled) { doubleTapTareActionEnabled.set(enabled); }
+
+void Settings::setTripleTapTimerEnabled(bool enabled) { tripleTapTimerEnabled.set(enabled); }
+
+void Settings::setDoubleTapPeakG(int grams) { doubleTapPeakG.set(grams); }
+
+void Settings::setDoubleTapWindowMs(int milliseconds) { doubleTapWindowMs.set(milliseconds); }
+
 void Settings::setAutoWakeupSchedules(const std::vector<AutoWakeupSchedule> &schedules) { autowakeupSchedules.set(schedules); }
 
 void Settings::setButtonBehavior(int index, String behavior) {

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -146,6 +146,11 @@ class Settings {
     int getFullTankDistance() const { return fullTankDistance.get(); }
     int getAltRelayFunction() const { return altRelayFunction.get(); }
     bool isAutoWakeupEnabled() const { return autowakeupEnabled.get(); }
+    bool isDoubleTapTareEnabled() const { return doubleTapTareEnabled.get(); }
+    bool isDoubleTapTareActionEnabled() const { return doubleTapTareActionEnabled.get(); }
+    bool isTripleTapTimerEnabled() const { return tripleTapTimerEnabled.get(); }
+    int getDoubleTapPeakG() const { return doubleTapPeakG.get(); }
+    int getDoubleTapWindowMs() const { return doubleTapWindowMs.get(); }
     std::vector<AutoWakeupSchedule> getAutoWakeupSchedules() const { return autowakeupSchedules.get(); }
     String getButtonBehavior(int index) const {
         if (index >= 0 && index < buttonBehavior.get().size())
@@ -226,6 +231,11 @@ class Settings {
     void setFullTankDistance(int full_tank_distance);
     void setAltRelayFunction(int alt_relay_function);
     void setAutoWakeupEnabled(bool enabled);
+    void setDoubleTapTareEnabled(bool enabled);
+    void setDoubleTapTareActionEnabled(bool enabled);
+    void setTripleTapTimerEnabled(bool enabled);
+    void setDoubleTapPeakG(int grams);
+    void setDoubleTapWindowMs(int milliseconds);
     void setAutoWakeupSchedules(const std::vector<AutoWakeupSchedule> &schedules);
     void setButtonBehavior(int index, String behavior);
     void setButtonBehaviorList(const std::vector<String> &behavior_list);
@@ -252,6 +262,11 @@ class Settings {
     Property<bool> delayAdjust{registry, "del_ad", true};
     Property<int> startupMode{registry, "sm", MODE_STANDBY};
     Property<bool> autowakeupEnabled{registry, "ab_en", false};
+    Property<bool> doubleTapTareEnabled{registry, "dtt_en", false};
+    Property<bool> doubleTapTareActionEnabled{registry, "dtt_dd", true};
+    Property<bool> tripleTapTimerEnabled{registry, "dtt_tt", false};
+    Property<int> doubleTapPeakG{registry, "dtt_peak", 20};
+    Property<int> doubleTapWindowMs{registry, "dtt_win", 350};
     Property<std::vector<AutoWakeupSchedule>> autowakeupSchedules{registry, "ab_schedules", {AutoWakeupSchedule("07:00")}};
     Property<int> standbyTimeout{registry, "sbt", DEFAULT_STANDBY_TIMEOUT_MS};
     Property<String> pid{registry, "pid", DEFAULT_PID};

--- a/src/display/plugins/BLEScalePlugin.h
+++ b/src/display/plugins/BLEScalePlugin.h
@@ -45,6 +45,19 @@ class BLEScalePlugin : public Plugin {
     std::vector<DiscoveredDevice> getDiscoveredScales() const;
     void tare() const;
 
+    // Timer controls forwarded to the connected scale (Timemore Dot etc.).
+    // No-ops when the scale driver doesn't support timer control.
+    bool hasTimerControl() const { return scale != nullptr && scale->hasTimerControl(); }
+    void startTimer() const {
+        if (scale != nullptr && scale->hasTimerControl()) scale->startTimer();
+    }
+    void stopTimer() const {
+        if (scale != nullptr && scale->hasTimerControl()) scale->stopTimer();
+    }
+    void resetTimer() const {
+        if (scale != nullptr && scale->hasTimerControl()) scale->resetTimer();
+    }
+
     // Accessors for the native scale fields that drivers optionally expose
     // (see RemoteScales). Each returns a sentinel value if not supported.
     float getFlowRate() const { return scale != nullptr && scale->hasFlowRate() ? scale->getFlowRate() : 0.0f; }

--- a/src/display/plugins/DoubleTapTarePlugin.cpp
+++ b/src/display/plugins/DoubleTapTarePlugin.cpp
@@ -1,0 +1,165 @@
+#include "DoubleTapTarePlugin.h"
+#include "BLEScalePlugin.h"
+#include <display/core/Controller.h>
+#include <display/core/Event.h>
+#include <esp_log.h>
+#include <cmath>
+
+static const char *LOG_TAG = "DoubleTapTarePlugin";
+
+// Weight tap detection, ported from the working blescale-tester
+// implementation (tuned against real tap data):
+//   - steady state: 5 samples (500 ms) spread < 0.5 g -> baseline
+//   - peak: rise > 2 g/sample then fall, height above baseline > peakG
+//   - sequence: peaks closer than the window setting chain up. Two peaks =
+//     double tap -> tare; three consecutive peaks = triple tap -> timer
+//     (start -> stop -> reset), cancelling the pending double decision.
+//   - fires when the window expires (no extra delay; single peaks and placed
+//     objects never fire, verified on real data)
+//
+// Real-data measurements (60 s capture, Acaia): double-tap peak gaps were
+// 155-307 ms, single taps >= 1.2 s apart, peak heights 20-73 g, placed
+// objects produced no peaks at all.
+static constexpr float TAP_PEAK_SLOPE = 2.0f;
+static constexpr unsigned long TAP_SAMPLE_MS = 100;
+static constexpr size_t TAP_STEADY_N = 5;
+static constexpr float TAP_STEADY_RANGE = 0.5f;
+
+void DoubleTapTarePlugin::setup(Controller *controller, PluginManager *pluginManager) {
+    this->controller = controller;
+
+    // Feed on the BLE scale's weight stream. This event fires from the NimBLE
+    // task at the scale's native cadence (~2-10 Hz); the state machine below
+    // only does float arithmetic, so running it here is safe.
+    pluginManager->on("controller:volumetric-measurement:bluetooth:change",
+                      [this](const Event &event) {
+                          float w = event.getFloat("value");
+                          if (std::isfinite(w)) {
+                              onWeightSample(w);
+                          }
+                      });
+
+    ESP_LOGI(LOG_TAG, "Double Tap Tare plugin initialized");
+}
+
+void DoubleTapTarePlugin::loop() {
+    // Actions fire from the measurement callback; loop exists for the Plugin
+    // interface only.
+}
+
+void DoubleTapTarePlugin::onWeightSample(float w) {
+    const unsigned long now = millis();
+    const float peakG = static_cast<float>(controller->getSettings().getDoubleTapPeakG());
+    const unsigned long windowMs =
+        static_cast<unsigned long>(controller->getSettings().getDoubleTapWindowMs());
+
+    // --- Steady-state baseline --------------------------------------------
+    if (now - tapSampleMs >= TAP_SAMPLE_MS) {
+        tapSampleMs = now;
+        tapHist[tapHistIdx] = w;
+        tapHistIdx = (tapHistIdx + 1) % TAP_STEADY_N;
+        if (tapHistCount < TAP_STEADY_N) {
+            tapHistCount++;
+        }
+        if (tapHistCount >= TAP_STEADY_N) {
+            float lo = tapHist[0], hi = tapHist[0];
+            float sum = 0;
+            for (size_t i = 0; i < TAP_STEADY_N; i++) {
+                if (tapHist[i] < lo) lo = tapHist[i];
+                if (tapHist[i] > hi) hi = tapHist[i];
+                sum += tapHist[i];
+            }
+            if (hi - lo < TAP_STEADY_RANGE) {
+                // Five stable samples: refresh the baseline (follows a scale
+                // that has settled on a new weight).
+                tapSteady = true;
+                tapBaseline = sum / TAP_STEADY_N;
+            } else {
+                tapSteady = false; // window unstable, keep the old baseline
+            }
+        }
+    }
+
+    // --- Local peak detection -> sequence counting -------------------------
+    // Peaks are accepted only once a baseline has been established (first
+    // five samples), so a stray transient on boot can't pass the height gate.
+    // tapSteady itself is NOT required here — the first tap of a gesture is a
+    // > 2 g deviation that already clears tapSteady; the baseline stays valid
+    // until the weight settles again.
+    const bool baselineReady = tapHistCount >= TAP_STEADY_N;
+    if (baselineReady && w > tapPrevW + TAP_PEAK_SLOPE) {
+        tapRising = true;
+    } else if (w < tapPrevW - TAP_PEAK_SLOPE && tapRising) {
+        tapRising = false;
+        float height = tapPrevW - tapBaseline;
+        if (baselineReady && height > peakG) {
+            if (now - tapLastPeakMs < windowMs) {
+                tapSeqCount++;
+                if (tapSeqCount >= 3) {
+                    // Triple tap: cancel the pending double decision and fire
+                    // the timer action immediately; start a fresh sequence.
+                    tapDecisionPending = false;
+                    tapSeqCount = 0;
+                    ESP_LOGI(LOG_TAG, "Triple tap detected -> timer");
+                    fireAction(true);
+                } else {
+                    // Peak 2: open the decision window to tell double/triple
+                    // apart (a third peak within the window overrides this).
+                    tapDecisionPending = true;
+                    tapDecisionAtMs = now;
+                }
+            } else {
+                tapSeqCount = 1; // first tap of a new sequence
+            }
+            tapLastPeakMs = now;
+        }
+    }
+    tapPrevW = w;
+
+    // --- Window expired without a third peak -> double tap, fire now --------
+    // The decision window is the only delay: unlike the triple tap (which
+    // fires on the third peak), the double tap can only be told apart from a
+    // triple by waiting out the window, after which it fires immediately.
+    if (tapDecisionPending && now - tapDecisionAtMs >= windowMs) {
+        tapDecisionPending = false;
+        tapSeqCount = 0;
+        ESP_LOGI(LOG_TAG, "Double tap detected -> tare");
+        fireAction(false);
+    }
+}
+
+void DoubleTapTarePlugin::fireAction(bool triple) {
+    Settings &settings = controller->getSettings();
+
+    // Master switch gates the whole plugin; each gesture has its own toggle.
+    if (!settings.isDoubleTapTareEnabled()) {
+        return;
+    }
+
+    if (triple) {
+        if (!settings.isTripleTapTimerEnabled() || !BLEScales.hasTimerControl()) {
+            return;
+        }
+        switch (tapTripleSeq) {
+            case 0:
+                BLEScales.startTimer();
+                ESP_LOGI(LOG_TAG, "Timer START");
+                break;
+            case 1:
+                BLEScales.stopTimer();
+                ESP_LOGI(LOG_TAG, "Timer STOP");
+                break;
+            default:
+                BLEScales.resetTimer();
+                ESP_LOGI(LOG_TAG, "Timer RESET");
+                break;
+        }
+        tapTripleSeq = (tapTripleSeq + 1) % 3;
+    } else {
+        if (!settings.isDoubleTapTareActionEnabled()) {
+            return;
+        }
+        BLEScales.tare();
+        ESP_LOGI(LOG_TAG, "TARE by double tap");
+    }
+}

--- a/src/display/plugins/DoubleTapTarePlugin.h
+++ b/src/display/plugins/DoubleTapTarePlugin.h
@@ -1,0 +1,65 @@
+#ifndef DOUBLETAPTAREPLUGIN_H
+#define DOUBLETAPTAREPLUGIN_H
+
+#include <cstddef>
+#include <cstdint>
+#include "../core/Plugin.h"
+
+// Detects tap gestures on the connected BLE scale from its weight stream and
+// maps them to actions, similar to the Decent "Half Decent Scale" tap logic:
+//
+//   double tap  -> tare the scale
+//   triple tap  -> cycle the scale timer (start -> stop -> reset)
+//
+// Both gestures are optional via the "doubleTapTareEnabled" /
+// "tripleTapTimerEnabled" settings (settings keys dtt_en / dtt_tt).
+//
+// Detection (ported from the working dot-scale-mate implementation):
+// 1. Steady state: 100 ms samples; 5 samples (500 ms) within 0.5 g of each
+//    other establish a baseline.
+// 2. Peak: a rise followed by a fall, height above the baseline > 20 g.
+// 3. Sequence: peaks closer than 400 ms chain together. Two peaks with no
+//    third within the 400 ms decision window = double tap; three consecutive
+//    peaks = triple tap.
+// 4. Recovery: weight returns to baseline +/- 0.5 g.
+// 5. Action fires 500 ms after recovery (so a placed object can settle).
+class DoubleTapTarePlugin : public Plugin {
+  public:
+    DoubleTapTarePlugin() = default;
+
+    void setup(Controller *controller, PluginManager *pluginManager) override;
+    void loop() override;
+
+  private:
+    void onWeightSample(float weight);
+    void fireAction(bool triple);
+
+    // Tuning constants (same values as the reference implementation).
+    static constexpr float TAP_PEAK_G = 20.0f;       // peak height above baseline
+    static constexpr float TAP_PEAK_SLOPE = 2.0f;    // min rise/fall slope
+    static constexpr unsigned long TAP_SAMPLE_MS = 100;
+    static constexpr size_t TAP_STEADY_N = 5;        // samples for a steady baseline
+    static constexpr float TAP_STEADY_RANGE = 0.5f;  // max spread for steady state
+    static constexpr unsigned long TAP_DOUBLE_MS = 400; // max gap to chain peaks
+    static constexpr float TAP_RECOVER_G = 0.5f;     // return-to-baseline tolerance
+    static constexpr unsigned long TAP_TARE_DELAY_MS = 500; // fire delay after recovery
+
+    Controller *controller = nullptr;
+
+    // Tap state machine.
+    float tapHist[TAP_STEADY_N] = {0};
+    size_t tapHistIdx = 0;
+    size_t tapHistCount = 0;
+    unsigned long tapSampleMs = 0;
+    bool tapSteady = false;
+    float tapBaseline = 0.0f;
+    float tapPrevW = 0.0f;
+    bool tapRising = false;
+    unsigned long tapLastPeakMs = 0;
+    uint8_t tapSeqCount = 0;
+    unsigned long tapDecisionAtMs = 0;
+    bool tapDecisionPending = false;
+    uint8_t tapTripleSeq = 0; // triple-tap timer cycle: 0=start, 1=stop, 2=reset
+};
+
+#endif // DOUBLETAPTAREPLUGIN_H

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -696,6 +696,13 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
             if (request->hasArg("steamFillTime"))
                 settings->setSteamFillTime(request->arg("steamFillTime").toInt() * 1000);
             settings->setSmartGrindActive(request->hasArg("smartGrindActive"));
+            settings->setDoubleTapTareEnabled(request->hasArg("doubleTapTareEnabled"));
+            settings->setDoubleTapTareActionEnabled(request->hasArg("doubleTapTareActionEnabled"));
+            settings->setTripleTapTimerEnabled(request->hasArg("tripleTapTimerEnabled"));
+            if (request->hasArg("doubleTapPeakG"))
+                settings->setDoubleTapPeakG(constrain(request->arg("doubleTapPeakG").toInt(), 1, 500));
+            if (request->hasArg("doubleTapWindowMs"))
+                settings->setDoubleTapWindowMs(constrain(request->arg("doubleTapWindowMs").toInt(), 50, 2000));
             if (request->hasArg("smartGrindIp"))
                 settings->setSmartGrindIp(request->arg("smartGrindIp"));
             if (request->hasArg("smartGrindMode"))
@@ -840,6 +847,11 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["steamFillTime"] = settings.getSteamFillTime() / 1000;
     doc["smartGrindActive"] = settings.isSmartGrindActive();
     doc["smartGrindIp"] = settings.getSmartGrindIp();
+    doc["doubleTapTareEnabled"] = settings.isDoubleTapTareEnabled();
+    doc["doubleTapTareActionEnabled"] = settings.isDoubleTapTareActionEnabled();
+    doc["tripleTapTimerEnabled"] = settings.isTripleTapTimerEnabled();
+    doc["doubleTapPeakG"] = settings.getDoubleTapPeakG();
+    doc["doubleTapWindowMs"] = settings.getDoubleTapWindowMs();
     doc["smartGrindMode"] = settings.getSmartGrindMode();
     doc["momentaryButtons"] = settings.isMomentaryButtons();
     doc["brewDelay"] = settings.getBrewDelay();

--- a/web/src/pages/Settings/PluginCard.jsx
+++ b/web/src/pages/Settings/PluginCard.jsx
@@ -10,12 +10,18 @@ const gearpumpAddon = computed(() => machine.value.capabilities.gearpumpAddon);
 export function PluginCard({
   formData,
   onChange,
+  setField,
+  onSubmit,
   autowakeupSchedules,
   addAutoWakeupSchedule,
   removeAutoWakeupSchedule,
   updateAutoWakeupTime,
   updateAutoWakeupDay,
 }) {
+  const resetDoubleTapDefaults = () => {
+    setField('doubleTapPeakG', 20);
+    setField('doubleTapWindowMs', 350);
+  };
   return (
     <div className='space-y-4'>
       <div className='bg-base-200 rounded-lg p-4'>
@@ -264,6 +270,119 @@ export function PluginCard({
                 </option>
               </select>
             </div>
+          </div>
+        )}
+      </div>
+
+      <div className='bg-base-200 rounded-lg p-4'>
+        <div className='flex items-center justify-between'>
+          <span className='text-xl font-medium'>Double Tap Tare</span>
+          <input
+            id='doubleTapTareEnabled'
+            name='doubleTapTareEnabled'
+            value='doubleTapTareEnabled'
+            type='checkbox'
+            className='toggle toggle-primary'
+            checked={!!formData.doubleTapTareEnabled}
+            onChange={onChange('doubleTapTareEnabled')}
+            aria-label='Enable Double Tap Tare'
+          />
+        </div>
+        {formData.doubleTapTareEnabled && (
+          <div className='border-base-300 mt-4 space-y-4 border-t pt-4'>
+            <p className='text-sm opacity-70'>
+              Tap gestures on the connected BLE scale are detected from the weight stream. A
+              double tap (two quick peaks above 20 g) tares the scale; a triple tap cycles its
+              timer (start → stop → reset).
+            </p>
+            <div className='form-control'>
+              <label className='mb-2 flex items-center justify-between'>
+                <span className='text-sm font-medium'>Double Tap to Tare</span>
+                <input
+                  id='doubleTapTareActionEnabled'
+                  name='doubleTapTareActionEnabled'
+                  value='doubleTapTareActionEnabled'
+                  type='checkbox'
+                  className='toggle toggle-primary'
+                  checked={!!formData.doubleTapTareActionEnabled}
+                  onChange={onChange('doubleTapTareActionEnabled')}
+                  aria-label='Enable double tap to tare'
+                />
+              </label>
+            </div>
+            <div className='form-control'>
+              <label className='mb-2 flex items-center justify-between'>
+                <span className='text-sm font-medium'>Triple Tap to Control Timer</span>
+                <input
+                  id='tripleTapTimerEnabled'
+                  name='tripleTapTimerEnabled'
+                  value='tripleTapTimerEnabled'
+                  type='checkbox'
+                  className='toggle toggle-primary'
+                  checked={!!formData.tripleTapTimerEnabled}
+                  onChange={onChange('tripleTapTimerEnabled')}
+                  aria-label='Enable triple tap to control the timer'
+                />
+              </label>
+            </div>
+            <div className='grid grid-cols-2 gap-4'>
+              <div className='form-control'>
+                <label htmlFor='doubleTapPeakG' className='mb-2 block text-sm font-medium'>
+                  Tap Peak (g)
+                </label>
+                <input
+                  id='doubleTapPeakG'
+                  name='doubleTapPeakG'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='1'
+                  max='500'
+                  placeholder='20'
+                  value={formData.doubleTapPeakG ?? 20}
+                  onChange={onChange('doubleTapPeakG')}
+                />
+              </div>
+              <div className='form-control'>
+                <label htmlFor='doubleTapWindowMs' className='mb-2 block text-sm font-medium'>
+                  Tap Window (ms)
+                </label>
+                <input
+                  id='doubleTapWindowMs'
+                  name='doubleTapWindowMs'
+                  type='number'
+                  className='input input-bordered w-full'
+                  min='100'
+                  max='2000'
+                  placeholder='350'
+                  value={formData.doubleTapWindowMs ?? 350}
+                  onChange={onChange('doubleTapWindowMs')}
+                />
+              </div>
+            </div>
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                onClick={resetDoubleTapDefaults}
+                className='btn btn-ghost btn-sm'
+                title='Reset tap detection parameters to defaults'
+              >
+                Reset Defaults
+              </button>
+              <button
+                type='button'
+                onClick={() => onSubmit(null, false)}
+                className='btn btn-primary btn-sm'
+                title='Save tap detection parameters'
+              >
+                Save
+              </button>
+            </div>
+            <p className='text-xs opacity-50'>
+              Tap Peak: a tap must rise at least this much above the settled baseline. Tap Window:
+              maximum gap between taps to count as one gesture (real double taps are 155-307 ms).
+              Requires a connected BLE scale with timer control for the timer gesture; the triple
+              tap timer cycles start → stop → reset.
+            </p>
           </div>
         )}
       </div>

--- a/web/src/pages/Settings/index.jsx
+++ b/web/src/pages/Settings/index.jsx
@@ -126,6 +126,9 @@ function buildSubmitFormData(formData, autowakeupSchedules, restart) {
     'clock24hFormat',
     'autowakeupEnabled',
     'smartGrindToggle',
+    'doubleTapTareEnabled',
+    'doubleTapTareActionEnabled',
+    'tripleTapTimerEnabled',
   ];
 
   for (const [key, value] of Object.entries(formData)) {
@@ -262,6 +265,9 @@ export function Settings() {
           'delayAdjust',
           'clock24hFormat',
           'autowakeupEnabled',
+          'doubleTapTareEnabled',
+          'doubleTapTareActionEnabled',
+          'tripleTapTimerEnabled',
         ].includes(key)
       ) {
         value = !formData[key];
@@ -484,6 +490,8 @@ export function Settings() {
             <LazyPluginsTab
               formData={formData}
               onChange={onChange}
+              setField={setField}
+              onSubmit={onSubmit}
               autowakeupSchedules={autowakeupSchedules}
               addAutoWakeupSchedule={addAutoWakeupSchedule}
               removeAutoWakeupSchedule={removeAutoWakeupSchedule}

--- a/web/src/pages/Settings/tabs/PluginsTab.jsx
+++ b/web/src/pages/Settings/tabs/PluginsTab.jsx
@@ -4,6 +4,8 @@ import Section from '../../../components/Card.jsx';
 export function PluginsTab({
   formData,
   onChange,
+  setField,
+  onSubmit,
   autowakeupSchedules,
   addAutoWakeupSchedule,
   removeAutoWakeupSchedule,
@@ -15,6 +17,8 @@ export function PluginsTab({
       <PluginCard
         formData={formData}
         onChange={onChange}
+        setField={setField}
+        onSubmit={onSubmit}
         autowakeupSchedules={autowakeupSchedules}
         addAutoWakeupSchedule={addAutoWakeupSchedule}
         removeAutoWakeupSchedule={removeAutoWakeupSchedule}


### PR DESCRIPTION

<img width="1206" height="782" alt="0abc4cb22b22f4095f5edf1fe4ae5839" src="https://github.com/user-attachments/assets/cce04af6-24e1-468f-949c-1c609ede5794" />

### Summary

Adds a new **Double Tap Tare** plugin that detects tap gestures on the
connected BLE scale from the weight stream and maps them to actions:

- **Double tap** → tare the scale
- **Triple tap** → cycle the scale timer (start → stop → reset), for scales
  with timer control (e.g. Timemore Dot)

The plugin is fully opt-in and configurable:

- Master switch to enable the whole plugin (default off)
- Separate toggles for the double-tap-tare and triple-tap-timer gestures
- **Tap Peak (g)** — a tap must rise at least this much above the settled
  baseline (default 20 g)
- **Tap Window (ms)** — maximum gap between taps to count as one gesture
  (default 350 ms; real double taps measured at 155-307 ms)
- **Reset Defaults** / **Save** buttons in the Plugins settings page

### Use case

Scales without physical buttons — or with broken/worn-out buttons — benefit
the most: a double tap on the scale surface tares without ever touching the
scale's own controls, and a triple tap drives the timer. Any BLE scale
benefits, since the plugin only consumes the existing weight stream and
requires no extra hardware.

### Tap detection

Ported from a real-data-tuned implementation (60 s capture: peak gaps
155-307 ms, single taps ≥ 1.2 s apart, peak heights 20-73 g, placed objects
produce no peaks):

1. Steady-state baseline: 5 samples (500 ms) with < 0.5 g spread
2. Peak: rise > 2 g/sample then fall, height above baseline > peak setting
3. Sequence: peaks closer than the window setting chain up; two peaks =
   double tap, three consecutive peaks = triple tap (cancels the pending
   double decision)
4. Fires when the window expires (no extra delay)

### Files changed

- `src/display/plugins/DoubleTapTarePlugin.{h,cpp}` — new plugin
- `src/display/core/Settings.{h,cpp}` — new settings: `dtt_en`, `dtt_dd`,
  `dtt_tt`, `dtt_peak`, `dtt_win`
- `src/display/plugins/WebUIPlugin.cpp` — settings API registration
  (GET/POST) for the five fields
- `src/display/core/Controller.cpp` — plugin registration
- `src/display/plugins/BLEScalePlugin.h` — timer-control passthrough
- `web/src/pages/Settings/PluginCard.jsx` — settings card with toggles,
  numeric inputs, Reset Defaults / Save buttons
- `web/src/pages/Settings/tabs/PluginsTab.jsx` — pass `setField` / `onSubmit`
- `web/src/pages/Settings/index.jsx` — checkbox lists for new toggles
- `sim/main.cpp` — simulated BLE scale weight stream (double-tap waveform)
  so tap detection can be exercised in the desktop simulator
- `sim/web/remote_scales.h` — timer-control stubs for the simulator shim

### Testing

- **Double tap → tare**: verified on a real **Timemore Dot** and **Acaia
  Lunar** (both success)
- **Triple tap → timer**: command transmission verified on the **Timemore
  Dot** only. Validation was limited — the test setup had no display, so the
  timer's on-scale behaviour could not be visually confirmed. Timer behaviour
  should be confirmed on a scale with a visible timer before relying on it
- Desktop simulator (`pio run -e display-sim`): the simulated BLE weight
  stream emits a double-tap waveform every 5 s and the plugin logs
  `Double tap detected -> tare` and fires `BLEScales.tare()`
- Settings round-trip verified via `/api/settings` (GET defaults 20 g /
  350 ms, POST saves, state persists in NVS)
- All settings default to disabled/off; nothing changes behavior unless the
  user enables the plugin

### Notes

The tap detection subscribes to
`controller:volumetric-measurement:bluetooth:change`, so it only reacts to a
real connected BLE scale, never to flow-estimation measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added double-tap gestures to tare the scale.
* Added optional triple-tap controls for starting, stopping, or resetting the timer.
* Added settings to enable gestures and customize tap sensitivity and timing.
* Added web settings controls, including reset-to-defaults and save options.

## Testing

* Added simulator support for generating BLE scale tap patterns without physical hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->