### PR TITLE
feat: Rework button control, flush

### DIFF
--- a/docs/websocket-api.yaml
+++ b/docs/websocket-api.yaml
@@ -39,6 +39,8 @@ channels:
           - $ref: '#/components/messages/ProfilesReorderResponse'
           - $ref: '#/components/messages/BrewConfirmEvent'
           - $ref: '#/components/messages/BrewConfirmCancelEvent'
+          - $ref: '#/components/messages/FlushStartResponse'
+          - $ref: '#/components/messages/FlushStopResponse'
     publish:
       description: Messages sent from the client to the server.
       message:
@@ -56,6 +58,8 @@ channels:
           - $ref: '#/components/messages/ProfilesReorderRequest'
           - $ref: '#/components/messages/ProcessActivateRequest'
           - $ref: '#/components/messages/BrewConfirmCancelRequest'
+          - $ref: '#/components/messages/FlushStartRequest'
+          - $ref: '#/components/messages/FlushStopRequest'
 components:
   schemas:
     StatusPayload:
@@ -464,6 +468,52 @@ components:
             enum: ['evt:brew:confirm:cancel']
         required: [tp]
 
+    FlushStartRequest:
+      summary: Start a flush (brew valve open, pump on) for the configured flush duration; with duration 0 it runs until req:flush:stop. The valve stays open for one more second after the pump stops.
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['req:flush:start']
+          rid:
+            type: string
+        required: [tp]
+    FlushStartResponse:
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['res:flush:start']
+          rid:
+            type: string
+          success:
+            type: boolean
+        required: [tp]
+    FlushStopRequest:
+      summary: End a hold-to-flush (flush duration 0). Ignored while a fixed-length flush runs.
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['req:flush:stop']
+          rid:
+            type: string
+        required: [tp]
+    FlushStopResponse:
+      payload:
+        type: object
+        properties:
+          tp:
+            type: string
+            enum: ['res:flush:stop']
+          rid:
+            type: string
+          success:
+            type: boolean
+        required: [tp]
     BrewConfirmCancelRequest:
       summary: Decline the pending brew confirmation on behalf of all UIs.
       payload:

