### PR TITLE
fix(shot-analyzer): make library action menus functional

### DIFF
--- a/web/src/pages/ShotAnalyzer/components/library/LibraryActionsMenu.jsx
+++ b/web/src/pages/ShotAnalyzer/components/library/LibraryActionsMenu.jsx
@@ -94,6 +94,7 @@ export function LibraryActionsMenu({ actions, ariaLabel, buttonClassName, placem
       ref={menuRef}
       role='menu'
       tabIndex={-1}
+      data-library-actions-menu='true'
       className='app-card-surface fixed z-[10000] rounded-xl p-1.5 shadow-xl'
       style={{
         top: `${menuPosition.top}px`,

--- a/web/src/pages/ShotAnalyzer/components/library/useLibraryPanelState.js
+++ b/web/src/pages/ShotAnalyzer/components/library/useLibraryPanelState.js
@@ -216,7 +216,9 @@ export function useCloseLibraryOnOutsideClick({ collapsed, panelRef, setCollapse
   useEffect(() => {
     if (collapsed) return;
     const handleOutsideClick = event => {
-      if (panelRef.current && !panelRef.current.contains(event.target)) {
+      const target = event.target;
+      const isLibraryActionMenuClick = target?.closest?.('[data-library-actions-menu]');
+      if (panelRef.current && !panelRef.current.contains(target) && !isLibraryActionMenuClick) {
         setCollapsed(true);
       }
     };


### PR DESCRIPTION
- Fix Export/Delete actions in the Shot Analyzer library menus.
- Fix Export All/Delete All for shots and profiles.
- Keep portaled action menus from being treated as outside clicks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Library action menus now remain open when users interact with their contents.
  - Clicking within the action menu no longer unintentionally closes the library panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->