### PR TITLE
fix(shot-analyzer): preserve final weight from extended recording

### DIFF
--- a/web/src/pages/ShotAnalyzer/components/shotChart/model/phaseAnnotations.js
+++ b/web/src/pages/ShotAnalyzer/components/shotChart/model/phaseAnnotations.js
@@ -8,6 +8,7 @@ import { faScaleBalanced } from '@fortawesome/free-solid-svg-icons/faScaleBalanc
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation';
 import { getPhaseName } from '../helpers';
 import { getDisplayStopReasonParts } from '../../../utils/analyzerUtils';
+import { getLastNonExtendedIndex } from '../../../services/analyzer/weightRate';
 
 function isWeightStopType(type) {
   return type === 'weight' || type === 'volumetric';
@@ -147,17 +148,6 @@ function buildPhaseNumberResolver(results) {
   };
 }
 
-function findLastWeightSample(samples) {
-  for (let i = samples.length - 1; i >= 0; i -= 1) {
-    const sample = samples[i];
-    const weightValue = Number(sample?.v);
-    if (!sample?.systemInfo?.extendedRecording && Number.isFinite(weightValue) && weightValue > 0) {
-      return sample;
-    }
-  }
-  return null;
-}
-
 function getStopBadgePadding(phaseNumber) {
   const digitCount = String(Math.max(0, Number(phaseNumber) || 0)).length;
   return {
@@ -259,17 +249,6 @@ const MAIN_STOP_SAMPLE_KEY_BY_EXIT_TYPE = {
   pumped: 'fl',
 };
 
-function getStopReferenceSample({
-  finalWeightSample,
-  isWeightStop,
-  samples,
-  stopSample,
-  useFinalSample,
-}) {
-  if (!useFinalSample || !isWeightStop) return stopSample;
-  return finalWeightSample || samples.at(-1) || null;
-}
-
 function getMainStopYValue(exitType, refSample, samples) {
   const sampleKey = MAIN_STOP_SAMPLE_KEY_BY_EXIT_TYPE[exitType];
   if (sampleKey) return refSample?.[sampleKey] ?? 0;
@@ -279,31 +258,18 @@ function getMainStopYValue(exitType, refSample, samples) {
   return 0;
 }
 
-function getStopPosition({
-  exitType,
-  stopSample,
-  samples,
-  finalWeightSample = null,
-  useFinalSample = false,
-}) {
+function getStopPosition({ exitType, stopSample, samples }) {
   const isWeightStop = isWeightStopType(exitType);
-  const refSample = getStopReferenceSample({
-    finalWeightSample,
-    isWeightStop,
-    samples,
-    stopSample,
-    useFinalSample,
-  });
 
   if (isWeightStop) {
     return {
-      yValue: refSample?.v ?? 0,
+      yValue: stopSample?.v ?? 0,
       yScaleID: 'yWeight',
     };
   }
 
   return {
-    yValue: getMainStopYValue(exitType, refSample, samples),
+    yValue: getMainStopYValue(exitType, stopSample, samples),
     yScaleID: 'yMain',
   };
 }
@@ -617,13 +583,12 @@ function addFinalWeightStopLines({ phaseAnnotations, stopTimeSec, yScaleID, yVal
   };
 }
 
-function resolveFinalStopAnnotationContext({
-  finalWeightSample,
-  maxTime,
-  resolvePhaseNumber,
-  results,
-  samples,
-}) {
+function getLastPhaseStopSample(samples) {
+  const lastNonExtendedIndex = getLastNonExtendedIndex(samples);
+  return lastNonExtendedIndex >= 0 ? samples[lastNonExtendedIndex] : samples.at(-1) || null;
+}
+
+function resolveFinalStopAnnotationContext({ maxTime, resolvePhaseNumber, results, samples }) {
   const resultPhases = Array.isArray(results?.phases) ? results.phases : [];
   if (resultPhases.length === 0) return null;
 
@@ -632,15 +597,14 @@ function resolveFinalStopAnnotationContext({
 
   const exitType = lastPhase.exit.type || '';
   const isWeightStop = isWeightStopType(exitType);
-  const stopTimeSec =
-    isWeightStop && finalWeightSample ? (finalWeightSample.t ?? 0) / 1000 : maxTime;
-  const refSample = samples.at(-1) || null;
+  const lastPhaseStopSample = getLastPhaseStopSample(samples);
+  const stopTimeMs = Number(lastPhaseStopSample?.t);
+  const stopTimeSec = isWeightStop && Number.isFinite(stopTimeMs) ? stopTimeMs / 1000 : maxTime;
+  const refSample = isWeightStop ? lastPhaseStopSample : samples.at(-1) || null;
   const position = getStopPosition({
     exitType,
     stopSample: refSample,
     samples,
-    finalWeightSample,
-    useFinalSample: true,
   });
   const lastPhaseNum = resolvePhaseNumber(
     lastPhase.number,
@@ -664,12 +628,10 @@ function addFinalStopAnnotations({
   samples,
   maxTime,
   visibility,
-  finalWeightSample,
   resolvePhaseNumber,
   colors,
 }) {
   const context = resolveFinalStopAnnotationContext({
-    finalWeightSample,
     maxTime,
     resolvePhaseNumber,
     results,
@@ -790,7 +752,6 @@ export function buildPhaseAnnotations({
   stopIconOverlays = [],
 }) {
   const phaseAnnotations = {};
-  const finalWeightSample = findLastWeightSample(samples);
   const resolvePhaseNumber = buildPhaseNumberResolver(results);
   const hasPhaseTransitions =
     Array.isArray(shotData?.phaseTransitions) && shotData.phaseTransitions.length > 0;
@@ -835,7 +796,6 @@ export function buildPhaseAnnotations({
     samples,
     maxTime,
     visibility,
-    finalWeightSample,
     resolvePhaseNumber,
     colors,
   });

--- a/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/phaseAnalysis.js
@@ -22,10 +22,11 @@ import {
 } from './targetMatching';
 import {
   getLastNonExtendedIndex,
+  getFinalWeightSample,
+  getFinalWeightSamples,
   getPhaseEndSample,
   getPhaseWeightRate,
   getSampleInstantWeightRate,
-  getSamplesThroughLastNonExtended,
   isPositiveFiniteRate,
 } from './weightRate';
 import { calculatePumpedWater } from './waterIntegration';
@@ -590,8 +591,8 @@ export function analyzeExecutedPhase({
   const pEnd = (phaseEndSample.t - globalStartTime) / 1000;
   const duration = pEnd - pStart;
   const phaseWeightRate = getPhaseWeightRate(samples, isLastPhase);
-  const weightSamples = getSamplesThroughLastNonExtended(samples);
-  const weightEndSample = weightSamples.at(-1) || getPhaseEndSample(samples);
+  const weightSamples = getFinalWeightSamples(samples);
+  const weightEndSample = getFinalWeightSample(samples) || getPhaseEndSample(samples);
   const rawName = phaseNameMap[phaseNum];
   const displayName = rawName || `Phase ${phaseNum}`;
   const sysInfo = getPhaseEndSample(samples).systemInfo || {};

--- a/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/shotAnalysis.js
@@ -12,7 +12,7 @@ import { getBluetoothScaleConnectionState } from './scaleConnection';
 import { getSlowSampleIntervalSummary } from './sampleIntervals';
 import { mergeSkippedProfilePhases } from './skippedPhases';
 import { calculatePumpedWater, createPumpedWaterSource } from './waterIntegration';
-import { getSamplesThroughLastNonExtended } from './weightRate';
+import { getFinalWeightSample, getFinalWeightSamples } from './weightRate';
 import {
   buildRecordedExitReasonByPhase,
   getBrewCompletionLabel,
@@ -151,8 +151,8 @@ export function calculateShotMetrics(shotData, profileData, settings) {
   // --- 3. GLOBAL TOTALS ---
   const gDuration = (gSamples.at(-1).t - gSamples[0].t) / 1000;
   const gWater = calculatePumpedWater(gSamples, gSamples.length - 1, null, pumpedWaterSource);
-  const gWeightSamples = getSamplesThroughLastNonExtended(gSamples);
-  const gWeight = (gWeightSamples.at(-1) || gSamples.at(-1)).v;
+  const gWeightSamples = getFinalWeightSamples(gSamples);
+  const gWeight = (getFinalWeightSample(gSamples) || gSamples.at(-1)).v;
 
   // --- 4. PHASE-BY-PHASE ANALYSIS ---
   const analyzedPhases = [];

--- a/web/src/pages/ShotAnalyzer/services/analyzer/weightRate.js
+++ b/web/src/pages/ShotAnalyzer/services/analyzer/weightRate.js
@@ -91,6 +91,65 @@ export function getSamplesThroughLastNonExtended(samples) {
   return endIndex >= 0 ? samples.slice(0, endIndex + 1) : [];
 }
 
+function getFiniteWeightValue(sample) {
+  const weight = Number(sample?.v);
+  return Number.isFinite(weight) ? weight : null;
+}
+
+/**
+ * Returns the recorded samples that are safe to use for final-weight stats.
+ *
+ * Extended recording captures post-stop dripping, so higher values there are
+ * valid final-weight updates. A lower value cannot be caused by the brewed
+ * drink itself; it is usually scale handling or the cup being removed and is
+ * therefore excluded without changing the raw chart data.
+ */
+export function getFinalWeightSamples(samples) {
+  if (!Array.isArray(samples) || samples.length === 0) return [];
+
+  let extendedTailStartIndex = 0;
+  for (let i = samples.length - 1; i >= 0; i -= 1) {
+    if (!samples[i]?.systemInfo?.extendedRecording) {
+      extendedTailStartIndex = i + 1;
+      break;
+    }
+  }
+
+  const acceptedSamples = samples.slice(0, extendedTailStartIndex);
+  let finalWeightSample = null;
+
+  for (let i = acceptedSamples.length - 1; i >= 0; i -= 1) {
+    if (getFiniteWeightValue(acceptedSamples[i]) !== null) {
+      finalWeightSample = acceptedSamples[i];
+      break;
+    }
+  }
+
+  for (let i = extendedTailStartIndex; i < samples.length; i += 1) {
+    const sample = samples[i];
+    const weight = getFiniteWeightValue(sample);
+    if (weight === null) continue;
+
+    const finalWeight = getFiniteWeightValue(finalWeightSample);
+    if (finalWeight === null || weight >= finalWeight) {
+      acceptedSamples.push(sample);
+      finalWeightSample = sample;
+    }
+  }
+
+  return acceptedSamples;
+}
+
+export function getFinalWeightSample(samples) {
+  const weightSamples = getFinalWeightSamples(samples);
+
+  for (let i = weightSamples.length - 1; i >= 0; i -= 1) {
+    if (getFiniteWeightValue(weightSamples[i]) !== null) return weightSamples[i];
+  }
+
+  return samples?.at(-1) || null;
+}
+
 export function isPositiveFiniteRate(value) {
   return value != null && Number.isFinite(value) && value > 0.1;
 }


### PR DESCRIPTION
Preserves the final shot weight when Extended Recording contains valid post-stop dripping. The analyzer now keeps the highest valid weight from the last normal sample through the Extended Recording tail. Later lower readings, such as when the cup is removed from the scale, no longer overwrite the final result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved final-weight calculations by handling extended recording data more reliably.
  - Prevented scale-handling or cup-removal readings from incorrectly lowering reported final weight.
  - Improved phase statistics and reported phase weights using the most appropriate valid measurement.
  - Updated shot stop annotations to use the correct final non-extended sample and stop timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->