--- a/eez-ui/gaggimate.eez-project
+++ b/eez-ui/gaggimate.eez-project
@@ -1706,7 +1706,7 @@
                   "eventHandlers": [
                     {
                       "objID": "00e1d3e4-87dc-440d-bdcd-faee45eced44",
-                      "eventName": "CLICKED",
+                      "eventName": "SHORT_CLICKED",
                       "handlerType": "action",
                       "action": "onBrewStart",
                       "userData": 0
@@ -3661,7 +3661,7 @@
                 "conditionalStyles": [],
                 "childStyles": []
               },
-              "hiddenInEditor": false,
+              "hiddenInEditor": true,
               "timeline": [],
               "eventHandlers": [],
               "identifier": "confirmDialog",
@@ -3685,7 +3685,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [],
                   "leftUnit": "px",
@@ -3737,7 +3737,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [],
                   "leftUnit": "px",
@@ -3790,7 +3790,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [
                     {
@@ -3849,7 +3849,7 @@
                     "conditionalStyles": [],
                     "childStyles": []
                   },
-                  "hiddenInEditor": false,
+                  "hiddenInEditor": true,
                   "timeline": [],
                   "eventHandlers": [
                     {

--- a/eez-ui/gaggimate.eez-project-ui-state
+++ b/eez-ui/gaggimate.eez-project-ui-state
@@ -1,6 +1,6 @@
 {
   "navigation": {
-    "selectedUserPageObject": "[gaggimate.eez-project]:/userPages/0",
+    "selectedUserPageObject": "[gaggimate.eez-project]:/userPages/1",
     "selectedUserWidgetObject": "[gaggimate.eez-project]:/userWidgets/1",
     "selectedActionObject": "[gaggimate.eez-project]:/actions/38",
     "selectedGlobalVariableObject": "[gaggimate.eez-project]:/variables/globalVariables/9",
@@ -131,7 +131,6 @@
                   "type": "tabset",
                   "id": "#62043989-83c1-428b-8417-b89c3070fb5a",
                   "weight": 0.5267379679144385,
-                  "selected": 1,
                   "enableClose": false,
                   "children": [
                     {
@@ -197,6 +196,7 @@
               "type": "tabset",
               "id": "EDITORS",
               "weight": 46.47304077762655,
+              "selected": 1,
               "enableDeleteWhenEmpty": false,
               "enableClose": false,
               "children": [
@@ -1225,9 +1225,7 @@
       "selectionFront": {},
       "selectionBack": {
         "0": {
-          "0": {
-            "$selected": true
-          },
+          "0": {},
           "1": {
             "0": {},
             "2": {

--- a/platformio.ini
+++ b/platformio.ini
@@ -175,6 +175,25 @@ build_flags =
 	-Wno-unused-variable
 	-Wno-unused-function
 
+; Native-host env for the physical button state machine (GM-200).
+; `pio test -e native_buttons` runs host-side, no ESP32/Arduino runtime.
+[env:native_buttons]
+platform = native
+framework =
+lib_ldf_mode = off
+lib_deps =
+	throwtheswitch/Unity@^2.6.0
+test_framework = unity
+test_filter = test_button_handler
+; Test TU includes ButtonHandler.cpp directly (STL only, no Arduino dependency).
+build_unflags =
+	-std=gnu++11
+build_flags =
+	-std=c++17
+	-I src
+	-Wno-unused-variable
+	-Wno-unused-function
+
 ; Desktop simulator: builds the real display firmware natively with the BLE link
 ; to the controller mocked (sim/comms) and an SDL window as the panel (sim/driver).
 ; All host shims for Arduino/ESP/FreeRTOS/FS/Preferences/WiFi live in sim/platform.

--- a/sim/README.md
+++ b/sim/README.md
@@ -39,7 +39,9 @@ pio run -e display-sim -t run          # build + launch (also: ./.pio/build/disp
 IDE (CLion/VSCode) it shows up under the `display-sim` environment as the
 **Run Simulator** task, so you can build and launch the sim with one click.
 
-- **Interact** with the mouse (it acts as the touchscreen).
+- **Interact** with the mouse (it acts as the touchscreen). Keys `1` and `2` press
+  and release the brew and steam inputs of the controller board (hold both for
+  the combined third button, hold one for a long press).
 - **WebUI**: open <http://localhost:8080/> while it runs (port 80 is remapped to
   8080 so it needs no root). Live status streams over the WebSocket just like on
   the device.

--- a/sim/comms/GaggiMateClient.h
+++ b/sim/comms/GaggiMateClient.h
@@ -97,6 +97,11 @@ class GaggiMateClient {
     void onSystemInfo(SystemInfoCallback cb) { _systemInfoCb = std::move(cb); }
     void onSensorData(SensorCallback cb) { _sensorCb = std::move(cb); }
     void onButtonState(ButtonCallback cb) { _buttonCb = std::move(cb); }
+    // Sim only: inject a physical button edge as if the controller board reported it.
+    void simulateButton(uint8_t index, bool pressed) {
+        if (_buttonCb)
+            _buttonCb(index, pressed);
+    }
     void onAutotuneResult(AutotuneResultCallback cb) { _autotuneResultCb = std::move(cb); }
     void onVolumetricMeasurement(VolumetricCallback cb) { _volumetricCb = std::move(cb); }
     void onTofMeasurement(TofCallback cb) { _tofCb = std::move(cb); }

--- a/sim/driver/SdlDriver.cpp
+++ b/sim/driver/SdlDriver.cpp
@@ -2,6 +2,7 @@
 
 #include <SDL.h>
 #include <cstdlib>
+#include <display/main.h>
 #include <lvgl.h>
 #include <vector>
 
@@ -108,6 +109,11 @@ void SdlDriver::pumpAndRender() {
         case SDL_MOUSEBUTTONUP:
             if (e.button.button == SDL_BUTTON_LEFT)
                 s_mousePressed = false;
+            break;
+        case SDL_KEYDOWN:
+        case SDL_KEYUP: // keys 1/2 act as the brew/steam inputs of the controller board
+            if (e.key.repeat == 0 && (e.key.keysym.sym == SDLK_1 || e.key.keysym.sym == SDLK_2))
+                controller.getClientController()->simulateButton(e.key.keysym.sym == SDLK_1 ? 0 : 1, e.type == SDL_KEYDOWN);
             break;
         default:
             break;

--- a/src/display/core/ButtonHandler.cpp
+++ b/src/display/core/ButtonHandler.cpp
@@ -1,0 +1,103 @@
+#include "ButtonHandler.h"
+
+void ButtonHandler::setConfig(const Config &cfg) {
+    std::lock_guard<std::mutex> guard(mutex);
+    config = cfg;
+}
+
+void ButtonHandler::onRawState(uint8_t index, bool pressed, unsigned long now) {
+    if (index >= BUTTON_COUNT)
+        return;
+    std::vector<Pending> events;
+    {
+        std::lock_guard<std::mutex> guard(mutex);
+        State &s = state[index];
+        const bool comboCandidate = config.combo && index < COMBO_BUTTON;
+        if (pressed) {
+            if (comboCandidate) {
+                State &other = state[1 - index];
+                if (other.pending) { // both edges inside the window: one virtual third button
+                    other.pending = false;
+                    s.consumed = other.consumed = true;
+                    comboActive = true;
+                    press(COMBO_BUTTON, now, events);
+                } else {
+                    s.pending = true; // hold back until the window passes (see loop)
+                    s.pressedAt = now;
+                }
+            } else {
+                press(index, now, events);
+            }
+        } else if (s.pending) { // tap shorter than the window: deliver both edges now
+            s.pending = false;
+            press(index, now, events);
+            release(index, events);
+        } else if (s.consumed) { // first release ends the combo, the other one is swallowed
+            s.consumed = false;
+            if (comboActive) {
+                comboActive = false;
+                release(COMBO_BUTTON, events);
+            }
+        } else {
+            release(index, events);
+        }
+    }
+    emit(events);
+}
+
+void ButtonHandler::loop(unsigned long now) {
+    std::vector<Pending> events;
+    {
+        std::lock_guard<std::mutex> guard(mutex);
+        for (uint8_t i = 0; i < BUTTON_COUNT; i++) {
+            State &s = state[i];
+            if (s.pending && now - s.pressedAt >= COMBO_WINDOW_MS) {
+                s.pending = false;
+                press(i, s.pressedAt, events);
+            }
+            if (s.logical && config.momentary && config.longPress[i] && !s.longFired && !s.clickFired &&
+                now - s.pressedAt >= LONG_PRESS_MS) {
+                s.longFired = true;
+                events.push_back({i, Event::LONG_PRESS});
+            }
+        }
+    }
+    emit(events);
+}
+
+void ButtonHandler::press(uint8_t index, unsigned long now, std::vector<Pending> &out) {
+    State &s = state[index];
+    s.logical = true;
+    s.pressedAt = now;
+    s.longFired = false;
+    s.clickFired = false;
+    if (!config.momentary) {
+        out.push_back({index, Event::PRESS});
+    } else if (config.clickOnPress[index] || !config.longPress[index]) {
+        s.clickFired = true;
+        out.push_back({index, Event::CLICK});
+    }
+}
+
+void ButtonHandler::release(uint8_t index, std::vector<Pending> &out) {
+    State &s = state[index];
+    if (!s.logical)
+        return;
+    s.logical = false;
+    if (!config.momentary) {
+        out.push_back({index, Event::RELEASE});
+    } else if (s.longFired) {
+        out.push_back({index, Event::LONG_PRESS_END});
+    } else if (s.clickFired) {
+        out.push_back({index, Event::CLICK_END});
+    } else {
+        out.push_back({index, Event::CLICK});
+    }
+}
+
+void ButtonHandler::emit(const std::vector<Pending> &events) {
+    if (!callback)
+        return;
+    for (const auto &e : events)
+        callback(e.index, e.event);
+}

--- a/src/display/core/ButtonHandler.h
+++ b/src/display/core/ButtonHandler.h
@@ -1,0 +1,67 @@
+#ifndef BUTTONHANDLER_H
+#define BUTTONHANDLER_H
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <vector>
+
+// Turns raw press/release edges from the controller board into button actions
+class ButtonHandler {
+  public:
+    static constexpr uint8_t BUTTON_COUNT = 3;
+    static constexpr uint8_t COMBO_BUTTON = 2; // index reported for brew + steam together
+    static constexpr unsigned long LONG_PRESS_MS = 400;
+    static constexpr unsigned long COMBO_WINDOW_MS = 200;
+
+    enum class Event {
+        PRESS,          // latching switch flipped on
+        RELEASE,        // latching switch flipped off
+        CLICK,          // momentary: normal action (on release, or on press when clickOnPress is set)
+        LONG_PRESS,     // momentary: held for LONG_PRESS_MS
+        CLICK_END,      // momentary: released after a click that fired on press
+        LONG_PRESS_END, // momentary: released after a long press
+    };
+
+    struct Config {
+        bool momentary = false;               // push buttons instead of latching switches
+        bool combo = false;                   // detect brew + steam as COMBO_BUTTON
+        bool longPress[BUTTON_COUNT] = {};    // a long-press action is configured for this button
+        bool clickOnPress[BUTTON_COUNT] = {}; // fire CLICK on press instead of release
+    };
+
+    using Callback = std::function<void(uint8_t index, Event event)>;
+
+    void setCallback(Callback cb) { callback = std::move(cb); }
+    void setConfig(const Config &cfg);
+    // Raw edge from the controller (index 0 = brew, 1 = steam). Safe to call from any task.
+    void onRawState(uint8_t index, bool pressed, unsigned long now);
+    // Emits deferred presses and long presses; call frequently (every ~50 ms).
+    void loop(unsigned long now);
+
+  private:
+    struct Pending {
+        uint8_t index;
+        Event event;
+    };
+    struct State {
+        bool logical = false;  // press delivered and not yet released
+        bool pending = false;  // raw press held back for the combo window
+        bool consumed = false; // raw release belongs to a combo, do not deliver
+        bool longFired = false;
+        bool clickFired = false;
+        unsigned long pressedAt = 0;
+    };
+
+    void press(uint8_t index, unsigned long now, std::vector<Pending> &out);
+    void release(uint8_t index, std::vector<Pending> &out);
+    void emit(const std::vector<Pending> &events);
+
+    std::mutex mutex;
+    Config config;
+    Callback callback;
+    State state[BUTTON_COUNT];
+    bool comboActive = false;
+};
+
+#endif // BUTTONHANDLER_H

--- a/src/display/core/Controller.cpp
+++ b/src/display/core/Controller.cpp
@@ -117,6 +117,8 @@ void Controller::setup() {
 
     pluginManager->on("profiles:profile:select", [this](Event const &event) { this->handleProfileUpdate(); });
 
+    buttons.setCallback([this](uint8_t index, ButtonHandler::Event event) { onButtonEvent(index, event); });
+
 #ifndef GAGGIMATE_HEADLESS
     ui->init();
 #endif
@@ -224,12 +226,8 @@ static void parseFloatCsv(const String &csv, float *out, size_t count, float def
 void Controller::setupBluetooth() {
     comms.init("GPBLC");
     comms.onConnectionChanged([this](bool connected) {
-        // Force a full control resend after any (re)connect -- the controller
-        // starts with no state and updateControl() otherwise only sends deltas.
         controlStateSent = false;
         if (connected) {
-            // Re-assert the connection interval for the fresh link (e.g. tight
-            // again if we reconnected mid-shot).
             applyConnectionPriority(true);
         } else if (initialized) {
             pluginManager->trigger("controller:bluetooth:disconnect");
@@ -242,18 +240,10 @@ void Controller::setupBluetooth() {
         onSystemInfo(hardware, version, protocolVersion, dimming, pressure, ledControl, tof, addons);
     });
     comms.onIncompatibleController([this](const String &info) { onIncompatibleController(info); });
-    // A controller OTA streams the firmware over this BLE link; the relaxed idle
-    // interval makes that crawl. Force a low-latency interval for the duration of
-    // a controller flash, then restore. (A display OTA is Wi-Fi-bound, so leave
-    // BLE relaxed to keep radio airtime for the download.)
     pluginManager->on("ota:update:start", [this](Event const &event) {
         if (event.getString("component") != "display") {
             connLowLatency = true;
             comms.setLowLatency(true);
-            // Streaming firmware over BLE -> BLE must win the shared radio, same
-            // as during a shot. Without this it would run against the new
-            // idle WiFi-preference and crawl. Restored by applyConnectionPriority
-            // on ota:update:end. [GM-90]
             esp_coex_preference_set(ESP_COEX_PREFER_BT);
         }
     });
@@ -274,50 +264,9 @@ void Controller::setupBluetooth() {
         pluginManager->trigger("pump:volume:change", "value", waterPumped);
     });
     comms.onButtonState([this](uint8_t index, bool pressed) {
-        const int status = pressed ? 1 : 0;
-        String behavior = settings.getButtonBehavior(index);
-        ESP_LOGV("Controller", "Button %d changed to %d, behavior: %s", index, status, behavior);
-        if (behavior == "" || behavior == "none") {
-            return;
-        }
-        if (behavior == "brew") {
-            handleBrewButton(status);
-            return;
-        }
-        if (behavior == "steam") {
-            handleSteamButton(status);
-            return;
-        }
-        if (behavior == "water") {
-            handleWaterButton(status);
-            return;
-        }
-        if (behavior == "flush") {
-            // Flush is a one-shot fixed-duration BrewProcess. Trigger on
-            // press only; release does nothing so the user can't
-            // accidentally cancel mid-flush by letting go (push button)
-            // or flipping the rocker back. onFlush() itself is a no-op
-            // if a process is already active, so rapid presses don't
-            // queue.
-            //
-            // Ensure we land in MODE_BREW so the flush UI renders, but
-            // only when no other process is currently running. Mutating
-            // mode mid-process would orphan the active mode's UI while
-            // onFlush() silently no-ops on the re-entrancy guard. The
-            // setMode guard mirrors the pattern other button handlers
-            // use when they need to switch modes safely.
-            if (status) {
-                if (getMode() == MODE_STANDBY) {
-                    deactivateStandby();
-                }
-                if (getMode() != MODE_BREW && !isActive()) {
-                    setMode(MODE_BREW);
-                }
-                onFlush();
-            }
-            return;
-        }
-        handleProfileButton(status, behavior);
+        ESP_LOGV(LOG_TAG, "Button %d changed to %d", index, pressed);
+        buttons.setConfig(buttonConfig()); // settings may have changed since the last edge
+        buttons.onRawState(index, pressed, millis());
     });
     comms.onError([this](int error) {
         // Autotune timeout = info-level, not runaway. Controller already
@@ -546,6 +495,7 @@ void Controller::loop() {
 
     warnings.loop();
     pluginManager->loop();
+    buttons.loop(millis()); // deferred combo presses + long-press timing
 
     if (screenReady && !initialized) {
         connect();
@@ -1251,7 +1201,11 @@ bool Controller::isBluetoothScaleHealthy() const {
 
 void Controller::onFlush() {
     // Allocate outside the lock; reachable from the UI, AsyncTCP and BLE tasks (GM-147).
-    auto *flush = new BrewProcess(FLUSH_PROFILE, ProcessTarget::TIME, settings.getBrewDelay());
+    const int duration = settings.getFlushDuration();
+    Profile profile = FLUSH_PROFILE;
+    profile.phases[0].duration = duration > 0 ? duration : FLUSH_HOLD_MAX_DURATION_S; // 0 = hold, capped
+    auto *flush = new BrewProcess(profile, ProcessTarget::TIME, settings.getBrewDelay());
+    flush->holdPhase = duration == 0; // pump phase ends on onFlushRelease(), the drain phase still runs
     std::vector<const char *> events;
     {
         std::lock_guard<std::recursive_mutex> guard(processMutex);
@@ -1267,106 +1221,183 @@ void Controller::onFlush() {
     dispatchEvents(events);
 }
 
+// Every hold-to-flush source (physical button, touch, web) funnels its release through here.
+void Controller::onFlushRelease() {
+    std::lock_guard<std::recursive_mutex> guard(processMutex);
+    if (currentProcess != nullptr && currentProcess->getType() == MODE_BREW) {
+        static_cast<BrewProcess *>(currentProcess)->release();
+    }
+}
+
 void Controller::onVolumetricDelete() {
     if (profileManager->getSelectedProfile().isVolumetric()) {
         profileManager->getSelectedProfile().removeVolumetricTarget();
     }
 }
 
-void Controller::handleBrewButton(int brewButtonStatus) {
-    if (brewButtonStatus) {
-        switch (getMode()) {
-        case MODE_STANDBY:
-            deactivateStandby();
-            break;
-        case MODE_BREW:
-            if (!isActive()) {
-                deactivateStandby();
-                clear();
-                activate();
-            } else if (settings.isMomentaryButtons()) {
-                deactivate();
-                clear();
-            }
-            break;
-        case MODE_WATER:
-            activate();
-            break;
-        case MODE_STEAM:
-            deactivate();
-            setMode(MODE_BREW);
-        default:
-            break;
-        }
-    } else if (!settings.isMomentaryButtons()) {
+// A long press on a momentary button that starts a shot (brew or a profile) flushes instead.
+static bool longPressFlushes(const String &behavior) {
+    return behavior != "" && behavior != "none" && behavior != "steam" && behavior != "water" && behavior != "flush";
+}
+
+ButtonHandler::Config Controller::buttonConfig() const {
+    ButtonHandler::Config cfg;
+    cfg.momentary = settings.isMomentaryButtons();
+    const bool holdFlush = settings.getFlushDuration() == 0;
+    for (uint8_t i = 0; i < ButtonHandler::BUTTON_COUNT; i++) {
+        const String behavior = settings.getButtonBehavior(i);
+        cfg.longPress[i] = cfg.momentary && longPressFlushes(behavior);
+        cfg.clickOnPress[i] = holdFlush && behavior == "flush"; // a hold-to-flush has to start on press
+    }
+    // Only pay the combo window when the virtual third button does something
+    const String third = settings.getButtonBehavior(ButtonHandler::COMBO_BUTTON);
+    cfg.combo = third != "" && third != "none";
+    return cfg;
+}
+
+void Controller::onButtonEvent(uint8_t index, ButtonHandler::Event event) {
+    using Event = ButtonHandler::Event;
+    const String behavior = settings.getButtonBehavior(index);
+    ESP_LOGV(LOG_TAG, "Button %d event %d, behavior: %s", index, static_cast<int>(event), behavior.c_str());
+    switch (event) {
+    case Event::PRESS:
+    case Event::CLICK:
+        runButtonBehavior(behavior, true);
+        break;
+    case Event::RELEASE:
+        runButtonBehavior(behavior, false);
+        break;
+    case Event::LONG_PRESS:
+        handleFlushButton(true);
+        break;
+    case Event::LONG_PRESS_END:
+        handleFlushButton(false);
+        break;
+    case Event::CLICK_END: // momentary release only matters for a hold-to-flush
+        if (behavior == "flush")
+            onFlushRelease();
+        break;
+    }
+}
+
+void Controller::runButtonBehavior(const String &behavior, bool pressed) {
+    if (behavior == "" || behavior == "none") {
+        return;
+    }
+    if (behavior == "brew") {
+        handleBrewButton(pressed);
+    } else if (behavior == "steam") {
+        handleSteamButton(pressed);
+    } else if (behavior == "water") {
+        handleWaterButton(pressed);
+    } else if (behavior == "flush") {
+        handleFlushButton(pressed);
+    } else {
+        handleProfileButton(pressed, behavior); // anything else is a profile id
+    }
+}
+
+void Controller::handleBrewButton(bool pressed) {
+    if (!pressed) { // latching switch flipped off
         if (getMode() == MODE_BREW) {
-            if (isActive()) {
-                deactivate();
-                clear();
-            } else {
-                clear();
-            }
+            deactivate();
+            clear();
         } else if (getMode() == MODE_WATER) {
             deactivate();
         }
+        return;
+    }
+    switch (getMode()) {
+    case MODE_STANDBY:
+        deactivateStandby();
+        break;
+    case MODE_BREW:
+        if (!isActive()) {
+            activate();
+        } else if (settings.isMomentaryButtons()) { // second press stops the shot
+            deactivate();
+            clear();
+        }
+        break;
+    case MODE_WATER:
+        activate();
+        break;
+    case MODE_STEAM:
+        deactivate();
+        setMode(MODE_BREW);
+        break;
+    default:
+        break;
     }
 }
 
-void Controller::handleSteamButton(int steamButtonStatus) {
-    if (steamButtonStatus) {
+void Controller::handleSteamButton(bool pressed) {
+    if (pressed) {
         if (getMode() != MODE_STEAM) {
             setMode(MODE_STEAM);
+        } else if (settings.isMomentaryButtons()) { // second press leaves steam mode
+            deactivate();
+            setMode(MODE_BREW);
         }
-    } else if (!settings.isMomentaryButtons() && getMode() == MODE_STEAM) {
+    } else if (getMode() == MODE_STEAM) {
         deactivate();
         setMode(MODE_BREW);
     }
-    steamSwitchOn = steamButtonStatus;
+    if (!settings.isMomentaryButtons()) {
+        steamSwitchOn = pressed; // the "steam switch left on" warning only makes sense for a latching switch
+    }
 }
 
-void Controller::handleWaterButton(int buttonStatus) {
-    if (buttonStatus) {
-        switch (getMode()) {
-        case MODE_WATER:
-            if (!isActive()) {
-                activate();
-            }
-            break;
-        default:
+void Controller::handleWaterButton(bool pressed) {
+    if (pressed) {
+        if (getMode() != MODE_WATER) {
             setMode(MODE_WATER);
-            break;
+        } else if (!isActive()) {
+            activate();
+        } else if (settings.isMomentaryButtons()) { // second press stops the water
+            deactivate();
         }
-    } else if (!settings.isMomentaryButtons() && getMode() == MODE_WATER && isActive()) {
+    } else if (getMode() == MODE_WATER && isActive()) {
         deactivate();
     }
 }
 
-void Controller::handleProfileButton(int buttonStatus, String id) {
-    if (buttonStatus && getMode() == MODE_STANDBY) {
+void Controller::handleFlushButton(bool pressed) {
+    if (!pressed) {
+        onFlushRelease(); // ends a hold-to-flush, otherwise nothing: a release must not cut a flush short
+        return;
+    }
+    if (getMode() == MODE_STANDBY) {
+        deactivateStandby();
+    }
+    if (getMode() != MODE_BREW && !isActive()) {
+        setMode(MODE_BREW); // land in brew mode so the flush UI renders, never mid-process
+    }
+    onFlush(); // no-op while a process runs, so repeated presses don't queue
+}
+
+void Controller::handleProfileButton(bool pressed, const String &id) {
+    if (!pressed) { // latching switch flipped off
+        deactivate();
+        clear();
+        return;
+    }
+    if (getMode() == MODE_STANDBY) {
         deactivateStandby();
         return;
     }
-    if (!buttonStatus && !settings.isMomentaryButtons()) {
-        deactivate();
-        clear();
+    if (getMode() != MODE_BREW) {
+        setMode(MODE_BREW);
     }
-    if (settings.isMomentaryButtons() && buttonStatus && isActive()) {
+    if (isActive()) { // pressing again stops the running shot
         deactivate();
         clear();
-    } else if (buttonStatus) {
-        if (getMode() != MODE_BREW) {
-            setMode(MODE_BREW);
-        }
-        if (isActive()) {
-            deactivate();
-            clear();
-            return;
-        }
-        std::vector<String> profileIds = profileManager->listProfiles();
-        if (std::find(profileIds.begin(), profileIds.end(), id) != profileIds.end()) {
-            profileManager->selectProfile(id);
-            activate();
-        }
+        return;
+    }
+    std::vector<String> profileIds = profileManager->listProfiles();
+    if (std::find(profileIds.begin(), profileIds.end(), id) != profileIds.end()) {
+        profileManager->selectProfile(id);
+        activate();
     }
 }
 

--- a/src/display/core/Controller.h
+++ b/src/display/core/Controller.h
@@ -6,6 +6,7 @@
 #include "Settings.h"
 #include "SystemInfo.h"
 #include <WiFi.h>
+#include <display/core/ButtonHandler.h>
 #include <display/core/ProfileManager.h>
 #include <display/core/WarningManager.h>
 #include <display/core/process/Process.h>
@@ -120,6 +121,7 @@ class Controller {
     void setVolumetricOverride(bool override) { volumetricOverride = override; }
     bool isBluetoothScaleHealthy() const;
     void onFlush();
+    void onFlushRelease(); // ends a hold-to-flush; no-op otherwise
     int getWaterLevel() const {
         float reversedLevel = static_cast<float>(settings.getEmptyTankDistance()) -
                               static_cast<float>(std::min(settings.getEmptyTankDistance(), tofDistance));
@@ -172,10 +174,16 @@ class Controller {
     void onTempRead(float temperature);
     void onPressureRead(float pressure);
 
-    void handleBrewButton(int brewButtonStatus);
-    void handleSteamButton(int steamButtonStatus);
-    void handleWaterButton(int buttonStatus);
-    void handleProfileButton(int buttonStatus, String id);
+    // Physical buttons (GM-200): raw edges -> ButtonHandler -> behavior handlers. `pressed`
+    // false only reaches the handlers for latching switches; momentary presses toggle.
+    ButtonHandler::Config buttonConfig() const;
+    void onButtonEvent(uint8_t index, ButtonHandler::Event event);
+    void runButtonBehavior(const String &behavior, bool pressed);
+    void handleBrewButton(bool pressed);
+    void handleSteamButton(bool pressed);
+    void handleWaterButton(bool pressed);
+    void handleFlushButton(bool pressed);
+    void handleProfileButton(bool pressed, const String &id);
     void handleProfileUpdate();
 
     // Private Attributes
@@ -184,6 +192,7 @@ class Controller {
     Driver *driver = nullptr;
 #endif
     GaggiMateClient comms;
+    ButtonHandler buttons;
     hw_timer_t *timer = nullptr;
     Settings settings;
     PluginManager *pluginManager{};

--- a/src/display/core/Settings.cpp
+++ b/src/display/core/Settings.cpp
@@ -165,6 +165,8 @@ void Settings::setHomeAssistantPassword(const String &homeAssistantPassword) {
 
 void Settings::setMomentaryButtons(bool momentary_buttons) { momentaryButtons.set(momentary_buttons); }
 
+void Settings::setFlushDuration(int seconds) { flushDuration.set(std::clamp(seconds, 0, MAX_FLUSH_DURATION_S)); }
+
 // Clamp to the WarningLevel range so a bad web value can't leave a warning in an undefined state.
 static int clampWarningLevel(int level) {
     return level < WARNING_LEVEL_IGNORE ? WARNING_LEVEL_IGNORE : (level > WARNING_LEVEL_ERROR ? WARNING_LEVEL_ERROR : level);

--- a/src/display/core/Settings.h
+++ b/src/display/core/Settings.h
@@ -110,6 +110,7 @@ class Settings {
     int getHomeAssistantPort() const { return homeAssistantPort.get(); }
     String getHomeAssistantTopic() const { return homeAssistantTopic.get(); }
     bool isMomentaryButtons() const { return momentaryButtons.get(); }
+    int getFlushDuration() const { return flushDuration.get(); } // seconds, 0 = as long as the button is held
     String getTimezone() const { return timezone.get(); }
     bool isClock24hFormat() const { return clock24hFormat.get(); }
     String getSelectedProfile() const { return selectedProfile.get(); }
@@ -204,6 +205,7 @@ class Settings {
     void setHomeAssistantPort(int homeAssistantPort);
     void setHomeAssistantTopic(const String &homeAssistantTopic);
     void setMomentaryButtons(bool momentary_buttons);
+    void setFlushDuration(int seconds);
     void setWarnWaterLevel(int level);
     void setWarnFlush(int level);
     void setWarnSteamSwitch(int level);
@@ -294,6 +296,7 @@ class Settings {
     Property<int> homeAssistantPort{registry, "ha_p", 1883};
     Property<String> homeAssistantTopic{registry, "ha_t", DEFAULT_HOME_ASSISTANT_TOPIC};
     Property<bool> momentaryButtons{registry, "mb", false};
+    Property<int> flushDuration{registry, "fl_dur", DEFAULT_FLUSH_DURATION_S};
     Property<String> timezone{registry, "tz", DEFAULT_TIMEZONE};
     Property<bool> clock24hFormat{registry, "clk_24h", true};
     Property<String> otaChannel{registry, "oc", DEFAULT_OTA_CHANNEL};

--- a/src/display/core/constants.h
+++ b/src/display/core/constants.h
@@ -10,6 +10,10 @@
 #define BREW_MAX_DURATION_MS 300000
 #define BREW_SAFETY_DURATION_MS BREW_MAX_DURATION_MS
 #define BREW_MIN_VOLUMETRIC 5.0
+#define DEFAULT_FLUSH_DURATION_S 5
+#define MAX_FLUSH_DURATION_S 60
+#define FLUSH_HOLD_MAX_DURATION_S 60 // safety cap for hold-to-flush (flush duration 0)
+#define FLUSH_DRAIN_DURATION_S 1     // valve stays open this long after the flush pump stops
 #define BREW_MAX_VOLUMETRIC 250.0
 #define DEFAULT_STANDBY_TIMEOUT_MS 900000
 #define MIN_TEMP 0

--- a/src/display/core/process/BrewProcess.h
+++ b/src/display/core/process/BrewProcess.h
@@ -20,6 +20,8 @@ class BrewProcess : public Process {
     unsigned long previousPhaseFinished = 0;
     unsigned long finished = 0;
     PhaseExitReason lastExitReason = PhaseExitReason::NONE; // why the most recent phase ended (for shot history)
+    bool holdPhase = false;                                 // phase 0 runs until release() (hold-to-flush, GM-201)
+    bool releaseRequested = false;
     double phaseStartVolume = 0;
     double currentVolume = 0; // most recent volume pushed
     float currentFlow = 0.0f;
@@ -55,10 +57,19 @@ class BrewProcess : public Process {
 
     unsigned long getPhaseDuration() const { return static_cast<long>(currentPhase.duration) * 1000L; }
 
+    // Ends a held first phase; no-op for every other process so callers need not check.
+    void release() {
+        if (holdPhase && phaseIndex == 0)
+            releaseRequested = true;
+    }
+
     // Reason the current phase is done, or PhaseExitReason::NONE if it should keep running.
     PhaseExitReason currentPhaseExitReason() {
         if (millis() - currentPhaseStarted > BREW_SAFETY_DURATION_MS) {
             return PhaseExitReason::SAFETY;
+        }
+        if (releaseRequested) {
+            return PhaseExitReason::HOLD_RELEASED;
         }
         double volume = currentVolume;
         if (volume > 0.0) {
@@ -146,6 +157,7 @@ class BrewProcess : public Process {
         while ((reason = currentPhaseExitReason()) != PhaseExitReason::NONE && processPhase == ProcessPhase::RUNNING) {
             previousPhaseFinished = millis();
             lastExitReason = reason; // record why this phase ended for the shot history transition
+            releaseRequested = false;
             if (phaseIndex + 1 < profile.phases.size()) {
                 phaseStartedPumped = waterPumped;
                 phaseIndex++;

--- a/src/display/core/static_profiles.h
+++ b/src/display/core/static_profiles.h
@@ -1,8 +1,10 @@
 #pragma once
 #ifndef STATIC_PROFILES_H
 #define STATIC_PROFILES_H
+#include <display/core/constants.h>
 #include <display/models/profile.h>
 
+// Phase 0 duration is a placeholder: Controller::onFlush() sets it from the flush duration setting (GM-201).
 Profile FLUSH_PROFILE{.label = "Flush",
                       .type = "standard",
                       .utility = true,
@@ -10,8 +12,14 @@ Profile FLUSH_PROFILE{.label = "Flush",
                       .phases = {Phase{.name = "Flush",
                                        .phase = PhaseType::PHASE_TYPE_BREW,
                                        .valve = 1,
-                                       .duration = 5,
+                                       .duration = DEFAULT_FLUSH_DURATION_S,
                                        .pumpIsSimple = true,
-                                       .pumpSimple = 100}}};
+                                       .pumpSimple = 100},
+                                 Phase{.name = "Drain",
+                                       .phase = PhaseType::PHASE_TYPE_BREW,
+                                       .valve = 1,
+                                       .duration = FLUSH_DRAIN_DURATION_S,
+                                       .pumpIsSimple = true,
+                                       .pumpSimple = 0}}};
 
 #endif // STATIC_PROFILES_H

--- a/src/display/models/profile.h
+++ b/src/display/models/profile.h
@@ -25,6 +25,7 @@ enum class PhaseExitReason : uint8_t {
     DURATION = 5,          // phase duration elapsed
     SAFETY = 6,            // brew safety timeout (set by BrewProcess, not Phase::isFinished)
     ABORTED = 7,           // shot manually stopped before the process finished
+    HOLD_RELEASED = 8,     // held phase ended because the button was released (hold-to-flush)
 };
 
 struct Target {

--- a/src/display/plugins/WebSocketHandler.cpp
+++ b/src/display/plugins/WebSocketHandler.cpp
@@ -237,6 +237,8 @@ void WebSocketHandler::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocke
                     client->text(toWsBuffer(resp));
                 } else if (msgType == "req:flush:start") {
                     handleFlushStart(client->id(), doc);
+                } else if (msgType == "req:flush:stop") {
+                    handleFlushStop(client->id(), doc);
                 }
             }
         }
@@ -432,6 +434,7 @@ void WebSocketHandler::publishTelemetry() {
             pObj["s"] = brew->currentPhase.phase == PhaseType::PHASE_TYPE_BREW ? "brew" : "infusion";
             pObj["l"] = brew->isActive() ? brew->currentPhase.name.c_str() : "Finished";
             pObj["e"] = ts - brew->processStarted;
+            pObj["u"] = brew->isUtility() ? 1 : 0;
             const bool isVolumetric = brew->target == ProcessTarget::VOLUMETRIC && brew->currentPhase.hasVolumetricTarget() &&
                                       controller->isVolumetricAvailable();
             pObj["tt"] = isVolumetric ? "volumetric" : "time";
@@ -492,6 +495,17 @@ void WebSocketHandler::handleFlushStart(uint32_t clientId, JsonDocument &request
 
     JsonDocument response(&psramAllocator);
     response["tp"] = "res:flush:start";
+    response["rid"] = request["rid"];
+    response["success"] = true;
+    ws.text(clientId, toWsBuffer(response));
+}
+
+// Ends a hold-to-flush (flush duration 0); a no-op while a fixed-length flush runs.
+void WebSocketHandler::handleFlushStop(uint32_t clientId, JsonDocument &request) {
+    controller->onFlushRelease();
+
+    JsonDocument response(&psramAllocator);
+    response["tp"] = "res:flush:stop";
     response["rid"] = request["rid"];
     response["success"] = true;
     ws.text(clientId, toWsBuffer(response));

--- a/src/display/plugins/WebSocketHandler.h
+++ b/src/display/plugins/WebSocketHandler.h
@@ -40,6 +40,7 @@ class WebSocketHandler {
     void handleAutotuneStart(uint32_t clientId, JsonDocument &request);
     void handleProfileRequest(uint32_t clientId, JsonDocument &request);
     void handleFlushStart(uint32_t clientId, JsonDocument &request);
+    void handleFlushStop(uint32_t clientId, JsonDocument &request);
     void publishState(unsigned long now);
     void publishTelemetry();
     void sendAutotuneResult();

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -342,6 +342,8 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
             if (request->hasArg("haTopic"))
                 settings->setHomeAssistantTopic(request->arg("haTopic"));
             settings->setMomentaryButtons(request->hasArg("momentaryButtons"));
+            if (request->hasArg("flushDuration"))
+                settings->setFlushDuration(request->arg("flushDuration").toInt());
             if (request->hasArg("warnWaterLevel"))
                 settings->setWarnWaterLevel(request->arg("warnWaterLevel").toInt());
             if (request->hasArg("warnFlush"))
@@ -485,6 +487,7 @@ void WebUIPlugin::handleSettings(AsyncWebServerRequest *request) const {
     doc["smartGrindIp"] = settings.getSmartGrindIp();
     doc["smartGrindMode"] = settings.getSmartGrindMode();
     doc["momentaryButtons"] = settings.isMomentaryButtons();
+    doc["flushDuration"] = settings.getFlushDuration();
     doc["warnWaterLevel"] = settings.getWarnWaterLevel();
     doc["warnFlush"] = settings.getWarnFlush();
     doc["warnSteamSwitch"] = settings.getWarnSteamSwitch();

--- a/src/display/ui/default/DefaultUI.cpp
+++ b/src/display/ui/default/DefaultUI.cpp
@@ -196,9 +196,27 @@ void DefaultUI::init() {
                             0);
 }
 
+// True while any pointer input device (the touch panel) is pressed.
+static bool pointerPressed() {
+    for (lv_indev_t *indev = lv_indev_get_next(nullptr); indev != nullptr; indev = lv_indev_get_next(indev)) {
+        if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER && indev->proc.state == LV_INDEV_STATE_PRESSED)
+            return true;
+    }
+    return false;
+}
+
 void DefaultUI::loop() {
     const unsigned long now = ::millis();
     const unsigned long diff = now - lastRender;
+
+    if (touchFlushHeld) {
+        if (!controller->isActive()) {
+            touchFlushHeld = false;
+        } else if (!pointerPressed()) {
+            touchFlushHeld = false;
+            controller->onFlushRelease();
+        }
+    }
 
     if (now - lastTempLog > TEMP_HISTORY_INTERVAL) {
         lastTempLog = now;

--- a/src/display/ui/default/DefaultUI.h
+++ b/src/display/ui/default/DefaultUI.h
@@ -46,6 +46,8 @@ class DefaultUI {
     };
 
     void onVolumetricDelete();
+    // Flush started from the touch start button; loop() releases it once the pointer lifts (GM-201).
+    void onTouchFlushStart() { touchFlushHeld = true; }
 
     // Brew confirmation overlay, shown when the controller asks to confirm a brew start.
     void setBrewConfirmVisible(bool visible) {
@@ -111,6 +113,7 @@ class DefaultUI {
     int christmasMode = false;
 
     bool rerender = false;
+    bool touchFlushHeld = false;
     unsigned long lastRender = 0;
 
     int mode = MODE_STANDBY;

--- a/src/display/ui/default/eez/actions.cpp
+++ b/src/display/ui/default/eez/actions.cpp
@@ -49,9 +49,12 @@ void action_on_grind_screen(lv_event_t *e) {
     controller.deactivate();
 };
 
-void action_on_brew_start(lv_event_t *e) { controller.activate(); };
+void action_on_brew_start(lv_event_t *e) { controller.activate(); }; // SHORT_CLICKED in EEZ: never fires after a long press
 
-void action_on_flush(lv_event_t *e) { controller.onFlush(); };
+void action_on_flush(lv_event_t *e) {
+    controller.onFlush();
+    controller.getUI()->onTouchFlushStart();
+};
 
 void action_on_volumetric_hold(lv_event_t *e) {
     controller.getClientController()->tare();

--- a/src/display/ui/default/eez/screens.c
+++ b/src/display/ui/default/eez/screens.c
@@ -345,7 +345,7 @@ static void event_handler_cb_brew_screen_start_button(lv_event_t *e) {
     void *flowState = lv_event_get_user_data(e);
     (void)flowState;
 
-    if (event == LV_EVENT_CLICKED) {
+    if (event == LV_EVENT_SHORT_CLICKED) {
         e->user_data = (void *)0;
         action_on_brew_start(e);
     }

--- a/test/test_button_handler/test_button_handler.cpp
+++ b/test/test_button_handler/test_button_handler.cpp
@@ -1,0 +1,217 @@
+// Unit tests: ButtonHandler combo / long-press / click-on-release semantics (GM-200).
+// Host-side, no ESP32/Arduino runtime — pio test -e native_buttons.
+
+#include <unity.h>
+
+#include <vector>
+
+#include "display/core/ButtonHandler.cpp"
+
+using Event = ButtonHandler::Event;
+
+struct Rig {
+    ButtonHandler handler;
+    std::vector<std::pair<uint8_t, Event>> events;
+    unsigned long now = 1000;
+
+    explicit Rig(const ButtonHandler::Config &cfg) {
+        handler.setConfig(cfg);
+        handler.setCallback([this](uint8_t index, Event event) { events.emplace_back(index, event); });
+    }
+    void raw(uint8_t index, bool pressed) { handler.onRawState(index, pressed, now); }
+    // Advance time in 50 ms ticks like the main loop does.
+    void advance(unsigned long ms) {
+        const unsigned long until = now + ms;
+        while (now < until) {
+            now += 50;
+            handler.loop(now);
+        }
+    }
+    void expect(std::initializer_list<std::pair<uint8_t, Event>> expected) {
+        TEST_ASSERT_EQUAL_MESSAGE(expected.size(), events.size(), "event count");
+        size_t i = 0;
+        for (const auto &e : expected) {
+            TEST_ASSERT_EQUAL_MESSAGE(e.first, events[i].first, "button index");
+            TEST_ASSERT_EQUAL_MESSAGE(static_cast<int>(e.second), static_cast<int>(events[i].second), "event kind");
+            i++;
+        }
+        events.clear();
+    }
+};
+
+static ButtonHandler::Config latching(bool combo = false) {
+    ButtonHandler::Config cfg;
+    cfg.combo = combo;
+    return cfg;
+}
+
+static ButtonHandler::Config momentary(bool combo = false) {
+    ButtonHandler::Config cfg;
+    cfg.momentary = true;
+    cfg.combo = combo;
+    return cfg;
+}
+
+void setUp() {}
+void tearDown() {}
+
+// --- latching switches ------------------------------------------------------
+
+void test_latching_passes_edges_through_immediately() {
+    Rig rig(latching());
+    rig.raw(0, true);
+    rig.expect({{0, Event::PRESS}});
+    rig.advance(1000);
+    rig.raw(0, false);
+    rig.expect({{0, Event::RELEASE}});
+}
+
+void test_latching_combo_window_defers_press() {
+    Rig rig(latching(true));
+    rig.raw(0, true);
+    rig.expect({});
+    rig.advance(ButtonHandler::COMBO_WINDOW_MS);
+    rig.expect({{0, Event::PRESS}});
+    rig.raw(0, false);
+    rig.expect({{0, Event::RELEASE}});
+}
+
+void test_latching_both_switches_within_window_is_third_button() {
+    Rig rig(latching(true));
+    rig.raw(0, true);
+    rig.advance(100);
+    rig.raw(1, true);
+    rig.expect({{2, Event::PRESS}});
+    rig.advance(2000);
+    rig.expect({});
+    rig.raw(1, false);
+    rig.expect({{2, Event::RELEASE}});
+    rig.raw(0, false); // second release is swallowed
+    rig.expect({});
+}
+
+void test_second_switch_after_window_is_a_plain_press() {
+    Rig rig(latching(true));
+    rig.raw(0, true);
+    rig.advance(500);
+    rig.expect({{0, Event::PRESS}});
+    rig.raw(1, true);
+    rig.advance(ButtonHandler::COMBO_WINDOW_MS);
+    rig.expect({{1, Event::PRESS}});
+    rig.raw(0, false);
+    rig.raw(1, false);
+    rig.expect({{0, Event::RELEASE}, {1, Event::RELEASE}});
+}
+
+void test_tap_inside_window_delivers_both_edges() {
+    Rig rig(latching(true));
+    rig.raw(0, true);
+    rig.advance(50);
+    rig.raw(0, false);
+    rig.expect({{0, Event::PRESS}, {0, Event::RELEASE}});
+}
+
+// --- momentary buttons ------------------------------------------------------
+
+void test_momentary_without_long_press_clicks_on_press() {
+    Rig rig(momentary());
+    rig.raw(0, true);
+    rig.expect({{0, Event::CLICK}});
+    rig.advance(1000);
+    rig.raw(0, false);
+    rig.expect({{0, Event::CLICK_END}});
+}
+
+void test_momentary_with_long_press_clicks_on_release() {
+    auto cfg = momentary();
+    cfg.longPress[0] = true;
+    Rig rig(cfg);
+    rig.raw(0, true);
+    rig.advance(150);
+    rig.expect({});
+    rig.raw(0, false);
+    rig.expect({{0, Event::CLICK}});
+}
+
+void test_momentary_long_press_fires_after_timeout_and_suppresses_click() {
+    auto cfg = momentary();
+    cfg.longPress[0] = true;
+    Rig rig(cfg);
+    rig.raw(0, true);
+    rig.advance(ButtonHandler::LONG_PRESS_MS);
+    rig.expect({{0, Event::LONG_PRESS}});
+    rig.advance(2000);
+    rig.raw(0, false);
+    rig.expect({{0, Event::LONG_PRESS_END}});
+}
+
+void test_momentary_long_press_counts_from_physical_press_despite_combo_window() {
+    auto cfg = momentary(true);
+    cfg.longPress[0] = true;
+    Rig rig(cfg);
+    rig.raw(0, true);
+    rig.advance(ButtonHandler::LONG_PRESS_MS);
+    rig.expect({{0, Event::LONG_PRESS}});
+}
+
+void test_momentary_click_on_press_blocks_long_press() {
+    auto cfg = momentary();
+    cfg.longPress[0] = true;
+    cfg.clickOnPress[0] = true; // hold-to-flush claims the whole hold
+    Rig rig(cfg);
+    rig.raw(0, true);
+    rig.expect({{0, Event::CLICK}});
+    rig.advance(1000);
+    rig.expect({});
+    rig.raw(0, false);
+    rig.expect({{0, Event::CLICK_END}});
+}
+
+void test_momentary_combo_clicks_third_button_on_release() {
+    Rig rig(momentary(true));
+    rig.raw(1, true);
+    rig.advance(50);
+    rig.raw(0, true);
+    rig.expect({{2, Event::CLICK}});
+    rig.raw(0, false);
+    rig.expect({{2, Event::CLICK_END}});
+    rig.raw(1, false);
+    rig.expect({});
+}
+
+void test_momentary_combo_long_press() {
+    auto cfg = momentary(true);
+    cfg.longPress[2] = true;
+    Rig rig(cfg);
+    rig.raw(0, true);
+    rig.raw(1, true);
+    rig.expect({});
+    rig.advance(ButtonHandler::LONG_PRESS_MS);
+    rig.expect({{2, Event::LONG_PRESS}});
+    rig.raw(1, false);
+    rig.expect({{2, Event::LONG_PRESS_END}});
+}
+
+void test_release_without_press_is_ignored() {
+    Rig rig(momentary());
+    rig.raw(1, false);
+    rig.expect({});
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_latching_passes_edges_through_immediately);
+    RUN_TEST(test_latching_combo_window_defers_press);
+    RUN_TEST(test_latching_both_switches_within_window_is_third_button);
+    RUN_TEST(test_second_switch_after_window_is_a_plain_press);
+    RUN_TEST(test_tap_inside_window_delivers_both_edges);
+    RUN_TEST(test_momentary_without_long_press_clicks_on_press);
+    RUN_TEST(test_momentary_with_long_press_clicks_on_release);
+    RUN_TEST(test_momentary_long_press_fires_after_timeout_and_suppresses_click);
+    RUN_TEST(test_momentary_long_press_counts_from_physical_press_despite_combo_window);
+    RUN_TEST(test_momentary_click_on_press_blocks_long_press);
+    RUN_TEST(test_momentary_combo_clicks_third_button_on_release);
+    RUN_TEST(test_momentary_combo_long_press);
+    RUN_TEST(test_release_without_press_is_ignored);
+    return UNITY_END();
+}

--- a/web/src/pages/Home/CompactProcessControls.jsx
+++ b/web/src/pages/Home/CompactProcessControls.jsx
@@ -5,10 +5,10 @@ import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faRectangleList } from '@fortawesome/free-solid-svg-icons/faRectangleList';
 import { faThermometerHalf } from '@fortawesome/free-solid-svg-icons/faThermometerHalf';
-import { faTint } from '@fortawesome/free-solid-svg-icons/faTint';
 import { faWeightScale } from '@fortawesome/free-solid-svg-icons/faWeightScale';
 import { WarningIcon } from '../../components/WarningIcon.jsx';
 import { activeWarnings, WARNING_LEVEL } from '../../utils/warnings.js';
+import { FlushButton } from './FlushButton.jsx';
 import { ModeTab } from './ModeTab.jsx';
 import { useDashboardState } from './useDashboardState.js';
 import {
@@ -110,6 +110,7 @@ export default function CompactProcessControls() {
     deactivate,
     clear,
     startFlush,
+    stopFlush,
     isFlushing,
     warnings,
     systemReady,
@@ -122,7 +123,7 @@ export default function CompactProcessControls() {
   } = ds;
 
   const showPrimary = mode === 1 || mode === 3 || (isGrinding && isGrindAvailable);
-  const showFlush = isBrewing && !isActive && !isFinished;
+  const showFlush = isBrewing && (isFlushing || (!isActive && !isFinished)); // stays mounted while held
   const showWeight = volumetricAvailable && (mode === 1 || mode === 3) && brewTarget;
   const processRunning = (isActive || isFinished) && (isBrewing || isGrinding);
   const shownWarnings = mode === 0 ? [] : activeWarnings(warnings);
@@ -252,14 +253,12 @@ export default function CompactProcessControls() {
             ))}
           </div>
           {showFlush && (
-            <button
+            <FlushButton
               className='btn btn-ghost btn-sm text-base-content/60 hover:text-base-content rounded-full text-xs'
-              onClick={startFlush}
-              disabled={isFlushing}
-              aria-label='Flush water'
-            >
-              <FontAwesomeIcon icon={faTint} /> Flush
-            </button>
+              isFlushing={isFlushing}
+              startFlush={startFlush}
+              stopFlush={stopFlush}
+            />
           )}
           {showPrimary && (
             <button

--- a/web/src/pages/Home/FlushButton.jsx
+++ b/web/src/pages/Home/FlushButton.jsx
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types';
+import { useEffect } from 'preact/hooks';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTint } from '@fortawesome/free-solid-svg-icons/faTint';
+
+// Press-and-hold aware: a hold-to-flush (flush duration 0) runs until the pointer or key is released.
+export function FlushButton({ className, isFlushing, startFlush, stopFlush }) {
+  // The release is caught on the window so it still arrives when the pointer left the button.
+  useEffect(() => {
+    if (!isFlushing) return undefined;
+    window.addEventListener('pointerup', stopFlush);
+    window.addEventListener('pointercancel', stopFlush);
+    return () => {
+      window.removeEventListener('pointerup', stopFlush);
+      window.removeEventListener('pointercancel', stopFlush);
+    };
+  }, [isFlushing, stopFlush]);
+
+  const onKeyDown = e => {
+    if ((e.key === 'Enter' || e.key === ' ') && !e.repeat) {
+      e.preventDefault();
+      startFlush();
+    }
+  };
+  const onKeyUp = e => {
+    if (e.key === 'Enter' || e.key === ' ') stopFlush();
+  };
+  return (
+    <button
+      type='button'
+      className={`${className} ${isFlushing ? 'btn-active' : ''}`}
+      onPointerDown={startFlush}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      aria-pressed={isFlushing}
+      aria-label='Flush water'
+    >
+      <FontAwesomeIcon icon={faTint} /> Flush
+    </button>
+  );
+}
+
+FlushButton.propTypes = {
+  className: PropTypes.string.isRequired,
+  isFlushing: PropTypes.bool.isRequired,
+  startFlush: PropTypes.func.isRequired,
+  stopFlush: PropTypes.func.isRequired,
+};

--- a/web/src/pages/Home/cards/ActionCard.jsx
+++ b/web/src/pages/Home/cards/ActionCard.jsx
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTint } from '@fortawesome/free-solid-svg-icons/faTint';
 import { getPrimaryIcon, getPrimaryLabel } from '../utils.js';
 import { WarningIcon } from '../../../components/WarningIcon.jsx';
 import { activeWarnings, WARNING_LEVEL } from '../../../utils/warnings.js';
 import { useEffect, useState } from 'preact/hooks';
 import TargetToggle from '../TargetToggle.jsx';
 import Adjuster from '../Adjuster.jsx';
+import { FlushButton } from '../FlushButton.jsx';
 
 export function ActionCard({
   mode,
@@ -20,6 +20,7 @@ export function ActionCard({
   deactivate,
   clear,
   startFlush,
+  stopFlush,
   inCard = false,
   currentTemperature,
   targetTemperature,
@@ -38,7 +39,7 @@ export function ActionCard({
   const showStandby = mode === 0;
   const showSteam = mode === 2;
 
-  const showFlush = isBrewing && !isActive && !isFinished;
+  const showFlush = isBrewing && (isFlushing || (!isActive && !isFinished)); // stays mounted while held
   const grindValue =
     grindTarget === 1 && volumetricAvailable
       ? `${grindTargetVolume}g`
@@ -113,15 +114,12 @@ export function ActionCard({
       {!showStandby && (
         <div className='flex justify-end'>
           {showFlush && (
-            <button
+            <FlushButton
               className='btn btn-ghost btn-sm text-base-content/60 hover:text-base-content rounded-full text-sm'
-              onClick={startFlush}
-              disabled={isFlushing}
-              aria-label='Flush water'
-            >
-              <FontAwesomeIcon icon={faTint} />
-              Flush
-            </button>
+              isFlushing={isFlushing}
+              startFlush={startFlush}
+              stopFlush={stopFlush}
+            />
           )}
         </div>
       )}
@@ -141,6 +139,7 @@ ActionCard.propTypes = {
   deactivate: PropTypes.func.isRequired,
   clear: PropTypes.func.isRequired,
   startFlush: PropTypes.func.isRequired,
+  stopFlush: PropTypes.func.isRequired,
   inCard: PropTypes.bool,
   warnings: PropTypes.array,
   systemMessage: PropTypes.string,

--- a/web/src/pages/Home/useDashboardState.js
+++ b/web/src/pages/Home/useDashboardState.js
@@ -1,5 +1,5 @@
 import { computed } from '@preact/signals';
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import { useQuery } from 'preact-fetching';
 import { ApiServiceContext, machine } from '../../services/ApiService.js';
 
@@ -9,7 +9,7 @@ const connected = computed(() => machine.value.connected);
 
 export function useDashboardState() {
   const apiService = useContext(ApiServiceContext);
-  const [isFlushing, setIsFlushing] = useState(false);
+  const [flushPending, setFlushPending] = useState(false); // flush requested, status not caught up yet
 
   const s = status.value;
   const caps = capabilities.value;
@@ -36,6 +36,10 @@ export function useDashboardState() {
   const isFinished = !!p?.e && !isActive;
   const isBrewing = mode === 1;
   const isGrinding = mode === 4;
+  // The firmware flags a flush (utility process) so this state survives re-renders and reloads.
+  const flushRunning = !!p?.u && isActive;
+  const flushFinished = !!p?.u && isFinished;
+  const isFlushing = flushPending || flushRunning;
 
   const isSmartGrindEnabled = settings?.smartGrindActive || false;
   const altRelayFunction = settings?.altRelayFunction ?? 1;
@@ -71,19 +75,32 @@ export function useDashboardState() {
     send(isGrinding ? 'req:grind:deactivate' : 'req:process:deactivate');
     if (isFlushing) {
       send('req:process:clear');
-      setIsFlushing(false);
+      setFlushPending(false);
     }
   };
   const clear = () => {
     send('req:process:clear');
-    setIsFlushing(false);
+    setFlushPending(false);
   };
 
   const startFlush = () => {
     if (isFlushing) return;
-    setIsFlushing(true);
-    apiService.request({ tp: 'req:flush:start' }).catch(() => setIsFlushing(false));
+    setFlushPending(true);
+    apiService.request({ tp: 'req:flush:start' }).catch(() => setFlushPending(false));
   };
+  // Ends a hold-to-flush (flush duration 0); the firmware ignores it for a fixed-length flush.
+  const stopFlush = () => {
+    if (!isFlushing) return;
+    send('req:flush:stop');
+  };
+
+  useEffect(() => {
+    if (flushRunning) setFlushPending(false);
+  }, [flushRunning]);
+  // A finished flush clears itself; nobody wants to confirm a flush like a shot.
+  useEffect(() => {
+    if (flushFinished) apiService.send({ tp: 'req:process:clear' });
+  }, [flushFinished, apiService]);
 
   const raiseTemp = () => send('req:raise-temp');
   const lowerTemp = () => send('req:lower-temp');
@@ -147,6 +164,7 @@ export function useDashboardState() {
     deactivate,
     clear,
     startFlush,
+    stopFlush,
     raiseTemp,
     lowerTemp,
     raiseTarget,

--- a/web/src/pages/Settings/tabs/GeneralTab.jsx
+++ b/web/src/pages/Settings/tabs/GeneralTab.jsx
@@ -12,6 +12,8 @@ import {
   ToggleField,
 } from '../../../components/SettingsFormField.jsx';
 
+const FLUSH_DURATION_STEPS = [0, 5, 10, 15, 20];
+
 function ButtonBehaviorSelect({ id, label, value, onChange, profiles }) {
   return (
     <SettingsFormField label={label} htmlFor={id} noMargin>
@@ -105,6 +107,8 @@ export function GeneralTab({
   showApPassword,
   setShowApPassword,
 }) {
+  // Snap legacy free-form values onto the 5 s steps the slider offers.
+  const flushDuration = Math.min(20, Math.round(Number(formData.flushDuration ?? 5) / 5) * 5);
   return (
     <div className='space-y-4 sm:space-y-6 lg:grid lg:grid-cols-2 lg:gap-4'>
       {/* User Preferences */}
@@ -214,12 +218,41 @@ export function GeneralTab({
           </div>
         </div>
 
+        {/* Flush */}
+        <div className='border-base-content/5 mt-6 border-t pt-6'>
+          <h3 className='text-md text-base-content mb-2 font-semibold'>Flush</h3>
+          <SettingsFormField
+            label='Flush Duration'
+            htmlFor='flushDuration'
+            helpText='Hold runs the flush for as long as the button is held. The valve stays open for one more second after the pump stops.'
+            noMargin
+          >
+            <input
+              id='flushDuration'
+              name='flushDuration'
+              type='range'
+              className='range w-full'
+              min={0}
+              max={20}
+              step={5}
+              value={flushDuration}
+              onChange={onChange('flushDuration')}
+            />
+            <div className='mt-1 flex justify-between px-1 text-xs opacity-70' aria-hidden='true'>
+              {FLUSH_DURATION_STEPS.map(step => (
+                <span key={step}>{step === 0 ? 'Hold' : `${step}s`}</span>
+              ))}
+            </div>
+          </SettingsFormField>
+        </div>
+
         {/* Buttons */}
         <div className='border-base-content/5 mt-6 border-t pt-6'>
           <h3 className='text-md text-base-content mb-2 font-semibold'>Physical Buttons</h3>
           <p className='text-base-content/85 mb-4 text-sm opacity-70'>
             Define behavior for physical buttons when pressed. Make sure they are wired to the
-            buttons header.
+            buttons header. Pressing the brew and steam buttons together (or a third button wired to
+            both) triggers the water button behavior.
           </p>
           <div className='mb-4'>
             <ToggleField
@@ -230,7 +263,8 @@ export function GeneralTab({
             />
           </div>
           <p className='text-base-content/85 mb-4 text-sm opacity-70'>
-            Activate this if your coffee machine is equipped with momentary buttons.
+            Activate this if your coffee machine is equipped with momentary buttons. A momentary
+            button set to Brew or a profile starts a flush instead when held.
           </p>
           <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
             <ButtonBehaviorSelect

--- a/web/src/utils/panelDefinitions.js
+++ b/web/src/utils/panelDefinitions.js
@@ -118,6 +118,7 @@ export const PANEL_DEFINITIONS = [
       deactivate: ds.deactivate,
       clear: ds.clear,
       startFlush: ds.startFlush,
+      stopFlush: ds.stopFlush,
       warnings: ds.warnings,
       systemMessage: ds.systemMessage,
       currentTemperature: ds.currentTemperature,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added press-and-hold flushing with configurable durations and automatic drain handling.
  - Added flush start/stop controls for WebSocket clients and the web interface.
  - Flush controls now remain available during brewing and support mouse, touch, keyboard, and physical-button input.
  - Added brew/steam button combination support and long-press behavior.
  - Added a Flush Duration setting with selectable values in the settings screen.

- **Documentation**
  - Expanded simulator and physical-button guidance, including keyboard controls and combined-button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->