### PR TITLE
fix(shot-analyzer): align water and sample calculations

### DIFF
--- a/web/src/pages/ShotAnalyzer/components/analysisTable/analysisTableModel.js
+++ b/web/src/pages/ShotAnalyzer/components/analysisTable/analysisTableModel.js
@@ -3,6 +3,7 @@ import { utilityColors } from '../../utils/analyzerUtils';
 const NEUTRAL_STATUS_BADGE_CLASS = 'bg-base-content/10 text-base-content/80 border-base-content/15';
 const WARNING_BADGE_HIGH_SCALE_LABEL = 'HIGH SCALE DELAY';
 const WARNING_BADGE_SCALE_LOST_LABEL = 'SCALE LOST';
+const WARNING_BADGE_SLOW_SAMPLING_LABEL = 'SLOW SAMPLING';
 
 const WARNING_HELP_COPY = {
   delayReview:
@@ -11,6 +12,8 @@ const WARNING_HELP_COPY = {
     'The configured or inferred scale delay is unusually high. Review the scale-delay setting before relying on predictive weight stops.',
   scaleLost:
     'Shown when the scale briefly loses connection during the brew. In this case, weight is ignored for stop detection for that brew, even if the scale reconnects later.',
+  slowSampling:
+    'Excessive delay while writing samples. Possible causes include a slow SD card or high OS/system load.',
 };
 
 function getDelayReviewLabel(results) {
@@ -21,6 +24,25 @@ function getDelayReviewLabel(results) {
 
 export function buildAnalysisWarningBadges(results) {
   const badges = [];
+
+  if (results?.hasSlowSampleInterval) {
+    const rawMaxIntervalMs = results.maxSampleIntervalMs;
+    const maxIntervalMs = rawMaxIntervalMs == null ? null : Number(rawMaxIntervalMs);
+    const intervalSuffix =
+      Number.isFinite(maxIntervalMs) && maxIntervalMs > 0
+        ? ` (${Math.round(maxIntervalMs)} ms)`
+        : '';
+    badges.push({
+      key: 'slow-sampling',
+      label: `${WARNING_BADGE_SLOW_SAMPLING_LABEL}${intervalSuffix}`,
+      colorClass: 'text-white shadow-sm',
+      details: WARNING_HELP_COPY.slowSampling,
+      style: {
+        backgroundColor: utilityColors.warningOrange,
+        borderColor: utilityColors.warningOrange,
+      },
+    });
+  }
 
   if (results?.globalScaleLost) {
     badges.push({

--- a/web/src/pages/ShotAnalyzer/components/shotChart/model/chartSeries.js
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/model/chartSeries.js
@@ -1,5 +1,6 @@
 import { TARGET_FLOW_MAX, TARGET_PRESSURE_MAX } from '../constants';
 import { getSpikeResistantSeriesMax, safeMax, safeMin, toNumberOrNull } from '../helpers';
+import { createPumpedWaterSource } from '../../../services/analyzer/waterIntegration';
 
 function getSampleValue(sample, keys) {
   for (const key of keys) {
@@ -12,14 +13,23 @@ function getFlowFromSample(sample) {
   return getSampleValue(sample, ['fl', 'f', 'flow']);
 }
 
+function getSampleTimeMs(sample) {
+  const time = Number(sample?.t);
+  return Number.isFinite(time) ? time : 0;
+}
+
 export function buildSampleTimeline(samples) {
   const sampleTimesSec = new Array(samples.length);
   const cumulativeWaterTotalBySample = new Array(samples.length);
+  const pumpedWaterSource = createPumpedWaterSource(samples);
+  const initialRecordedWater = pumpedWaterSource.usesRecordedPumpedWater
+    ? Number(samples[0]?.wp)
+    : 0;
   let cumulativeWaterTotal = 0;
 
   for (let i = 0; i < samples.length; i++) {
     const sample = samples[i] || {};
-    const tMs = Number(sample.t) || 0;
+    const tMs = getSampleTimeMs(sample);
     sampleTimesSec[i] = tMs / 1000;
 
     if (i === 0) {
@@ -27,17 +37,23 @@ export function buildSampleTimeline(samples) {
       continue;
     }
 
-    // Water totals are reconstructed from flow * dt so hover/export logic can query
-    // consistent cumulative values even when the original shot payload does not store them.
-    const prevTMs = Number(samples[i - 1]?.t) || tMs;
+    if (pumpedWaterSource.usesRecordedPumpedWater) {
+      cumulativeWaterTotalBySample[i] = Math.max(0, Number(sample.wp) - initialRecordedWater);
+      continue;
+    }
+
+    // The previous sample's flow was active during this interval. This also keeps
+    // t=0 valid instead of treating the first 250 ms as a zero-length interval.
+    const previousSample = samples[i - 1] || {};
+    const prevTMs = getSampleTimeMs(previousSample);
     const dt = Math.max(0, (tMs - prevTMs) / 1000);
-    const flow = Number(getFlowFromSample(sample));
+    const flow = Number(getFlowFromSample(previousSample));
     cumulativeWaterTotal += (Number.isFinite(flow) ? flow : 0) * dt;
     cumulativeWaterTotalBySample[i] = cumulativeWaterTotal;
   }
 
   return {
-    maxTime: samples.length > 0 ? (samples[samples.length - 1].t || 0) / 1000 : 0,
+    maxTime: samples.length > 0 ? getSampleTimeMs(samples[samples.length - 1]) / 1000 : 0,
     shotStartSec: sampleTimesSec[0] ?? 0,
     sampleTimesSec,
     cumulativeWaterTotalBySample,

--- a/web/src/pages/ShotAnalyzer/components/shotChart/model/waterValues.js
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/model/waterValues.js
@@ -25,6 +25,7 @@ export function buildPhaseHoverRanges(
         label: phase?.displayName || phase?.name || null,
         startAbs,
         endAbs,
+        phaseTotalWaterMl: Number.isFinite(Number(phase?.water)) ? Number(phase.water) : null,
         startCumWater:
           startSampleIndexFloor >= 0 ? cumulativeWaterTotalBySample[startSampleIndexFloor] || 0 : 0,
       };
@@ -39,7 +40,7 @@ export function createHoverWaterValueGetter({
 }) {
   return xValue => {
     if (!Number.isFinite(xValue) || sampleTimesSec.length === 0) {
-      return { totalWaterMl: null, phaseWaterMl: null };
+      return { totalWaterMl: null, phaseWaterMl: null, phaseTotalWaterMl: null };
     }
 
     const sampleIndex = findLastSampleIndexAtOrBeforeX(sampleTimesSec, xValue);
@@ -59,6 +60,7 @@ export function createHoverWaterValueGetter({
       phaseWaterMl: activePhase
         ? Math.max(0, totalWaterMl - (activePhase.startCumWater ?? 0))
         : null,
+      phaseTotalWaterMl: activePhase?.phaseTotalWaterMl ?? null,
     };
   };
 }

--- a/web/src/pages/ShotAnalyzer/components/shotChart/tooltip/tooltipModel.js
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/tooltip/tooltipModel.js
@@ -86,14 +86,30 @@ function buildCompareDifferenceRow(rows) {
   };
 }
 
-function buildCompareWaterRows({ shotLabel, shotOrder, phaseWaterMl, totalWaterMl, color }) {
+function formatWaterValue(value) {
+  return Number.isFinite(value) ? `${value.toFixed(1)} ml` : '-';
+}
+
+function formatPhaseWaterValue(phaseWaterMl, phaseTotalWaterMl) {
+  if (!Number.isFinite(phaseWaterMl) || !Number.isFinite(phaseTotalWaterMl)) return '-';
+  return `${formatWaterValue(phaseWaterMl)} → ${formatWaterValue(phaseTotalWaterMl)}`;
+}
+
+function buildCompareWaterRows({
+  shotLabel,
+  shotOrder,
+  phaseWaterMl,
+  phaseTotalWaterMl,
+  totalWaterMl,
+  color,
+}) {
   return [
     {
       shotLabel,
       shotOrder,
       label: WATER_DRAWN_PHASE_LABEL,
       displayLabel: getShotChartDisplayLabel(WATER_DRAWN_PHASE_LABEL),
-      valueText: Number.isFinite(phaseWaterMl) ? `${phaseWaterMl.toFixed(1)} ml` : '-',
+      valueText: formatPhaseWaterValue(phaseWaterMl, phaseTotalWaterMl),
       color,
     },
     {
@@ -101,7 +117,7 @@ function buildCompareWaterRows({ shotLabel, shotOrder, phaseWaterMl, totalWaterM
       shotOrder,
       label: WATER_DRAWN_TOTAL_LABEL,
       displayLabel: getShotChartDisplayLabel(WATER_DRAWN_TOTAL_LABEL),
-      valueText: Number.isFinite(totalWaterMl) ? `${totalWaterMl.toFixed(1)} ml` : '-',
+      valueText: formatWaterValue(totalWaterMl),
       color,
     },
   ];
@@ -126,9 +142,11 @@ function buildTooltipRowModel(tooltipItem, getHoverWaterValuesAtX, tooltipColorB
   let valueText = null;
   if (TOOLTIP_WATER_LABELS.has(label)) {
     const xValue = tooltipItem.parsed?.x;
-    const { totalWaterMl, phaseWaterMl } = getHoverWaterValuesAtX(xValue);
-    const waterValue = label === WATER_DRAWN_PHASE_LABEL ? phaseWaterMl : totalWaterMl;
-    valueText = Number.isFinite(waterValue) ? `${waterValue.toFixed(1)} ml` : '-';
+    const { totalWaterMl, phaseWaterMl, phaseTotalWaterMl } = getHoverWaterValuesAtX(xValue);
+    valueText =
+      label === WATER_DRAWN_PHASE_LABEL
+        ? formatPhaseWaterValue(phaseWaterMl, phaseTotalWaterMl)
+        : formatWaterValue(totalWaterMl);
   } else {
     const value = tooltipItem.parsed?.y;
     if (value === null || value === undefined) return null;
@@ -193,11 +211,12 @@ function buildCompareExternalTooltipRows({ chart, xValue }) {
       const shotLabel = `Shot ${shotOrder + 1}`;
       const waterGetter = dataset.compareTooltipGetHoverWaterValuesAtX;
       if (typeof waterGetter === 'function' && !waterByShotOrder.has(shotOrder)) {
-        const { totalWaterMl, phaseWaterMl } = waterGetter(xValue);
+        const { totalWaterMl, phaseWaterMl, phaseTotalWaterMl } = waterGetter(xValue);
         waterByShotOrder.set(shotOrder, {
           shotLabel,
           shotOrder,
           phaseWaterMl,
+          phaseTotalWaterMl,
           totalWaterMl,
           color: dataset.borderColor || '#94a3b8',
         });

--- a/web/src/pages/ShotAnalyzer/docs/PhaseEndStop_Algorithm_English.md
+++ b/web/src/pages/ShotAnalyzer/docs/PhaseEndStop_Algorithm_English.md
@@ -20,13 +20,12 @@ The following steps are executed for each phase. The goal is to determine which 
 
 - Preparation: Check time-based stops first, as they do not require special logic. Also no tolerance calculation, since shot.json already uses rounded values.
 - Step 1: Check values at stop time (Delay = 0 ms) Take the last sample of the current phase (for the last phase: last non-extended sample) Check all targets against the current values (cp for pressure, fl for flow, v for weight, cumulative pumped volume) If match: set exitReason, estimatedDelay = 0
-- Step 2: Check first sample of next phase (Delay = 1 × sampleInterval) Take the first sample of the following phase Continue cumulative values (do not reset): pumped: previous cumulative value + nextSample.fl \* dt weight: nextSample.v directly (is global)
+- Step 2: Check first sample of next phase (Delay = nextSample.t − anchor.t) Take the first sample of the following phase. Continue cumulative values (do not reset): pumped: previous cumulative value + last phase flow × actual dt; weight: nextSample.v directly (is global).
   - Direction check (for all target types including pressure/flow): For gte targets: nextValue >= currentValue → direction correct For lte targets: nextValue <= currentValue → direction correct
-  - If direction is correct: check actual value against target If direction is not correct: use prediction: For weight: getRegressionWeightRate() × sampleInterval/1000 + last value For pressure/flow: slope from the last two phase samples × sampleInterval/1000 + last value For pumped: lastFlow \* sampleInterval/1000 + cumulative value
-  - If match: set exitReason, estimatedDelay = sampleInterval
-- Step 3: Check second sample of next phase (Delay = 2 × sampleInterval) Identical to Step 2, but using the second sample of the next phase Direction check: comparison with the value from Step 2 (or prediction if Step 2 used prediction) Prediction uses 2 × sampleInterval as time horizon (from the last phase sample)
-  - If match: set exitReason, estimatedDelay = 2 × sampleInterval Set delayReviewHint → User receives “REVIEW PHASE N” badge
-- Step 4: Predictive Extrapolation (Fallback) If no match after Step 3: continue linear extrapolation Continue extrapolating in sampleInterval steps until target is reached Reasonable maximum: LAST_PHASE_ESTIMATED_DELAY_MAX_MS (4000 ms) Set delayReviewHint
+  - If direction is correct: check actual value against target. If direction is not correct: use a prediction at that same actual delay.
+  - If match: set exitReason and estimatedDelay to the actual timestamp difference.
+- Step 3: Check second sample of next phase with the same actual-timestamp rule. If match: set exitReason and estimatedDelay to that actual difference and set delayReviewHint when applicable.
+- Step 4: Predictive Extrapolation (Fallback) If no match after Step 3: start after the second observed sample and continue linear extrapolation in fixed 100-ms steps until the target is reached. Reasonable maximum: LAST_PHASE_ESTIMATED_DELAY_MAX_MS (4000 ms). Set delayReviewHint.
 
 ### Mode: Manual, Fixed Delay (isAutoAdjusted = false)
 
@@ -41,4 +40,4 @@ The following steps are executed for each phase. The goal is to determine which 
 - Scale-lost detection: weight targets are skipped if scale is lost
 - Brew-by-Time: duration >= profDur check
 - Extended-recording filtering: for the last phase, the last non-extended sample is used as the anchor point
-- SampleInterval: Read from shotData.sampleInterval, Fallback: 250 ms (default sampling rate)
+- The stored sampleInterval remains part of the shot data, but target-delay matching uses actual sample timestamps; only unobserved future values use the fixed 100-ms prediction step.

--- a/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
@@ -10,21 +10,25 @@ import {
   createPhaseDelayTracker,
 } from './delayTracking';
 import { getMetricStats } from './metricStats';
+import { getBluetoothScaleConnectionState } from './scaleConnection';
 import {
+  PREDICTION_INTERVAL_MS,
   buildTargetCalcValues,
   findManualTargetMatch,
   findTargetMatch,
   findTargetMatchWithDirection,
   formatStopReason,
-  predictTargetValuesAtStep,
+  predictTargetValuesAtDelay,
 } from './targetMatching';
 import {
   getLastNonExtendedIndex,
   getPhaseEndSample,
   getPhaseWeightRate,
   getSampleInstantWeightRate,
+  getSamplesThroughLastNonExtended,
   isPositiveFiniteRate,
 } from './weightRate';
+import { calculatePumpedWater } from './waterIntegration';
 import {
   getBrewModeLabel,
   getPhaseExitReasonMeta,
@@ -77,16 +81,7 @@ function getNextPhaseSamples({ phaseNum, phases, sortedPhaseKeys }) {
   return nextPhaseKey ? phases[nextPhaseKey] || [] : [];
 }
 
-function getPumpedWaterUntilIndex(samples, endIndex) {
-  let pumped = 0;
-  for (let i = 1; i <= endIndex; i++) {
-    const dt = (samples[i].t - samples[i - 1].t) / 1000;
-    pumped += samples[i].fl * dt;
-  }
-  return pumped;
-}
-
-function getRecordedStopValue(exitType, samples, phaseStartTime) {
+function getRecordedStopValue(exitType, samples, phaseStartTime, closingSample, pumpedWaterSource) {
   const stopIndex = getLastNonExtendedIndex(samples);
   const stopSample = stopIndex >= 0 ? samples[stopIndex] : getPhaseEndSample(samples);
   if (!stopSample) return null;
@@ -94,19 +89,25 @@ function getRecordedStopValue(exitType, samples, phaseStartTime) {
   if (exitType === 'weight' || exitType === 'volumetric') return stopSample.v;
   if (exitType === 'pressure') return stopSample.cp;
   if (exitType === 'flow') return stopSample.fl;
-  if (exitType === 'pumped') return getPumpedWaterUntilIndex(samples, stopIndex);
-  if (exitType === 'duration') return (stopSample.t - phaseStartTime) / 1000;
+  if (exitType === 'pumped') {
+    const stopClosingSample = stopIndex === samples.length - 1 ? closingSample : null;
+    return calculatePumpedWater(samples, stopIndex, stopClosingSample, pumpedWaterSource);
+  }
+  if (exitType === 'duration') {
+    const stopTime =
+      stopIndex === samples.length - 1 && closingSample ? closingSample.t : stopSample.t;
+    return (stopTime - phaseStartTime) / 1000;
+  }
   return null;
 }
 
 function buildPhaseTargetContext({
   isBrewByWeight,
   isLastPhase,
+  pumpedWaterSource,
   samples,
   scaleConnectionBrokenPermanently,
-  shotData,
 }) {
-  const sampleInterval = shotData.sampleInterval || 250;
   const lastNonExtendedIndex = getLastNonExtendedIndex(samples);
   const lastNonExtendedSample =
     lastNonExtendedIndex >= 0 ? samples[lastNonExtendedIndex] : getPhaseEndSample(samples);
@@ -118,14 +119,14 @@ function buildPhaseTargetContext({
 
   return {
     anchor,
-    anchorPumped: getPumpedWaterUntilIndex(samples, anchorIdx),
+    anchorPumped: calculatePumpedWater(samples, anchorIdx, null, pumpedWaterSource),
     flowSlope: anchorDt > 0 ? (anchor.fl - prevAnchor.fl) / anchorDt : 0,
     isBrewByWeight,
     isLastPhase,
     lastNonExtendedSample,
     pressureSlope: anchorDt > 0 ? (anchor.cp - prevAnchor.cp) / anchorDt : 0,
-    sampleInterval,
-    sampleIntervalSec: sampleInterval / 1000,
+    phaseSamples: samples,
+    pumpedWaterSource,
     scaleConnectionBrokenPermanently,
     weightRate: getPhaseWeightRate(samples, isLastPhase),
   };
@@ -146,22 +147,28 @@ function findAutoAdjustedTargetMatch(targets, targetContext, nextPhaseSamples) {
   );
   if (match) return match;
 
-  if (nextPhaseSamples.length > 0) {
-    match = findTargetMatchWithDirection(targets, nextPhaseSamples[0], 1, targetContext);
+  let lastObservedDelayMs = 0;
+  for (const nextSample of nextPhaseSamples.slice(0, 2)) {
+    const observedDelayMs = Number(nextSample?.t) - Number(anchor.t);
+    if (Number.isFinite(observedDelayMs)) {
+      lastObservedDelayMs = Math.max(lastObservedDelayMs, observedDelayMs);
+    }
+    match = findTargetMatchWithDirection(targets, nextSample, targetContext);
+    if (match) return match;
   }
-  if (match) return match;
 
-  if (nextPhaseSamples.length > 1) {
-    match = findTargetMatchWithDirection(targets, nextPhaseSamples[1], 2, targetContext);
-  }
-  if (match) return match;
-
-  const maxSteps = Math.ceil(LAST_PHASE_ESTIMATED_DELAY_MAX_MS / targetContext.sampleInterval);
-  for (let step = 3; step <= maxSteps; step++) {
+  const firstPredictionDelayMs =
+    Math.floor(lastObservedDelayMs / PREDICTION_INTERVAL_MS) * PREDICTION_INTERVAL_MS +
+    PREDICTION_INTERVAL_MS;
+  for (
+    let predictionDelayMs = firstPredictionDelayMs;
+    predictionDelayMs <= LAST_PHASE_ESTIMATED_DELAY_MAX_MS;
+    predictionDelayMs += PREDICTION_INTERVAL_MS
+  ) {
     match = findTargetMatch(
       targets,
-      predictTargetValuesAtStep(step, targetContext),
-      step * targetContext.sampleInterval,
+      predictTargetValuesAtDelay(predictionDelayMs, targetContext),
+      predictionDelayMs,
       targetContext,
     );
     if (match) return match;
@@ -224,7 +231,6 @@ function applyTargetMatchResult({
   exitState,
   isAutoAdjusted,
   match,
-  nextPhaseSamples,
   phaseNum,
   profilePhase,
   shotData,
@@ -235,7 +241,7 @@ function applyTargetMatchResult({
   exitState.finalPredictedWeight = match.predictedWeight;
   delayTracker.setEstimatedScaleDelay(match.delayMs);
 
-  if (isAutoAdjusted && match.delayMs >= targetContext.sampleInterval * 2) {
+  if (isAutoAdjusted && match.delayMs >= PREDICTION_INTERVAL_MS * 2) {
     delayTracker.setPhaseDelayReviewHint(match.delayMs, 'auto-delay');
   }
 
@@ -253,11 +259,7 @@ function applyTargetMatchResult({
   }
 
   if (match.delayMs > 0) {
-    exitState.targetCalcValues = buildTargetCalcValues(profilePhase.targets, match, {
-      ...targetContext,
-      isAutoAdjusted,
-      nextPhaseSamples,
-    });
+    exitState.targetCalcValues = buildTargetCalcValues(profilePhase.targets, match, targetContext);
   }
 }
 
@@ -458,6 +460,7 @@ function analyzePhaseTargets({
   phaseNum,
   phaseWeightRate,
   phases,
+  pumpedWaterSource,
   profilePhase,
   samples,
   scaleConnectionBrokenPermanently,
@@ -475,9 +478,9 @@ function analyzePhaseTargets({
   const targetContext = buildPhaseTargetContext({
     isBrewByWeight,
     isLastPhase,
+    pumpedWaterSource,
     samples,
     scaleConnectionBrokenPermanently,
-    shotData,
   });
   const match = findPhaseTargetMatch({
     isAutoAdjusted,
@@ -496,7 +499,6 @@ function analyzePhaseTargets({
       exitState,
       isAutoAdjusted,
       match,
-      nextPhaseSamples,
       phaseNum,
       profilePhase,
       shotData,
@@ -534,7 +536,7 @@ function analyzePhaseTargets({
   }
 }
 
-function getPhaseStats(samples, sysInfo, sysAnomalies, analyzerSystemInfo) {
+function getPhaseStats(samples, weightSamples, sysInfo, sysAnomalies, analyzerSystemInfo) {
   return {
     p: getMetricStats(samples, 'cp'),
     tp: getMetricStats(samples, 'tp'),
@@ -543,7 +545,7 @@ function getPhaseStats(samples, sysInfo, sysAnomalies, analyzerSystemInfo) {
     tf: getMetricStats(samples, 'tf'),
     t: getMetricStats(samples, 'ct'),
     tt: getMetricStats(samples, 'tt'),
-    w: getMetricStats(samples, 'v'),
+    w: getMetricStats(weightSamples, 'v'),
     wf: getMetricStats(samples, 'vf'),
     sys_raw: sysInfo.raw,
     sys_shot_vol: sysInfo.shotStartedVolumetric,
@@ -569,7 +571,9 @@ export function analyzeExecutedPhase({
   phaseNum,
   phases,
   profileData,
+  pumpedWaterSource,
   recordedExitReasonCode,
+  bluetoothScaleWasConnected,
   scaleConnectionBrokenPermanently,
   settings,
   shotData,
@@ -577,16 +581,26 @@ export function analyzeExecutedPhase({
 }) {
   const samples = phases[phaseNum];
   const pStart = (samples[0].t - globalStartTime) / 1000;
-  const pEnd = (getPhaseEndSample(samples).t - globalStartTime) / 1000;
-  const duration = pEnd - pStart;
   const isLastPhase = phaseNum === lastPhaseKey;
+  const nextPhaseSamples = getNextPhaseSamples({ phaseNum, phases, sortedPhaseKeys });
+  const closingSample = isLastPhase ? null : nextPhaseSamples[0] || null;
+  // The first sample of the next phase closes this phase, but remains sample 0
+  // of the next phase. The exact transition time inside this interval is unknown.
+  const phaseEndSample = closingSample || getPhaseEndSample(samples);
+  const pEnd = (phaseEndSample.t - globalStartTime) / 1000;
+  const duration = pEnd - pStart;
   const phaseWeightRate = getPhaseWeightRate(samples, isLastPhase);
+  const weightSamples = getSamplesThroughLastNonExtended(samples);
+  const weightEndSample = weightSamples.at(-1) || getPhaseEndSample(samples);
   const rawName = phaseNameMap[phaseNum];
   const displayName = rawName || `Phase ${phaseNum}`;
   const sysInfo = getPhaseEndSample(samples).systemInfo || {};
   const sysAnomalies = getPhaseSysAnomalies(samples, sysInfo);
-  const scaleLostInThisPhase =
-    isBrewByWeight && samples.some(s => s.systemInfo?.bluetoothScaleConnected === false);
+  const bluetoothScaleConnection = getBluetoothScaleConnectionState(
+    samples,
+    bluetoothScaleWasConnected,
+  );
+  const scaleLostInThisPhase = isBrewByWeight && bluetoothScaleConnection.scaleLost;
   const nextScaleConnectionBroken = scaleConnectionBrokenPermanently || scaleLostInThisPhase;
   const delayTracker = createPhaseDelayTracker(isLastPhase);
   const exitState = createExitState();
@@ -597,7 +611,13 @@ export function analyzeExecutedPhase({
     normalizedRecordedExitReasonCode,
   );
   const recordedStopValue = hasRecordedExitReason
-    ? getRecordedStopValue(exitState.exitType, samples, samples[0].t)
+    ? getRecordedStopValue(
+        exitState.exitType,
+        samples,
+        samples[0].t,
+        closingSample,
+        pumpedWaterSource,
+      )
     : null;
 
   if (profilePhase && !hasRecordedExitReason) {
@@ -614,6 +634,7 @@ export function analyzeExecutedPhase({
       phaseNum,
       phaseWeightRate,
       phases,
+      pumpedWaterSource,
       profilePhase,
       samples,
       scaleConnectionBrokenPermanently: nextScaleConnectionBroken,
@@ -631,9 +652,9 @@ export function analyzeExecutedPhase({
       start: pStart,
       end: pEnd,
       duration,
-      water: getPumpedWaterUntilIndex(samples, samples.length - 1),
-      weight: getPhaseEndSample(samples).v,
-      stats: getPhaseStats(samples, sysInfo, sysAnomalies, {
+      water: calculatePumpedWater(samples, samples.length - 1, closingSample, pumpedWaterSource),
+      weight: weightEndSample.v,
+      stats: getPhaseStats(samples, weightSamples, sysInfo, sysAnomalies, {
         brewModeLabel: getBrewModeLabel(isBrewByWeight),
         configuredScaleDelayMs: Math.max(0, Number(shotData.brewDelay) || 0),
         recordedStopReason: getPhaseExitReasonMeta(normalizedRecordedExitReasonCode).label,
@@ -659,6 +680,7 @@ export function analyzeExecutedPhase({
       targetCalcValues: exitState.targetCalcValues,
       isFinalExecuted: isLastPhase,
     },
+    bluetoothScaleWasConnected: bluetoothScaleConnection.bluetoothScaleWasConnected,
     scaleConnectionBrokenPermanently: nextScaleConnectionBroken,
   };
 }

--- a/web/src/pages/ShotAnalyzer/services/analyzer/sampleIntervals.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/sampleIntervals.js
@@ -1,0 +1,34 @@
+/** Identifies recorded sample gaps that exceed the normal 255 ms cadence. */
+
+export const SLOW_SAMPLE_INTERVAL_THRESHOLD_MS = 255;
+
+function getFiniteTimestamp(sample) {
+  const rawTimestamp = sample?.t;
+  if (rawTimestamp === null || rawTimestamp === undefined || rawTimestamp === '') return null;
+
+  const timestamp = Number(rawTimestamp);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function getSlowSampleIntervalSummary(samples) {
+  let maxSampleIntervalMs = null;
+  if (!Array.isArray(samples)) {
+    return { hasSlowSampleInterval: false, maxSampleIntervalMs };
+  }
+
+  for (let index = 1; index < samples.length; index++) {
+    const previousTimestamp = getFiniteTimestamp(samples[index - 1]);
+    const currentTimestamp = getFiniteTimestamp(samples[index]);
+    if (previousTimestamp === null || currentTimestamp === null) continue;
+
+    const intervalMs = currentTimestamp - previousTimestamp;
+    if (intervalMs > SLOW_SAMPLE_INTERVAL_THRESHOLD_MS) {
+      maxSampleIntervalMs = Math.max(maxSampleIntervalMs ?? 0, intervalMs);
+    }
+  }
+
+  return {
+    hasSlowSampleInterval: maxSampleIntervalMs !== null,
+    maxSampleIntervalMs,
+  };
+}

--- a/web/src/pages/ShotAnalyzer/services/analyzer/scaleConnection.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/scaleConnection.js
@@ -1,0 +1,25 @@
+/** Tracks real Bluetooth-scale connection loss without mistaking non-Bluetooth scales for one. */
+
+function isBluetoothScaleConnected(value) {
+  return value === true || value === 1;
+}
+
+function isBluetoothScaleDisconnected(value) {
+  return value === false || value === 0;
+}
+
+export function getBluetoothScaleConnectionState(samples, bluetoothScaleWasConnected = false) {
+  let wasConnected = bluetoothScaleWasConnected;
+  let scaleLost = false;
+
+  for (const sample of samples) {
+    const connection = sample?.systemInfo?.bluetoothScaleConnected;
+    if (isBluetoothScaleConnected(connection)) {
+      wasConnected = true;
+    } else if (wasConnected && isBluetoothScaleDisconnected(connection)) {
+      scaleLost = true;
+    }
+  }
+
+  return { bluetoothScaleWasConnected: wasConnected, scaleLost };
+}

--- a/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
@@ -8,7 +8,11 @@ import {
 } from './delayTracking';
 import { getMetricStats } from './metricStats';
 import { analyzeExecutedPhase } from './phaseAnalysis';
+import { getBluetoothScaleConnectionState } from './scaleConnection';
+import { getSlowSampleIntervalSummary } from './sampleIntervals';
 import { mergeSkippedProfilePhases } from './skippedPhases';
+import { calculatePumpedWater, createPumpedWaterSource } from './waterIntegration';
+import { getSamplesThroughLastNonExtended } from './weightRate';
 import {
   buildRecordedExitReasonByPhase,
   getBrewCompletionLabel,
@@ -35,15 +39,6 @@ function groupSamplesByPhase(samples) {
     groups[pNum].push(sample);
     return groups;
   }, {});
-}
-
-function calculateWaterVolume(samples) {
-  let water = 0;
-  for (let i = 1; i < samples.length; i++) {
-    const dt = (samples[i].t - samples[i - 1].t) / 1000;
-    water += samples[i].fl * dt;
-  }
-  return water;
 }
 
 function applyConfiguredScaleDelayWarning(analyzedPhases, configuredScaleDelayMs) {
@@ -132,6 +127,7 @@ export function calculateShotMetrics(shotData, profileData, settings) {
   const debugEnabled = isAnalyzerDebugEnabled();
   const gSamples = shotData.samples;
   const globalStartTime = gSamples[0].t;
+  const pumpedWaterSource = createPumpedWaterSource(gSamples);
 
   // --- 1. PHASE SEPARATION ---
   const phaseNameMap = buildPhaseNameMap(shotData.phaseTransitions);
@@ -149,19 +145,19 @@ export function calculateShotMetrics(shotData, profileData, settings) {
   const finalExitReasonCode = normalizePhaseExitReasonCode(shotData.finalExitReason);
   const finalExitReasonLabel = getPhaseExitReasonMeta(finalExitReasonCode).label;
 
-  let globalScaleLost = false;
-  if (isBrewByWeight) {
-    globalScaleLost = gSamples.some(s => s.systemInfo?.bluetoothScaleConnected === false);
-  }
+  const globalScaleLost = isBrewByWeight && getBluetoothScaleConnectionState(gSamples).scaleLost;
+  const { hasSlowSampleInterval, maxSampleIntervalMs } = getSlowSampleIntervalSummary(gSamples);
 
   // --- 3. GLOBAL TOTALS ---
   const gDuration = (gSamples.at(-1).t - gSamples[0].t) / 1000;
-  const gWater = calculateWaterVolume(gSamples);
-  const gWeight = gSamples.at(-1).v;
+  const gWater = calculatePumpedWater(gSamples, gSamples.length - 1, null, pumpedWaterSource);
+  const gWeightSamples = getSamplesThroughLastNonExtended(gSamples);
+  const gWeight = (gWeightSamples.at(-1) || gSamples.at(-1)).v;
 
   // --- 4. PHASE-BY-PHASE ANALYSIS ---
   const analyzedPhases = [];
   const delayTotals = createDelayTotals();
+  let bluetoothScaleWasConnected = false;
   let scaleConnectionBrokenPermanently = false;
 
   for (const phaseNum of sortedPhaseKeys) {
@@ -176,13 +172,16 @@ export function calculateShotMetrics(shotData, profileData, settings) {
       phaseNum,
       phases,
       profileData,
+      pumpedWaterSource,
       recordedExitReasonCode: recordedExitReasonByPhase.get(String(phaseNum)) || 0,
+      bluetoothScaleWasConnected,
       scaleConnectionBrokenPermanently,
       settings,
       shotData,
       sortedPhaseKeys,
     });
     analyzedPhases.push(result.phase);
+    bluetoothScaleWasConnected = result.bluetoothScaleWasConnected;
     scaleConnectionBrokenPermanently = result.scaleConnectionBrokenPermanently;
   }
 
@@ -226,7 +225,7 @@ export function calculateShotMetrics(shotData, profileData, settings) {
     tf: getMetricStats(gSamples, 'tf'),
     t: getMetricStats(gSamples, 'ct'),
     tt: getMetricStats(gSamples, 'tt'),
-    w: getMetricStats(gSamples, 'v'),
+    w: getMetricStats(gWeightSamples, 'v'),
     wf: getMetricStats(gSamples, 'vf'),
     sys_raw: finalSysInfo.raw,
     sys_shot_vol: finalSysInfo.shotStartedVolumetric,
@@ -249,6 +248,8 @@ export function calculateShotMetrics(shotData, profileData, settings) {
   return {
     isBrewByWeight,
     globalScaleLost,
+    hasSlowSampleInterval,
+    maxSampleIntervalMs,
     highScaleDelay: hasHighScaleDelay,
     highScaleDelayMs,
     delayReviewHint: delayReviewSummary.delayReviewHint,

--- a/web/src/pages/ShotAnalyzer/services/analyzer/targetMatching.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/targetMatching.js
@@ -1,6 +1,9 @@
 /** Resolves profile exit targets against measured and delay-adjusted shot values. */
 
 import { LAST_PHASE_OVERSHOOT_MAX_G } from './delayTracking';
+import { calculatePumpedWaterAtSample } from './waterIntegration';
+
+export const PREDICTION_INTERVAL_MS = 100;
 
 function isDirectionallyValidLookAhead(operator, currentValue, nextValue) {
   if (!Number.isFinite(currentValue) || !Number.isFinite(nextValue)) return false;
@@ -43,11 +46,12 @@ function getTargetValue(target, values) {
   return undefined;
 }
 
-function createTargetMatch(target, value, delayMs) {
+function createTargetMatch(target, value, delayMs, observedSample = null) {
   return {
     target,
     delayMs,
     predictedWeight: isWeightTarget(target) ? value : null,
+    observedSample,
   };
 }
 
@@ -65,9 +69,8 @@ export function findTargetMatch(targets, values, delayMs, context) {
   return null;
 }
 
-function getLookAheadTargetValues(target, nextSample, nSteps, context) {
-  const horizon = nSteps * context.sampleIntervalSec;
-  const nextDt = (nextSample.t - context.anchor.t) / 1000;
+function getLookAheadTargetValues(target, nextSample, delayMs, context) {
+  const horizon = Math.max(0, delayMs) / 1000;
 
   if (target.type === 'pressure') {
     return {
@@ -92,38 +95,49 @@ function getLookAheadTargetValues(target, nextSample, nSteps, context) {
     };
   }
   if (target.type === 'pumped') {
+    const observedPumped = Array.isArray(context.phaseSamples)
+      ? calculatePumpedWaterAtSample(context.phaseSamples, nextSample, context.pumpedWaterSource)
+      : context.anchorPumped + context.anchor.fl * horizon;
     return {
       anchorValue: context.anchorPumped,
-      nextValue: context.anchorPumped + nextSample.fl * nextDt,
+      nextValue: observedPumped,
       predictedValue: context.anchorPumped + Math.max(0, context.anchor.fl) * horizon,
     };
   }
   return null;
 }
 
-export function findTargetMatchWithDirection(targets, nextSample, nSteps, context) {
+function getLookAheadMatchedValue(target, nextSample, delayMs, context) {
+  const values = getLookAheadTargetValues(target, nextSample, delayMs, context);
+  if (!values) return undefined;
+
+  const directionIsValid = isDirectionallyValidLookAhead(
+    target.operator,
+    values.anchorValue,
+    values.nextValue,
+  );
+  return directionIsValid ? values.nextValue : values.predictedValue;
+}
+
+export function findTargetMatchWithDirection(targets, nextSample, context) {
+  const rawDelayMs = Number(nextSample?.t) - Number(context.anchor?.t);
+  const delayMs = Number.isFinite(rawDelayMs) ? Math.max(0, rawDelayMs) : 0;
+
   for (const target of targets) {
     if (shouldSkipTarget(target, context)) continue;
 
-    const values = getLookAheadTargetValues(target, nextSample, nSteps, context);
-    if (!values) continue;
-
-    const directionIsValid = isDirectionallyValidLookAhead(
-      target.operator,
-      values.anchorValue,
-      values.nextValue,
-    );
-    const value = directionIsValid ? values.nextValue : values.predictedValue;
+    const value = getLookAheadMatchedValue(target, nextSample, delayMs, context);
+    if (value === undefined) continue;
 
     if (isTargetHit(target, value, context)) {
-      return createTargetMatch(target, value, nSteps * context.sampleInterval);
+      return createTargetMatch(target, value, delayMs, nextSample);
     }
   }
   return null;
 }
 
-export function predictTargetValuesAtStep(nSteps, context) {
-  const horizon = nSteps * context.sampleIntervalSec;
+export function predictTargetValuesAtDelay(delayMs, context) {
+  const horizon = Math.max(0, delayMs) / 1000;
   return {
     pressure: Math.max(0, context.anchor.cp + context.pressureSlope * horizon),
     flow: Math.max(0, context.anchor.fl + context.flowSlope * horizon),
@@ -178,34 +192,11 @@ export function findManualTargetMatch(targets, context) {
 }
 
 function getCalculatedTargetValueAtDelay(target, context) {
-  const matchStep = Math.round(context.matchDelayMs / context.sampleInterval);
-  const nextSampleIndex = matchStep - 1;
-  const hasNextSample =
-    context.isAutoAdjusted &&
-    nextSampleIndex >= 0 &&
-    nextSampleIndex < context.nextPhaseSamples.length;
-
-  if (hasNextSample) {
-    const values = getLookAheadTargetValues(
-      target,
-      context.nextPhaseSamples[nextSampleIndex],
-      matchStep,
-      context,
-    );
-    if (!values) return undefined;
-
-    const directionIsValid = isDirectionallyValidLookAhead(
-      target.operator,
-      values.anchorValue,
-      values.nextValue,
-    );
-    return directionIsValid ? values.nextValue : values.predictedValue;
+  if (context.observedSample) {
+    return getLookAheadMatchedValue(target, context.observedSample, context.matchDelayMs, context);
   }
 
-  return getTargetValue(
-    target,
-    predictTargetValuesAtStep(context.matchDelayMs / context.sampleInterval, context),
-  );
+  return getTargetValue(target, predictTargetValuesAtDelay(context.matchDelayMs, context));
 }
 
 export function buildTargetCalcValues(targets, match, context) {
@@ -215,6 +206,7 @@ export function buildTargetCalcValues(targets, match, context) {
   const calcContext = {
     ...context,
     matchDelayMs: match.delayMs,
+    observedSample: match.observedSample,
   };
 
   for (const target of targets) {

--- a/web/src/pages/ShotAnalyzer/services/analyzer/waterIntegration.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/waterIntegration.js
@@ -1,0 +1,107 @@
+/** Resolves recorded pump-counter values before falling back to flow integration. */
+
+function getRecordedPumpedWater(sample) {
+  const water = sample?.wp;
+  return typeof water === 'number' && Number.isFinite(water) && water >= 0 ? water : null;
+}
+
+/**
+ * Recorded `wp` is a cumulative pump counter. Only a complete, non-decreasing
+ * series is trustworthy; a partially logged counter must not mix with inferred
+ * flow values inside the same shot.
+ */
+export function hasCompleteRecordedPumpedWater(samples) {
+  if (!Array.isArray(samples) || samples.length === 0) return false;
+
+  let previousWater = null;
+  for (const sample of samples) {
+    const water = getRecordedPumpedWater(sample);
+    if (water === null || (previousWater !== null && water < previousWater)) return false;
+    previousWater = water;
+  }
+  return true;
+}
+
+export function createPumpedWaterSource(samples) {
+  return { usesRecordedPumpedWater: hasCompleteRecordedPumpedWater(samples) };
+}
+
+function getFiniteFlow(sample) {
+  const flow = Number(sample?.fl);
+  return Number.isFinite(flow) ? flow : 0;
+}
+
+function getIntervalSeconds(startSample, endSample) {
+  const startTime = Number(startSample?.t);
+  const endTime = Number(endSample?.t);
+  if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) return 0;
+  return Math.max(0, (endTime - startTime) / 1000);
+}
+
+function resolveLastIndex(samples, endIndex) {
+  const requestedEndIndex = Number.isInteger(endIndex) ? endIndex : samples.length - 1;
+  return Math.min(Math.max(requestedEndIndex, 0), samples.length - 1);
+}
+
+function shouldUseRecordedPumpedWater(samples, waterSource) {
+  if (typeof waterSource?.usesRecordedPumpedWater === 'boolean') {
+    return waterSource.usesRecordedPumpedWater;
+  }
+  return hasCompleteRecordedPumpedWater(samples);
+}
+
+function calculateFlowPumpedWater(samples, lastIndex, closingSample) {
+  let water = 0;
+
+  for (let index = 0; index < lastIndex; index += 1) {
+    water += getFiniteFlow(samples[index]) * getIntervalSeconds(samples[index], samples[index + 1]);
+  }
+
+  if (closingSample) {
+    water +=
+      getFiniteFlow(samples[lastIndex]) * getIntervalSeconds(samples[lastIndex], closingSample);
+  }
+
+  return water;
+}
+
+function calculateRecordedPumpedWater(samples, lastIndex, closingSample) {
+  const startWater = getRecordedPumpedWater(samples[0]);
+  const endWater = getRecordedPumpedWater(closingSample || samples[lastIndex]);
+  if (startWater === null || endWater === null) return null;
+  return Math.max(0, endWater - startWater);
+}
+
+/**
+ * Calculates a phase or shot water total. `closingSample` is the first sample
+ * of the next phase: it closes this phase while remaining sample 0 of the next.
+ */
+export function calculatePumpedWater(
+  samples,
+  endIndex = samples?.length - 1,
+  closingSample = null,
+  waterSource = null,
+) {
+  if (!Array.isArray(samples) || samples.length === 0) return 0;
+
+  const lastIndex = resolveLastIndex(samples, endIndex);
+  if (shouldUseRecordedPumpedWater(samples, waterSource)) {
+    const recordedWater = calculateRecordedPumpedWater(samples, lastIndex, closingSample);
+    if (recordedWater !== null) return recordedWater;
+  }
+
+  return calculateFlowPumpedWater(samples, lastIndex, closingSample);
+}
+
+/** Returns phase-relative water at a real sample, including a following-phase sample. */
+export function calculatePumpedWaterAtSample(samples, sample, waterSource = null) {
+  if (!Array.isArray(samples) || samples.length === 0 || !sample) return 0;
+
+  if (shouldUseRecordedPumpedWater(samples, waterSource)) {
+    const startWater = getRecordedPumpedWater(samples[0]);
+    const sampleWater = getRecordedPumpedWater(sample);
+    if (startWater !== null && sampleWater !== null) return Math.max(0, sampleWater - startWater);
+  }
+
+  return calculatePumpedWater(samples, samples.length - 1, sample, waterSource);
+}

--- a/web/src/pages/ShotAnalyzer/services/analyzer/weightRate.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/weightRate.js
@@ -82,6 +82,15 @@ export function getLastNonExtendedIndex(samples) {
   return samples.length - 1;
 }
 
+/**
+ * Excludes only the post-shot extended-recording tail. A zero from the actual
+ * brew remains a valid measurement because it is retained when not extended.
+ */
+export function getSamplesThroughLastNonExtended(samples) {
+  const endIndex = getLastNonExtendedIndex(samples);
+  return endIndex >= 0 ? samples.slice(0, endIndex + 1) : [];
+}
+
 export function isPositiveFiniteRate(value) {
   return value != null && Number.isFinite(value) && value > 0.1;
 }


### PR DESCRIPTION
## Summary
- use recorded `wp` water-pumped values when a complete counter series is available
- keep flow-based integration as the fallback for legacy or incomplete logs
- align phase water, stop values, target matching, hover data, and dynamic sample handling

## Validation
- `npm run lint:check`
- `npm run build`
- targeted analyzer and water-source checks